### PR TITLE
feat: enable img2img and inpainting for Z-Image family

### DIFF
--- a/python/modl_worker/adapters/arch_config.py
+++ b/python/modl_worker/adapters/arch_config.py
@@ -310,6 +310,8 @@ ARCH_CONFIGS: dict[str, dict] = {
     },
     "zimage_turbo": {
         "pipeline_class": "ZImagePipeline",
+        "img2img_class": "ZImageImg2ImgPipeline",
+        "inpaint_class": "ZImageInpaintPipeline",
         "gen_components": {
             "transformer": {
                 "model_class": "ZImageTransformer2DModel",
@@ -355,6 +357,8 @@ ARCH_CONFIGS: dict[str, dict] = {
     },
     "zimage": {
         "pipeline_class": "ZImagePipeline",
+        "img2img_class": "ZImageImg2ImgPipeline",
+        "inpaint_class": "ZImageInpaintPipeline",
         "gen_components": {
             "transformer": {
                 "model_class": "ZImageTransformer2DModel",

--- a/src/core/model_family.rs
+++ b/src/core/model_family.rs
@@ -338,8 +338,8 @@ pub static FAMILIES: &[ModelFamily] = &[
                 vram_fp8_gb: 14,
                 capabilities: Capabilities {
                     txt2img: true,
-                    img2img: false,
-                    inpaint: false,
+                    img2img: true,
+                    inpaint: true,
                     edit: false,
                     lora: true,
                     training: true,
@@ -364,8 +364,8 @@ pub static FAMILIES: &[ModelFamily] = &[
                 vram_fp8_gb: 14,
                 capabilities: Capabilities {
                     txt2img: true,
-                    img2img: false,
-                    inpaint: false,
+                    img2img: true,
+                    inpaint: true,
                     edit: false,
                     lora: true,
                     training: true,


### PR DESCRIPTION
## Summary

- Enable `--init-image` (img2img) and `--mask` (inpainting) for Z-Image and Z-Image Turbo
- Flip capability flags in `model_family.rs` from `false` → `true`
- Register `ZImageImg2ImgPipeline` and `ZImageInpaintPipeline` in `arch_config.py`

No new logic needed — `gen_adapter.py` already handles mode switching generically via `resolve_pipeline_class_for_mode()` → `from_pipe()`, and both diffusers pipeline classes already exist.

## What this unlocks

Two-stage refine workflows that were previously impossible:

```bash
# Stage 1: Z-Image base generation
modl generate "a knight in blue armor" --base z-image --steps 20 -o base.png

# Stage 2: Z-Image Turbo refinement (the missing primitive)
modl generate "a knight in blue armor" --base z-image-turbo --init-image base.png --strength 0.5 --steps 8
```

This is the key primitive needed to replicate multi-model ComfyUI workflows (e.g. Z-Image → ZIT refine pipelines) using composable CLI commands.

## Test plan

- [ ] `modl generate "test" --base z-image-turbo --init-image <existing.png> --strength 0.5` completes successfully
- [ ] `modl generate "test" --base z-image --init-image <existing.png> --strength 0.7` completes successfully
- [ ] `modl generate "test" --base z-image-turbo --init-image <existing.png> --mask <mask.png>` completes successfully (inpainting)
- [ ] Existing txt2img flow still works: `modl generate "test" --base z-image-turbo`
- [ ] UI capability badges update to show img2img/inpaint for Z-Image models

🤖 Generated with [Claude Code](https://claude.com/claude-code)