### PR TITLE
fix: serve lazy-loaded UI chunks with correct MIME type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,6 +1208,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,6 +1535,7 @@ dependencies = [
  "flate2",
  "futures-util",
  "image",
+ "include_dir",
  "indicatif",
  "libc",
  "llama-cpp-2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ open = "5"
 # Image processing (thumbnails)
 image = { version = "0.25", default-features = false, features = ["jpeg", "png", "webp"] }
 
+# Embedded assets
+include_dir = "0.7"
+
 # Misc
 chrono = { version = "0.4", features = ["serde"] }
 shellexpand = "3"

--- a/src/ui/routes/files.rs
+++ b/src/ui/routes/files.rs
@@ -4,9 +4,12 @@ use axum::{
     http::{StatusCode, header},
     response::{Html, IntoResponse},
 };
+use include_dir::{Dir, include_dir};
 use serde::Deserialize;
 
 use crate::core::paths::modl_root;
+
+static DIST_ASSETS: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/ui/dist/assets");
 
 /// Serve files from ~/.modl/ (images, samples, etc.)
 pub async fn serve_file(
@@ -140,18 +143,15 @@ async fn serve_thumbnail(source: &std::path::Path, width: u32) -> axum::response
 
 /// Serve bundled UI assets embedded at compile time.
 pub async fn serve_ui_asset(Path(path): Path<String>) -> impl IntoResponse {
-    match path.as_str() {
-        "app.js" => (
-            [(header::CONTENT_TYPE, "text/javascript; charset=utf-8")],
-            include_str!("../dist/assets/app.js"),
-        )
-            .into_response(),
-        "index.css" => (
-            [(header::CONTENT_TYPE, "text/css; charset=utf-8")],
-            include_str!("../dist/assets/index.css"),
-        )
-            .into_response(),
-        _ => (StatusCode::NOT_FOUND, "Not found").into_response(),
+    let content_type = match path.rsplit('.').next().unwrap_or("") {
+        "js" => "text/javascript; charset=utf-8",
+        "css" => "text/css; charset=utf-8",
+        _ => "application/octet-stream",
+    };
+
+    match DIST_ASSETS.get_file(&path) {
+        Some(file) => ([(header::CONTENT_TYPE, content_type)], file.contents()).into_response(),
+        None => (StatusCode::NOT_FOUND, "Not found").into_response(),
     }
 }
 


### PR DESCRIPTION
## Summary
- The Vite build code-splits lazy components (OutputsGallery, TrainingRuns, etc.) into separate `.js` chunks under `dist/assets/`
- The `serve_ui_asset` handler only matched `app.js` and `index.css` — all other chunks hit the 404 fallback, served as `text/plain`, causing browsers to block them
- Replaced hardcoded match arms with `include_dir!` to embed the entire `dist/assets/` directory, serving any file with the correct Content-Type

## Test plan
- [x] `cargo build` passes
- [ ] Open web UI, navigate to Outputs tab — OutputsGallery loads without MIME errors
- [ ] Navigate to Training, Datasets, LoRA Library, Models tabs — all lazy chunks load

🤖 Generated with [Claude Code](https://claude.com/claude-code)