### PR TITLE
ci: add CLI docs freshness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,22 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-targets -- -D warnings
+
+  docs:
+    name: CLI docs freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check README commands match CLI
+        run: |
+          cargo build --quiet
+          LIVE_COMMANDS=$(./target/debug/modl cli-schema 2>/dev/null | jq -r '.commands[].name' | sort)
+          README_COMMANDS=$(grep -oP '`modl (\S+)`' README.md | sed 's/`modl //;s/`//' | sort -u)
+          # Check if any CLI command is completely missing from README
+          MISSING=$(comm -23 <(echo "$LIVE_COMMANDS") <(echo "$README_COMMANDS") || true)
+          if [ -n "$MISSING" ]; then
+            echo "::warning::README may be stale — these CLI commands are not mentioned: $MISSING"
+            echo "Run: scripts/generate-cli-reference.sh"
+          fi


### PR DESCRIPTION
## Summary
- Add CI job that warns when README commands table drifts from actual CLI
- Compares `modl cli-schema` output against commands mentioned in README
- Non-blocking (warning only) so it doesn't break PRs, just flags staleness

Note: The README and install.sh fixes were pushed to main before branch protection was enabled.

## Test plan
- [x] CI job runs `modl cli-schema` and compares against README
- [x] Warning-only — won't block merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)