### PR TITLE
fix: macOS MPS inference — runtime, dtypes, variant selection, init

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "modl"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/python/modl_worker/adapters/controlnet.py
+++ b/python/modl_worker/adapters/controlnet.py
@@ -257,7 +257,8 @@ def _load_controlnet(
             tokenizer=pipeline.tokenizer,
             scheduler=pipeline.scheduler,
         )
-        cn_pipe.enable_model_cpu_offload()
+        from modl_worker.device import move_pipe_to_device
+        move_pipe_to_device(cn_pipe)
         emitter.info(f"ControlNet loaded ({cn_model_size_gb:.1f}GB, CPU offload via wrapper)")
     else:
         # Standard approach: construct the ControlNet pipeline directly.
@@ -284,8 +285,8 @@ def _load_controlnet(
         # no shared modules — safe to keep resident).
         base_was_offloaded = bool(getattr(pipeline, "_all_hooks", None))
         if base_was_offloaded:
-            cn_pipe.enable_model_cpu_offload()
-            from modl_worker.device import get_device
+            from modl_worker.device import move_pipe_to_device, get_device
+            move_pipe_to_device(cn_pipe)
             cn_pipe.controlnet.to(get_device())
             emitter.info(f"ControlNet loaded ({cn_model_size_gb:.1f}GB, CPU offload)")
         else:

--- a/python/modl_worker/adapters/pipeline_loader.py
+++ b/python/modl_worker/adapters/pipeline_loader.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from modl_worker.protocol import EventEmitter
+from modl_worker.device import get_inference_dtype, is_mps
 from modl_worker.adapters.arch_config import (
     resolve_model_path,
     resolve_pipeline_class,
@@ -303,14 +304,15 @@ def assemble_pipeline(
                 # GGUF files: load directly via from_single_file with
                 # GGUFQuantizationConfig. Weights stay quantized on GPU.
                 from diffusers import GGUFQuantizationConfig
+                dtype = get_inference_dtype()
                 quantization_config = GGUFQuantizationConfig(
-                    compute_dtype=torch.bfloat16,
+                    compute_dtype=dtype,
                 )
                 model = ModelClass.from_single_file(
                     base_model_path,
                     config=str(config_dir),
                     quantization_config=quantization_config,
-                    torch_dtype=torch.bfloat16,
+                    torch_dtype=dtype,
                 )
                 emitter.info(f"  → GGUF quantized model loaded")
             else:
@@ -323,11 +325,12 @@ def assemble_pipeline(
                 ]
                 has_comfy_fp8_scales = len(weight_scale_keys) > 0
 
-                # For small models (≤5B params / ≤8GB fp8), dequantize to bf16
+                # For small models (≤5B params / ≤8GB fp8), dequantize to inference dtype
                 # for maximum quality. For larger models, keep fp8 and use
                 # layerwise casting to avoid OOM during loading.
+                # MPS does not support float8 — always dequantize.
                 file_size_gb = Path(base_model_path).stat().st_size / (1024**3)
-                use_fp8_inference = is_fp8 and file_size_gb > 8.0
+                use_fp8_inference = is_fp8 and file_size_gb > 8.0 and not is_mps()
 
                 dequant_count = 0
                 if has_comfy_fp8_scales:
@@ -340,8 +343,8 @@ def assemble_pipeline(
                                 # Peak memory: one tensor at a time (not whole model).
                                 checkpoint[wk] = actual.to(torch.float8_e4m3fn)
                             else:
-                                # Small model: keep as bf16 for best quality.
-                                checkpoint[wk] = actual.to(torch.bfloat16)
+                                # Small model / MPS: dequant to inference dtype.
+                                checkpoint[wk] = actual.to(get_inference_dtype())
                             dequant_count += 1
 
                 # Strip all scale/quant tensors (not needed after dequant,
@@ -417,23 +420,26 @@ def assemble_pipeline(
                     model.load_state_dict(converted, strict=False, assign=True)
                     del converted
                     _materialize_meta_tensors(model)
-                    model = model.to(torch.bfloat16)
+                    dtype = get_inference_dtype()
+                    model = model.to(dtype)
                     emitter.info(
-                        f"  → Loaded dequantized fp8 → bf16 via from_config"
+                        f"  → Loaded dequantized fp8 → {dtype} via from_config"
                     )
                 else:
+                    dtype = get_inference_dtype()
                     model = ModelClass.from_single_file(
                         base_model_path, config=str(config_dir),
-                        torch_dtype=torch.bfloat16,
+                        torch_dtype=dtype,
                     )
                     emitter.info(
-                        f"  → Loaded via from_single_file (bf16)"
+                        f"  → Loaded via from_single_file ({dtype})"
                     )
 
             # Apply fp8 layerwise casting to reduce VRAM: weights stored in
             # fp8, compute in bf16. Auto for large models (>15GB), or forced
             # when ControlNet is active (need room for CN weights on GPU).
-            if not is_fp8 and not is_gguf:
+            # MPS does not support float8 — skip layerwise casting.
+            if not is_fp8 and not is_gguf and not is_mps():
                 file_size_gb = Path(base_model_path).stat().st_size / (1024**3)
                 if file_size_gb > 15.0 or (force_fp8 and file_size_gb > 5.0):
                     model.enable_layerwise_casting(
@@ -497,7 +503,7 @@ def assemble_pipeline(
                     components[param_name] = ModelClass.from_single_file(
                         resolved_path,
                         config=str(config_dir),
-                        torch_dtype=torch.bfloat16,
+                        torch_dtype=get_inference_dtype(),
                     )
                 except (ValueError, NotImplementedError):
                     # Fall back: load config → create model → load weights
@@ -516,12 +522,12 @@ def assemble_pipeline(
                             f"Re-install with `modl pull` to get compatible weights."
                         )
                     model.load_state_dict(state_dict, strict=False)
-                    model = model.to(torch.bfloat16)
+                    model = model.to(get_inference_dtype())
                     components[param_name] = model
             elif use_hf_dir:
                 # HF directory layout — use from_pretrained with optional
                 # NF4 quantization (e.g. Flux2's 24B Mistral3 text encoder)
-                load_kwargs = {"torch_dtype": torch.bfloat16}
+                load_kwargs = {"torch_dtype": get_inference_dtype()}
                 if quantize_nf4:
                     try:
                         from transformers import BitsAndBytesConfig
@@ -544,9 +550,9 @@ def assemble_pipeline(
                 state_dict = safetensors.torch.load_file(resolved_path)
                 model.load_state_dict(state_dict, strict=False, assign=True)
                 _materialize_meta_tensors(model)
-                # Always cast text encoders to bf16 for numerical stability.
+                # Always cast text encoders to inference dtype for numerical stability.
                 # fp8 text encoders produce unreliable embeddings.
-                model = model.to(torch.bfloat16)
+                model = model.to(get_inference_dtype())
                 components[param_name] = model
         else:
             emitter.info(f"Skipping {param_name} (no weights found)")
@@ -557,7 +563,8 @@ def assemble_pipeline(
     pipeline_kwargs = ARCH_CONFIGS.get(arch_name, {}).get("pipeline_kwargs", {})
     pipe = PipelineClass(**components, **pipeline_kwargs)
     if not no_offload:
-        pipe.enable_model_cpu_offload()
+        from modl_worker.device import move_pipe_to_device
+        move_pipe_to_device(pipe)
     # Attach loaded file info for downstream metadata embedding
     pipe._modl_loaded_files = loaded_files
     return pipe
@@ -589,6 +596,7 @@ def load_pipeline(
     """
     import torch
 
+    dtype = get_inference_dtype()
     PipelineClass = _get_pipeline(cls_name)
     model_source = base_model_path or resolve_model_path(base_model_id)
     fmt = detect_model_format(model_source)
@@ -598,7 +606,7 @@ def load_pipeline(
     if fmt == "hf_directory":
         pipe = PipelineClass.from_pretrained(
             model_source,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=dtype,
         )
         emitter.info(f"Loaded from directory: {model_source}")
     elif fmt == "full_checkpoint":
@@ -613,7 +621,7 @@ def load_pipeline(
         try:
             pipe = PipelineClass.from_single_file(
                 model_source,
-                torch_dtype=torch.bfloat16,
+                torch_dtype=dtype,
             )
         finally:
             hf_constants.HF_HUB_OFFLINE = was_offline
@@ -631,7 +639,7 @@ def load_pipeline(
             emitter.info(f"No assembly spec, falling back to HF: {hf_repo}")
             pipe = PipelineClass.from_pretrained(
                 hf_repo,
-                torch_dtype=torch.bfloat16,
+                torch_dtype=dtype,
             )
     elif fmt == "gguf":
         # GGUF models need assembly with quantization config
@@ -646,14 +654,15 @@ def load_pipeline(
         # HF repo identifier
         pipe = PipelineClass.from_pretrained(
             model_source,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=dtype,
         )
 
     if force_fp8:
-        # When fp8 is forced (ControlNet mode), use model_cpu_offload
-        # instead of .to("cuda") so that text encoder and transformer
-        # don't both occupy GPU simultaneously during inference.
-        pipe.enable_model_cpu_offload()
+        # When fp8 is forced (ControlNet mode), use cpu_offload
+        # so that text encoder and transformer don't both occupy GPU
+        # simultaneously during inference.
+        from modl_worker.device import move_pipe_to_device
+        move_pipe_to_device(pipe)
         return pipe
     from modl_worker.device import get_device
     return pipe.to(get_device())

--- a/python/modl_worker/device.py
+++ b/python/modl_worker/device.py
@@ -41,6 +41,36 @@ def get_generator_device() -> str:
     return dev
 
 
+def get_inference_dtype():
+    """Return the best inference dtype for the active device.
+
+    MPS has limited bfloat16 support — use float16 for reliability.
+    CUDA uses bfloat16 for best quality.
+    """
+    if get_device() == "mps":
+        return torch.float16
+    return torch.bfloat16
+
+
+def is_mps() -> bool:
+    """Return True if running on MPS (Apple Silicon)."""
+    return get_device() == "mps"
+
+
+def move_pipe_to_device(pipe):
+    """Move a pipeline to the active device, using the right strategy.
+
+    On CUDA: use enable_model_cpu_offload() for memory efficiency.
+    On MPS: use pipe.to("mps") since cpu_offload is CUDA-only.
+    On CPU: use pipe.to("cpu").
+    """
+    dev = get_device()
+    if dev == "cuda":
+        pipe.enable_model_cpu_offload()
+    else:
+        pipe.to(dev)
+
+
 def empty_cache():
     """Free GPU cache for the active device."""
     dev = get_device()

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 use crate::compat::{check_windows_dev_mode, detect_tools};
 use crate::core::config::{Config, GpuOverride, StorageConfig, TargetConfig, ToolType};
 use crate::core::gpu;
+use crate::core::runtime;
 
 /// Starter models offered during interactive setup.
 /// Hardcoded top picks — sorted by VRAM fit at display time.
@@ -21,9 +22,23 @@ struct StarterModel {
 
 const STARTER_MODELS: &[StarterModel] = &[
     StarterModel {
+        id: "flux2-klein-4b",
+        label: "flux2-klein-4b",
+        description: "4-step, small & fast, Apache 2.0",
+        size_bytes: 4_200_000_000,
+        vram_min: 8_000,
+    },
+    StarterModel {
+        id: "z-image-turbo",
+        label: "z-image-turbo",
+        description: "1-step real-time, Apache 2.0",
+        size_bytes: 8_500_000_000,
+        vram_min: 12_000,
+    },
+    StarterModel {
         id: "flux-schnell",
         label: "flux-schnell",
-        description: "4-step, fastest",
+        description: "4-step, fast",
         size_bytes: 4_600_000_000,
         vram_min: 8_000,
     },
@@ -32,13 +47,6 @@ const STARTER_MODELS: &[StarterModel] = &[
         label: "flux-dev",
         description: "28-step, highest quality",
         size_bytes: 12_000_000_000,
-        vram_min: 12_000,
-    },
-    StarterModel {
-        id: "z-image-turbo",
-        label: "z-image-turbo",
-        description: "1-step, real-time",
-        size_bytes: 8_500_000_000,
         vram_min: 12_000,
     },
     StarterModel {
@@ -172,6 +180,13 @@ pub async fn run(defaults: bool, root_override: Option<&str>) -> Result<()> {
         Config::default_path().display()
     );
 
+    // Runtime install — auto-install on defaults, prompt otherwise
+    let runtime_installed = if defaults {
+        install_runtime(&gpu_info).await.unwrap_or(false)
+    } else {
+        offer_runtime_install(&gpu_info).await?
+    };
+
     // Model download offer
     let mut model_installed = false;
     if !defaults {
@@ -185,6 +200,9 @@ pub async fn run(defaults: bool, root_override: Option<&str>) -> Result<()> {
 
     println!();
     println!("Next steps:");
+    if !runtime_installed {
+        println!("  {} Install runtime", style("modl runtime install").cyan());
+    }
     if model_installed {
         println!(
             "  {} Generate an image",
@@ -199,7 +217,7 @@ pub async fn run(defaults: bool, root_override: Option<&str>) -> Result<()> {
         );
         println!(
             "  {} Install a model",
-            style("modl pull flux-schnell").cyan()
+            style("modl pull flux2-klein-4b").cyan()
         );
         println!("  {} Launch the web UI", style("modl serve").cyan());
     }
@@ -442,4 +460,56 @@ async fn offer_service_install() -> Result<()> {
 
     super::serve::install_service(3333).await?;
     Ok(())
+}
+
+/// Install runtime without prompting (used for --defaults mode).
+async fn install_runtime(gpu_info: &Option<gpu::GpuInfo>) -> Result<bool> {
+    let profile = runtime::default_profile();
+    println!();
+    println!(
+        "{} Installing runtime (profile: {})...",
+        style("→").cyan(),
+        style(profile).bold()
+    );
+    runtime::install(Some(profile), None)?;
+    runtime::bootstrap(Some(profile), None).await?;
+
+    println!("  {} Runtime installed ({})", style("✓").green(), profile);
+
+    if gpu_info.as_ref().map(|g| g.device) == Some(gpu::DeviceType::Mps) {
+        println!(
+            "  {} Generation works on MPS. Training requires {} (cloud GPU).",
+            style("i").dim(),
+            style("modl train --cloud").cyan(),
+        );
+    }
+
+    Ok(true)
+}
+
+/// Prompt user to install the Python runtime during init.
+async fn offer_runtime_install(gpu_info: &Option<gpu::GpuInfo>) -> Result<bool> {
+    let profile = runtime::default_profile();
+    let profile_desc = if profile == "generator" {
+        "generation-only (MPS)"
+    } else {
+        "generation + training (CUDA)"
+    };
+
+    println!();
+    let install = Confirm::new()
+        .with_prompt(format!("Install the Python runtime? ({profile_desc})"))
+        .default(true)
+        .interact()?;
+
+    if !install {
+        println!(
+            "  {} You can install later with {}",
+            style("i").dim(),
+            style("modl runtime install").cyan(),
+        );
+        return Ok(false);
+    }
+
+    install_runtime(gpu_info).await
 }

--- a/src/cli/runtime.rs
+++ b/src/cli/runtime.rs
@@ -50,7 +50,10 @@ pub enum RuntimeCommands {
 pub async fn run(command: RuntimeCommands) -> Result<()> {
     match command {
         RuntimeCommands::Install { profile, channel } => {
-            crate::core::preflight::check_device_for_training()?;
+            // Only check for training capability if explicitly requesting a trainer profile
+            if profile.as_deref() == Some("trainer-cu124") {
+                crate::core::preflight::check_device_for_training()?;
+            }
             let result = runtime::install(profile.as_deref(), channel.as_deref())?;
 
             println!("{} Runtime installed", style("✓").green().bold());

--- a/src/core/gpu.rs
+++ b/src/core/gpu.rs
@@ -112,7 +112,9 @@ fn detect_mps() -> Option<GpuInfo> {
         .trim()
         .parse()
         .ok()?;
-    let vram_mb = mem_bytes / (1024 * 1024);
+    // Unified memory is shared with the OS. Report ~75% as effective VRAM
+    // to avoid selecting variants that would leave no room for the system.
+    let vram_mb = (mem_bytes / (1024 * 1024)) * 3 / 4;
 
     Some(GpuInfo {
         name,

--- a/src/core/install.rs
+++ b/src/core/install.rs
@@ -54,9 +54,23 @@ pub fn select_variant<'a>(
     }
 
     if let Some(vram_mb) = vram {
+        // On MPS (Apple Silicon), exclude fp8 and GGUF variants — they require
+        // CUDA-specific kernels (float8 dtype, ggml quantization).
+        let is_mps = gpu::detect()
+            .map(|g| g.device == gpu::DeviceType::Mps)
+            .unwrap_or(false);
+
         let variant_info: Vec<(String, u64)> = manifest
             .variants
             .iter()
+            .filter(|v| {
+                if is_mps {
+                    let id = v.id.to_lowercase();
+                    !id.contains("fp8") && !id.contains("gguf")
+                } else {
+                    true
+                }
+            })
             .map(|v| (v.id.clone(), v.vram_required.unwrap_or(0)))
             .collect();
         if let Some(selected_id) = gpu::select_variant(vram_mb, &variant_info) {

--- a/src/core/preflight.rs
+++ b/src/core/preflight.rs
@@ -203,7 +203,7 @@ pub fn check_device_for_training() -> Result<()> {
             "Training requires a CUDA GPU and is not supported on Apple Silicon (MPS).\n\n\
              Use cloud training instead:\n\n  \
              modl train --cloud\n\n\
-             This runs training on a remote A100 GPU." // TODO: point to `modl train --attach-gpu` when cloud GPU orchestrator lands
+             This runs training on a cloud GPU."
         );
     }
     Ok(())

--- a/src/core/runtime.rs
+++ b/src/core/runtime.rs
@@ -13,8 +13,21 @@ use console::style;
 use crate::core::download;
 use crate::core::store::Store;
 
-const DEFAULT_PROFILE: &str = "trainer-cu124";
+const DEFAULT_PROFILE_CUDA: &str = "trainer-cu124";
 const GENERATOR_PROFILE: &str = "generator";
+
+/// Returns the default runtime profile for the current device.
+///
+/// On MPS (Apple Silicon), defaults to the lightweight `generator` profile
+/// since training requires CUDA. On CUDA/CPU, defaults to `trainer-cu124`.
+pub fn default_profile() -> &'static str {
+    if let Some(info) = crate::core::gpu::detect()
+        && info.device == crate::core::gpu::DeviceType::Mps
+    {
+        return GENERATOR_PROFILE;
+    }
+    DEFAULT_PROFILE_CUDA
+}
 const DEFAULT_CHANNEL: &str = "stable";
 const PYTHON_VERSION: &str = "3.11.12";
 const TRAINER_CU126_INDEX_URL: &str = "https://download.pytorch.org/whl/cu126";
@@ -108,7 +121,7 @@ struct PythonArtifact {
 }
 
 pub fn install(profile: Option<&str>, channel: Option<&str>) -> Result<RuntimeInstallResult> {
-    let profile = profile.unwrap_or(DEFAULT_PROFILE);
+    let profile = profile.unwrap_or_else(|| default_profile());
     validate_profile(profile)?;
 
     let channel = channel.unwrap_or(DEFAULT_CHANNEL);
@@ -181,8 +194,8 @@ pub fn train_command_template() -> Result<Option<String>> {
 }
 
 pub async fn setup_training(reinstall: bool) -> Result<TrainingSetupResult> {
-    let install = install(Some(DEFAULT_PROFILE), None)?;
-    let env_dir = install.runtime_root.join("envs").join(DEFAULT_PROFILE);
+    let install = install(Some(DEFAULT_PROFILE_CUDA), None)?;
+    let env_dir = install.runtime_root.join("envs").join(DEFAULT_PROFILE_CUDA);
 
     if reinstall {
         let marker = bootstrap_marker_path(env_dir.as_path());
@@ -192,7 +205,7 @@ pub async fn setup_training(reinstall: bool) -> Result<TrainingSetupResult> {
         }
     }
 
-    let boot = bootstrap(Some(DEFAULT_PROFILE), None).await?;
+    let boot = bootstrap(Some(DEFAULT_PROFILE_CUDA), None).await?;
     let template = train_command_template()?;
 
     Ok(TrainingSetupResult {
@@ -209,15 +222,15 @@ pub async fn setup_training(reinstall: bool) -> Result<TrainingSetupResult> {
 /// trainer profile is already bootstrapped, reuses it to avoid a redundant venv.
 pub async fn setup_generation() -> Result<GenerationSetupResult> {
     // If the full trainer profile is already bootstrapped, reuse it (superset)
-    if is_profile_ready(DEFAULT_PROFILE).unwrap_or(false) {
+    if is_profile_ready(DEFAULT_PROFILE_CUDA).unwrap_or(false) {
         let root = runtime_root()?;
         let python_path = root
             .join("envs")
-            .join(DEFAULT_PROFILE)
+            .join(DEFAULT_PROFILE_CUDA)
             .join("bin")
             .join("python");
         return Ok(GenerationSetupResult {
-            profile: DEFAULT_PROFILE.to_string(),
+            profile: DEFAULT_PROFILE_CUDA.to_string(),
             python_path,
         });
     }
@@ -237,8 +250,8 @@ pub async fn setup_generation() -> Result<GenerationSetupResult> {
 /// If the trainer profile is already bootstrapped, returns that (superset).
 /// Otherwise returns the lightweight generator profile.
 pub fn resolved_generation_profile() -> &'static str {
-    if is_profile_ready(DEFAULT_PROFILE).unwrap_or(false) {
-        DEFAULT_PROFILE
+    if is_profile_ready(DEFAULT_PROFILE_CUDA).unwrap_or(false) {
+        DEFAULT_PROFILE_CUDA
     } else {
         GENERATOR_PROFILE
     }
@@ -286,7 +299,10 @@ pub fn doctor() -> Result<RuntimeDoctorReport> {
 
 pub fn upgrade(channel: Option<&str>) -> Result<RuntimeInstallResult> {
     let current = status()?;
-    let profile = current.profile.as_deref().unwrap_or(DEFAULT_PROFILE);
+    let profile = current
+        .profile
+        .as_deref()
+        .unwrap_or_else(|| default_profile());
     install(Some(profile), channel)
 }
 
@@ -428,7 +444,7 @@ fn write_manifest_index_if_missing(root: &Path, channel: &str) -> Result<()> {
         "generated_at": chrono::Utc::now().to_rfc3339(),
         "profiles": [
             {
-                "id": DEFAULT_PROFILE,
+                "id": DEFAULT_PROFILE_CUDA,
                 "version": "2026.02.1",
                 "manifest_uri": "https://github.com/modl/modl-runtime-manifests/releases/download/v2026.02.1/trainer-cu124.json",
                 "sha256": ""
@@ -454,11 +470,11 @@ fn write_manifest_index_if_missing(root: &Path, channel: &str) -> Result<()> {
 }
 
 fn ensure_profile_seed_files(root: &Path) -> Result<()> {
-    write_profile_manifest_if_missing(root, DEFAULT_PROFILE)?;
+    write_profile_manifest_if_missing(root, DEFAULT_PROFILE_CUDA)?;
     write_profile_manifest_if_missing(root, "inference-cu124")?;
     write_profile_manifest_if_missing(root, GENERATOR_PROFILE)?;
 
-    write_profile_requirements_if_missing(root, DEFAULT_PROFILE)?;
+    write_profile_requirements_if_missing(root, DEFAULT_PROFILE_CUDA)?;
     write_profile_requirements_if_missing(root, "inference-cu124")?;
     write_profile_requirements_if_missing(root, GENERATOR_PROFILE)?;
 


### PR DESCRIPTION
## Summary
- **Runtime install unblocked on MPS**: auto-selects `generator` profile instead of `trainer-cu124`. Only checks for training capability when explicitly requesting trainer profile.
- **Pipeline inference on MPS**: replaces hardcoded `bfloat16` with device-aware dtype (`float16` on MPS, `bfloat16` on CUDA). Replaces `enable_model_cpu_offload()` with `move_pipe_to_device()` that uses `pipe.to("mps")` on Apple Silicon.
- **fp8/GGUF blocked on MPS**: float8 is unsupported on MPS — fp8 inference path and layerwise casting are skipped. Variant auto-selection filters out fp8/gguf variants on MPS.
- **VRAM reporting**: MPS reports 75% of unified memory as effective VRAM (was 100%, which over-provisions since OS shares it).
- **Init flow**: `modl init` now prompts to install runtime and suggests `flux2-klein-4b` and `z-image-turbo` (small, Apache 2.0) as default starter models.
- **Error message**: removed A100 GPU mention from training preflight error.

## Test plan
- [ ] `modl init` on macOS: should detect MPS, offer runtime install with "generation-only (MPS)", show klein-4b as first starter model
- [ ] `modl runtime install` on macOS: should install generator profile (not trainer-cu124)
- [ ] `modl generate "a cat" --base flux2-klein-4b` on macOS: should load in fp16, use `pipe.to("mps")`
- [ ] `modl pull flux-dev` on macOS: should select bf16 variant (not fp8), report scaled VRAM
- [ ] `modl train` on macOS: should error with "use `modl train --cloud`" (no A100 mention)
- [ ] All CUDA paths unchanged: bf16, enable_model_cpu_offload, fp8 inference still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)