### PR TITLE
feat: edit --size, release packaging, qwen-image-edit fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,16 +76,22 @@ jobs:
       - name: Package (Unix)
         if: matrix.archive == 'tar.gz'
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ../../../modl-${{ github.ref_name }}-${{ matrix.target }}.tar.gz modl
-          cd ../../..
+          mkdir -p staging/python
+          cp target/${{ matrix.target }}/release/modl staging/
+          rsync -a --exclude='__pycache__' python/modl_worker/ staging/python/modl_worker/
+          cd staging
+          tar czf ../modl-${{ github.ref_name }}-${{ matrix.target }}.tar.gz modl python/
+          cd ..
 
       # Package — Windows
       - name: Package (Windows)
         if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          Compress-Archive -Path "target/${{ matrix.target }}/release/modl.exe" -DestinationPath "modl-${{ github.ref_name }}-${{ matrix.target }}.zip"
+          New-Item -ItemType Directory -Force -Path staging/python
+          Copy-Item "target/${{ matrix.target }}/release/modl.exe" staging/
+          Copy-Item -Recurse python/modl_worker staging/python/modl_worker
+          Compress-Archive -Path "staging/*" -DestinationPath "modl-${{ github.ref_name }}-${{ matrix.target }}.zip"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/install.sh
+++ b/install.sh
@@ -111,7 +111,7 @@ fi
 
 tar xzf "$TMPDIR/${ASSET}" -C "$TMPDIR"
 
-# Install
+# Install binary
 if [ -w "$INSTALL_DIR" ]; then
     mv "$TMPDIR/modl" "$INSTALL_DIR/modl"
 else
@@ -120,6 +120,18 @@ else
 fi
 
 chmod +x "$INSTALL_DIR/modl"
+
+# Install Python worker (next to binary, where the CLI expects it)
+if [ -d "$TMPDIR/python" ]; then
+    PYTHON_DIR="$INSTALL_DIR/python"
+    if [ -w "$INSTALL_DIR" ]; then
+        rm -rf "$PYTHON_DIR"
+        mv "$TMPDIR/python" "$PYTHON_DIR"
+    else
+        sudo rm -rf "$PYTHON_DIR"
+        sudo mv "$TMPDIR/python" "$PYTHON_DIR"
+    fi
+fi
 
 echo ""
 echo "modl ${LATEST} installed to ${INSTALL_DIR}/modl"

--- a/python/modl_worker/adapters/arch_config.py
+++ b/python/modl_worker/adapters/arch_config.py
@@ -502,7 +502,7 @@ ARCH_CONFIGS: dict[str, dict] = {
             },
             "scheduler": {
                 "model_class": "FlowMatchEulerDiscreteScheduler",
-                "config_dir": "qwen-image-scheduler",
+                "config_dir": "qwen-image-edit-scheduler",
             },
         },
         "model_flags": {

--- a/python/modl_worker/adapters/edit_adapter.py
+++ b/python/modl_worker/adapters/edit_adapter.py
@@ -123,6 +123,11 @@ def run_edit_with_pipeline(spec: dict, emitter: EventEmitter, pipeline: object) 
             "num_inference_steps": steps,
             "generator": generator,
         }
+        # Optional output dimensions (for outpainting — larger than source)
+        if params.get("width"):
+            gen_kwargs["width"] = params["width"]
+        if params.get("height"):
+            gen_kwargs["height"] = params["height"]
 
     artifact_paths = []
 

--- a/python/modl_worker/adapters/pipeline_loader.py
+++ b/python/modl_worker/adapters/pipeline_loader.py
@@ -74,16 +74,15 @@ def detect_model_format(model_source: str) -> str:
                 header = _json.loads(header_bytes)
 
             keys = set(header.keys()) - {"__metadata__"}
-            # Sample a few keys to determine format
-            sample_keys = list(keys)[:50]
-            key_str = " ".join(sample_keys)
+            key_prefixes = {k.split(".")[0] for k in keys}
 
-            # Full checkpoint indicators (SD/SDXL format)
-            full_ckpt_prefixes = [
-                "conditioner.", "first_stage_model.", "model.diffusion_model.",
-                "cond_stage_model.",
-            ]
-            if any(p in key_str for p in full_ckpt_prefixes):
+            # Full checkpoint = has VAE/TE alongside the diffusion model.
+            # "model.diffusion_model.*" alone is just ComfyUI-format
+            # transformer weights (e.g. Qwen-Image fp8), NOT a full ckpt.
+            has_vae_or_te = key_prefixes & {
+                "conditioner", "first_stage_model", "cond_stage_model",
+            }
+            if has_vae_or_te:
                 return "full_checkpoint"
 
             # If we got here with safetensors keys, it's transformer-only

--- a/python/modl_worker/configs/qwen-image-edit-scheduler/scheduler_config.json
+++ b/python/modl_worker/configs/qwen-image-edit-scheduler/scheduler_config.json
@@ -1,0 +1,18 @@
+{
+  "_class_name": "FlowMatchEulerDiscreteScheduler",
+  "_diffusers_version": "0.37.0",
+  "base_image_seq_len": 256,
+  "base_shift": 0.5,
+  "invert_sigmas": false,
+  "max_image_seq_len": 4096,
+  "max_shift": 1.15,
+  "num_train_timesteps": 1000,
+  "shift": 1.0,
+  "shift_terminal": 0.02,
+  "stochastic_sampling": false,
+  "time_shift_type": "exponential",
+  "use_beta_sigmas": false,
+  "use_dynamic_shifting": true,
+  "use_exponential_sigmas": false,
+  "use_karras_sigmas": false
+}

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -21,6 +21,7 @@ pub struct EditArgs<'a> {
     pub steps: Option<u32>,
     pub guidance: Option<f32>,
     pub count: u32,
+    pub size: Option<&'a str>,
     pub fast: bool,
     pub cloud: bool,
     pub provider: Option<CloudProvider>,
@@ -117,6 +118,30 @@ fn resolve_lora(name: &str, weight: f32, db: &Database) -> Result<Option<LoraRef
     Ok(None)
 }
 
+const SIZE_PRESETS: &[(&str, u32, u32)] = &[
+    ("1:1", 1024, 1024),
+    ("16:9", 1344, 768),
+    ("9:16", 768, 1344),
+    ("4:3", 1152, 896),
+    ("3:4", 896, 1152),
+];
+
+fn resolve_edit_size(size: &str) -> Result<(u32, u32)> {
+    for &(name, w, h) in SIZE_PRESETS {
+        if size == name {
+            return Ok((w, h));
+        }
+    }
+    if let Some((w, h)) = size.split_once('x') {
+        let w: u32 = w.parse().context("Invalid width in size")?;
+        let h: u32 = h.parse().context("Invalid height in size")?;
+        return Ok((w, h));
+    }
+    anyhow::bail!(
+        "Unknown size: {size}. Use a preset (1:1, 16:9, 9:16, 4:3, 3:4) or WxH (e.g. 1820x1024)"
+    );
+}
+
 pub async fn run(args: EditArgs<'_>) -> Result<()> {
     let db = Database::open()?;
 
@@ -128,6 +153,7 @@ pub async fn run(args: EditArgs<'_>) -> Result<()> {
         steps,
         guidance,
         count,
+        size,
         fast,
         cloud,
         provider,
@@ -216,6 +242,15 @@ pub async fn run(args: EditArgs<'_>) -> Result<()> {
     let guidance = guidance.or(fast_guidance).unwrap_or(default_guidance);
 
     // -------------------------------------------------------------------
+    // Resolve output size (for outpainting)
+    // -------------------------------------------------------------------
+    let output_size: Option<(u32, u32)> = if let Some(s) = size {
+        Some(resolve_edit_size(s)?)
+    } else {
+        None
+    };
+
+    // -------------------------------------------------------------------
     // Build spec
     // -------------------------------------------------------------------
     let spec = EditJobSpec {
@@ -234,6 +269,8 @@ pub async fn run(args: EditArgs<'_>) -> Result<()> {
             guidance,
             seed,
             count,
+            width: output_size.map(|(w, _)| w),
+            height: output_size.map(|(_, h)| h),
         },
         runtime: RuntimeRef {
             profile: runtime::resolved_generation_profile().to_string(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -623,6 +623,9 @@ pub enum Commands {
         /// Number of output images
         #[arg(long, default_value = "1")]
         count: u32,
+        /// Output size (e.g. "16:9", "1820x1024") — larger than source for outpainting
+        #[arg(long)]
+        size: Option<String>,
         /// Use Lightning distillation LoRA for fast editing (fewer steps)
         #[arg(long)]
         fast: bool,
@@ -1069,6 +1072,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             steps,
             guidance,
             count,
+            size,
             fast,
             cloud,
             provider,
@@ -1083,6 +1087,7 @@ pub async fn run(cli: Cli) -> Result<()> {
                 steps,
                 guidance,
                 count,
+                size: size.as_deref(),
                 fast,
                 cloud,
                 provider,

--- a/src/core/job.rs
+++ b/src/core/job.rs
@@ -357,6 +357,11 @@ pub struct EditParams {
     #[serde(default)]
     pub seed: Option<u64>,
     pub count: u32,
+    /// Optional output dimensions (for outpainting — larger than source image)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub width: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub height: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/core/training.rs
+++ b/src/core/training.rs
@@ -10,8 +10,11 @@ use super::training_status;
 
 /// Resolve the path to the Python worker package root.
 ///
-/// Checks `MODL_WORKER_PYTHON_ROOT` env var first, then falls back to
-/// `CARGO_MANIFEST_DIR/python`.
+/// Search order:
+///   1. `MODL_WORKER_PYTHON_ROOT` env var (explicit override)
+///   2. `<binary_dir>/python` (next to the installed binary)
+///   3. `<binary_dir>/../python` (symlink → repo: target/release/../python)
+///   4. `CARGO_MANIFEST_DIR/python` (dev builds)
 pub fn resolve_worker_python_root() -> Result<PathBuf> {
     if let Ok(custom) = env::var("MODL_WORKER_PYTHON_ROOT") {
         let path = PathBuf::from(custom);
@@ -24,14 +27,31 @@ pub fn resolve_worker_python_root() -> Result<PathBuf> {
         );
     }
 
+    // Resolve relative to the actual binary (following symlinks)
+    if let Ok(exe) = env::current_exe() {
+        let exe = exe.canonicalize().unwrap_or(exe);
+        if let Some(bin_dir) = exe.parent() {
+            // <bin>/python (installed layout)
+            let candidate = bin_dir.join("python");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+            // <bin>/../python (symlink into repo: target/release/../python)
+            if let Some(parent) = bin_dir.parent() {
+                let candidate = parent.join("python");
+                if candidate.exists() {
+                    return Ok(candidate);
+                }
+            }
+        }
+    }
+
+    // Compile-time fallback (dev builds only)
     let default_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("python");
     if default_path.exists() {
         Ok(default_path)
     } else {
-        bail!(
-            "Worker python package not found at {}. Set MODL_WORKER_PYTHON_ROOT to a valid path.",
-            default_path.display()
-        )
+        bail!("Worker python package not found. Set MODL_WORKER_PYTHON_ROOT to a valid path.")
     }
 }
 

--- a/src/ui/routes/generate.rs
+++ b/src/ui/routes/generate.rs
@@ -237,6 +237,7 @@ async fn run_single_edit(sender: &broadcast::Sender<String>, req: EditRequest) {
         steps: Some(req.steps),
         guidance: Some(req.guidance),
         count: req.num_images,
+        size: None,
         fast: req.fast,
         cloud: false,
         provider: None,


### PR DESCRIPTION
## Summary

- **`modl edit --size`**: Output size control for outpainting — specify a larger canvas (e.g. `--size 16:9` or `--size 1820x1024`) and the edit model fills the extra space natively via its vision encoder conditioning
- **Release packaging**: Bundle `python/modl_worker/` in release tarballs + install alongside binary. `resolve_worker_python_root()` now finds the worker next to the installed binary.
- **qwen-image-edit fix**: Dedicated scheduler config (`qwen-image-edit-scheduler`), and fix `detect_model_format` misclassifying ComfyUI transformer-only files as full checkpoints

## Test plan
- [x] `modl edit --size 16:9` with qwen-image-edit — outputs at target resolution
- [x] `cargo test` — 11 passed
- [x] `cargo clippy` clean
- [x] Validation: size presets (1:1, 16:9, 9:16, 4:3, 3:4) and WxH format

🤖 Generated with [Claude Code](https://claude.com/claude-code)