### PR TITLE
fix: find npm.cmd on Windows in build.rs

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -65,8 +65,14 @@ fn ensure_stub_dist(dist_dir: &str) {
 }
 
 fn which_npm() -> String {
-    // Prefer the npm that's already on PATH; fall back to common locations
-    for candidate in ["npm", "/usr/local/bin/npm", "/usr/bin/npm"] {
+    // On Windows, Command::new("npm") won't find npm.cmd automatically,
+    // so we check npm.cmd first on Windows.
+    let candidates: &[&str] = if cfg!(windows) {
+        &["npm.cmd", "npm", "npm.exe"]
+    } else {
+        &["npm", "/usr/local/bin/npm", "/usr/bin/npm"]
+    };
+    for candidate in candidates {
         if Command::new(candidate)
             .arg("--version")
             .output()


### PR DESCRIPTION
## Summary
- `Command::new("npm")` doesn't resolve `.cmd` extensions on Windows, so `build.rs` panics with "npm not found" even though `setup-node` installed it
- Added `npm.cmd` and `npm.exe` as candidates on Windows

## Test plan
- [ ] Merge and re-tag to trigger release workflow
- [ ] Verify Windows build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)