### PR TITLE
feat: improve onboarding — fuzzy pull, better errors, fix registry URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,7 +1492,7 @@ dependencies = [
 
 [[package]]
 name = "modl"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modl"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "CLI model manager for the AI image generation ecosystem"
 license = "AGPL-3.0-only"

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -173,8 +173,9 @@ pub async fn run(defaults: bool, root_override: Option<&str>) -> Result<()> {
     );
 
     // Model download offer
+    let mut model_installed = false;
     if !defaults {
-        offer_starter_model(&gpu_info).await?;
+        model_installed = offer_starter_model(&gpu_info).await?;
     }
 
     // Service install offer
@@ -184,12 +185,24 @@ pub async fn run(defaults: bool, root_override: Option<&str>) -> Result<()> {
 
     println!();
     println!("Next steps:");
-    println!("  {} Fetch the model registry", style("modl update").cyan());
-    println!(
-        "  {} Install a model",
-        style("modl pull flux-schnell").cyan()
-    );
-    println!("  {} Launch the web UI", style("modl serve").cyan());
+    if model_installed {
+        println!(
+            "  {} Generate an image",
+            style("modl generate \"a cat in space\"").cyan()
+        );
+        println!("  {} Launch the web UI", style("modl serve").cyan());
+        println!("  {} Browse all models", style("modl search flux").cyan());
+    } else {
+        println!(
+            "  {} Browse available models",
+            style("modl search flux").cyan()
+        );
+        println!(
+            "  {} Install a model",
+            style("modl pull flux-schnell").cyan()
+        );
+        println!("  {} Launch the web UI", style("modl serve").cyan());
+    }
 
     Ok(())
 }
@@ -312,7 +325,7 @@ fn detect_tool_targets() -> Result<Vec<TargetConfig>> {
     Ok(targets)
 }
 
-async fn offer_starter_model(gpu_info: &Option<gpu::GpuInfo>) -> Result<()> {
+async fn offer_starter_model(gpu_info: &Option<gpu::GpuInfo>) -> Result<bool> {
     println!();
     let download = Confirm::new()
         .with_prompt("Would you like to download a starter model?")
@@ -320,7 +333,7 @@ async fn offer_starter_model(gpu_info: &Option<gpu::GpuInfo>) -> Result<()> {
         .interact()?;
 
     if !download {
-        return Ok(());
+        return Ok(false);
     }
 
     let vram_mb = gpu_info.as_ref().map(|g| g.vram_mb).unwrap_or(0);
@@ -352,7 +365,7 @@ async fn offer_starter_model(gpu_info: &Option<gpu::GpuInfo>) -> Result<()> {
 
     if selected >= STARTER_MODELS.len() {
         // User chose "Skip"
-        return Ok(());
+        return Ok(false);
     }
 
     let model_id = STARTER_MODELS[selected].id;
@@ -413,7 +426,7 @@ async fn offer_starter_model(gpu_info: &Option<gpu::GpuInfo>) -> Result<()> {
         model_id
     );
 
-    Ok(())
+    Ok(true)
 }
 
 async fn offer_service_install() -> Result<()> {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -21,13 +21,32 @@ pub async fn run(id: &str, variant: Option<&str>, dry_run: bool, force: bool) ->
     let index = RegistryIndex::load_or_fetch().await?;
     let db = Database::open()?;
 
-    let (mut plan, vram) = install::resolve_plan(id, variant, &index, &db)?;
+    // Try exact match first, then fuzzy-resolve the ID if not found
+    let resolved_id = if index.find(id).is_some() {
+        id.to_string()
+    } else {
+        try_resolve_alias(id, &index)
+    };
+
+    let (mut plan, vram) = install::resolve_plan(&resolved_id, variant, &index, &db)?;
+
+    // Show alias resolution if we resolved to a different ID
+    if resolved_id != id {
+        println!(
+            "{} {} → {}",
+            style("→").cyan(),
+            style(id).dim(),
+            style(&resolved_id).bold()
+        );
+    }
 
     // Interactive variant selection for the primary model (if it has multiple variants
     // and the user didn't specify --variant)
     if variant.is_none() {
         for item in &mut plan.items {
-            if item.manifest.id == id && !item.already_installed && item.manifest.variants.len() > 1
+            if item.manifest.id == resolved_id
+                && !item.already_installed
+                && item.manifest.variants.len() > 1
             {
                 let selected = prompt_variant_selection(&item.manifest, vram)?;
                 item.variant_id = Some(selected);
@@ -39,13 +58,13 @@ pub async fn run(id: &str, variant: Option<&str>, dry_run: bool, force: bool) ->
     println!(
         "{} Install plan for {}:",
         style("→").cyan(),
-        style(id).bold()
+        style(&resolved_id).bold()
     );
     println!();
 
     let mut total_download: u64 = 0;
     for item in &plan.items {
-        let effective_variant = if item.manifest.id == id {
+        let effective_variant = if item.manifest.id == resolved_id {
             item.variant_id.as_deref().or(variant)
         } else {
             item.variant_id.as_deref()
@@ -104,7 +123,7 @@ pub async fn run(id: &str, variant: Option<&str>, dry_run: bool, force: bool) ->
 
     // Download each item
     for item in &items_to_install {
-        let effective_variant = if item.manifest.id == id {
+        let effective_variant = if item.manifest.id == resolved_id {
             item.variant_id.as_deref().or(variant)
         } else {
             item.variant_id.as_deref()
@@ -168,7 +187,7 @@ pub async fn run(id: &str, variant: Option<&str>, dry_run: bool, force: bool) ->
     println!(
         "{} Installed {} successfully.",
         style("✓").green().bold(),
-        style(id).bold()
+        style(&resolved_id).bold()
     );
 
     Ok(())
@@ -289,4 +308,50 @@ fn prompt_variant_selection(manifest: &Manifest, vram: Option<u64>) -> Result<St
         .interact()?;
 
     Ok(manifest.variants[selection].id.clone())
+}
+
+/// Try to resolve a user-typed ID to a registry ID.
+///
+/// Handles common aliases: "sdxl" → "sdxl-base-1.0", "klein" → "flux2-klein-4b", etc.
+/// Falls back to substring search on the registry index.
+/// Returns the original ID if no match is found (the resolver will then produce
+/// a nice error with suggestions).
+fn try_resolve_alias(id: &str, index: &RegistryIndex) -> String {
+    let lower = id.to_lowercase();
+
+    // 1. Try single-result substring match on registry IDs
+    //    e.g. "sdxl" matches "sdxl-base-1.0", "klein-4b" matches "flux2-klein-4b"
+    let matches: Vec<_> = index
+        .items
+        .iter()
+        .filter(|m| {
+            let mid = m.id.to_lowercase();
+            mid.contains(&lower) || lower.contains(&mid)
+        })
+        .collect();
+
+    if matches.len() == 1 {
+        return matches[0].id.clone();
+    }
+
+    // 2. Try model_family fuzzy resolve → map family ID to registry ID
+    if let Some(info) = crate::core::model_family::resolve_model(id) {
+        // The family ID (e.g. "sdxl") may differ from registry ID (e.g. "sdxl-base-1.0")
+        // Try exact match first
+        if index.find(info.id).is_some() {
+            return info.id.to_string();
+        }
+        // Then try substring match with the family ID
+        let family_matches: Vec<_> = index
+            .items
+            .iter()
+            .filter(|m| m.id.to_lowercase().contains(info.id))
+            .collect();
+        if family_matches.len() == 1 {
+            return family_matches[0].id.clone();
+        }
+    }
+
+    // No confident match — return original and let resolver show suggestions
+    id.to_string()
 }

--- a/src/cli/search.rs
+++ b/src/cli/search.rs
@@ -128,12 +128,14 @@ pub async fn run(
     // Skip HF search if user used registry-only filters
     let skip_hf = for_model.is_some() || min_rating.is_some();
 
+    let mut hf_printed = false;
     if !skip_hf {
         let auth_store = AuthStore::load().unwrap_or_default();
         let hf_token = auth_store.token_for("huggingface");
 
         match huggingface::search(query, hf_token.as_deref(), 10).await {
             Ok(hf_results) if !hf_results.is_empty() => {
+                hf_printed = true;
                 println!("\n{} HuggingFace results:\n", style("→").cyan(),);
 
                 let mut hf_table = Table::new();
@@ -163,20 +165,25 @@ pub async fn run(
 
                 println!("{hf_table}");
             }
-            Ok(_) => {} // No HF results, just skip
+            Ok(_) => {}
             Err(e) => {
-                // Don't fail the whole search if HF is unreachable
                 if results.is_empty() {
-                    println!("No results for '{}'.", query);
                     eprintln!("  {} HuggingFace search failed: {}", style("!").yellow(), e);
                 }
             }
         }
     }
 
-    if results.is_empty() {
-        // Already printed HF results above if any, so only print "no results"
-        // if we haven't printed anything at all
+    if results.is_empty() && !hf_printed {
+        println!("\nNo results for '{}'.\n", query);
+        println!(
+            "  Popular models: {}, {}, {}, {}",
+            style("flux-schnell").cyan(),
+            style("flux-dev").cyan(),
+            style("sdxl").cyan(),
+            style("z-image-turbo").cyan(),
+        );
+        println!("  Browse all:     {}", style("modl search flux").cyan());
     }
 
     Ok(())

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -60,13 +60,55 @@ impl RegistryIndex {
             .collect()
     }
 
+    /// Suggest similar model IDs for a failed lookup.
+    ///
+    /// Tries substring matching, prefix matching, and edit distance
+    /// to find the closest matches in the registry.
+    pub fn suggest(&self, query: &str, max: usize) -> Vec<&Manifest> {
+        let q = query.to_lowercase();
+
+        // 1. Substring match on ID (e.g. "sdx" matches "sdxl-base-1.0")
+        let mut candidates: Vec<(&Manifest, usize)> = self
+            .items
+            .iter()
+            .filter_map(|m| {
+                let id = m.id.to_lowercase();
+                let name = m.name.to_lowercase();
+                if id.contains(&q) || q.contains(&id) || name.contains(&q) {
+                    // Score: shorter edit distance = better
+                    Some((m, edit_distance(&q, &id)))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // 2. If no substring matches, try edit distance on all items
+        if candidates.is_empty() {
+            candidates = self
+                .items
+                .iter()
+                .map(|m| {
+                    let id_dist = edit_distance(&q, &m.id.to_lowercase());
+                    let name_dist = edit_distance(&q, &m.name.to_lowercase());
+                    (m, id_dist.min(name_dist))
+                })
+                .filter(|(_, dist)| *dist <= q.len().max(3))
+                .collect();
+        }
+
+        candidates.sort_by_key(|(_, dist)| *dist);
+        candidates.into_iter().take(max).map(|(m, _)| m).collect()
+    }
+
     /// The URL to fetch the latest index from.
     ///
-    /// Uses registry.modl.run (Cloudflare-cached) as primary,
-    /// with raw GitHub as fallback. Override via MODL_REGISTRY_URL env var.
+    /// Uses raw GitHub as primary. Override via MODL_REGISTRY_URL env var.
+    /// TODO: switch primary to registry.modl.run once the CDN is deployed.
     pub fn remote_url() -> String {
-        std::env::var("MODL_REGISTRY_URL")
-            .unwrap_or_else(|_| "https://registry.modl.run/index.json".to_string())
+        std::env::var("MODL_REGISTRY_URL").unwrap_or_else(|_| {
+            "https://raw.githubusercontent.com/modl-org/modl-registry/main/index.json".to_string()
+        })
     }
 
     /// Fallback URL if the primary registry is unreachable
@@ -170,4 +212,29 @@ impl RegistryIndex {
             Self::load()
         }
     }
+}
+
+/// Simple Levenshtein edit distance for typo suggestions.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a_len = a.len();
+    let b_len = b.len();
+    let mut matrix = vec![vec![0usize; b_len + 1]; a_len + 1];
+
+    for (i, row) in matrix.iter_mut().enumerate() {
+        row[0] = i;
+    }
+    for (j, cell) in matrix[0].iter_mut().enumerate() {
+        *cell = j;
+    }
+
+    for (i, ca) in a.chars().enumerate() {
+        for (j, cb) in b.chars().enumerate() {
+            let cost = if ca == cb { 0 } else { 1 };
+            matrix[i + 1][j + 1] = (matrix[i][j + 1] + 1)
+                .min(matrix[i + 1][j] + 1)
+                .min(matrix[i][j] + cost);
+        }
+    }
+
+    matrix[a_len][b_len]
 }

--- a/src/core/resolver.rs
+++ b/src/core/resolver.rs
@@ -45,9 +45,26 @@ fn resolve_recursive(
     }
     visited.insert(id.to_string());
 
-    let manifest = index
-        .find(id)
-        .ok_or_else(|| anyhow::anyhow!("Model '{}' not found in registry", id))?;
+    let manifest = index.find(id).ok_or_else(|| {
+        let suggestions = index.suggest(id, 5);
+        if suggestions.is_empty() {
+            anyhow::anyhow!(
+                "Model '{}' not found in registry.\n\n  Try: modl search {}",
+                id,
+                id
+            )
+        } else {
+            let suggestion_list: Vec<String> = suggestions
+                .iter()
+                .map(|m| format!("  {} — {}", m.id, m.name))
+                .collect();
+            anyhow::anyhow!(
+                "Model '{}' not found in registry. Similar models:\n\n{}\n\n  Install with: modl pull <id>",
+                id,
+                suggestion_list.join("\n")
+            )
+        }
+    })?;
 
     // Resolve dependencies first (depth-first)
     for dep in &manifest.requires {


### PR DESCRIPTION
## Summary

- **Fix registry URL**: Switch from `registry.modl.run` (not deployed yet) to GitHub raw URL so fresh installs don't fail on first network call
- **Fuzzy model resolution in `modl pull`**: `sdxl` → `sdxl-base-1.0`, `klein` → `flux2-klein-4b`, `flux-klein-4b` → `flux2-klein-4b`. Shows `→ sdxl → sdxl-base-1.0` when resolving
- **"Did you mean?" suggestions**: When no match found, shows top 5 similar models via substring + Levenshtein distance matching with install commands
- **Contextual `modl init` next steps**: If user downloaded a model during init, shows `modl generate` instead of `modl update` + `modl pull`
- **Better empty search results**: Shows popular model names and browse hint instead of silent nothing
- **Bump version to 0.2.2**

## Test plan

- [x] All 111 existing tests pass
- [x] Clippy clean, fmt clean
- [ ] `modl pull sdxl` resolves to `sdxl-base-1.0`
- [ ] `modl pull flux-klein-4b` resolves to `flux2-klein-4b`
- [ ] `modl pull asdfgh` shows "did you mean?" suggestions
- [ ] `modl search xyznonexistent` shows popular models hint
- [ ] `modl init` on fresh install shows contextual next steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)