### PR TITLE
fix: code quality — validation, dedup, error consistency, job cleanup

### DIFF
--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -9,6 +9,7 @@ use crate::core::executor::{Executor, LocalExecutor};
 use crate::core::gpu_session;
 use crate::core::job::*;
 use crate::core::model_family;
+use crate::core::model_resolve;
 use crate::core::outputs::{SidecarMetadata, write_sidecar_yaml};
 use crate::core::preflight;
 use crate::core::remote_executor::RemoteExecutor;
@@ -81,69 +82,16 @@ fn url_extension(url: &str) -> Option<&str> {
     }
 }
 
-/// Resolve base model path from installed models.
 fn resolve_base_model_path(base_model: &str, db: &Database) -> Option<String> {
-    let installed = db.list_installed(None).ok()?;
-    for model in &installed {
-        if (model.name == base_model || model.id == base_model)
-            && (model.asset_type == "checkpoint" || model.asset_type == "diffusion_model")
-        {
-            return Some(model.store_path.clone());
-        }
-    }
-    None
+    model_resolve::resolve_base_model_path(base_model, db)
 }
 
-/// Resolve a LoRA name to its store path by looking in the DB.
 fn resolve_lora(name: &str, weight: f32, db: &Database) -> Result<Option<LoraRef>> {
-    let path = PathBuf::from(name);
-    if path.exists() && path.extension().is_some_and(|e| e == "safetensors") {
-        return Ok(Some(LoraRef {
-            name: path
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
-            path: path.to_string_lossy().to_string(),
-            weight,
-        }));
-    }
-
-    let installed = db.list_installed(None)?;
-    for model in &installed {
-        if (model.name == name || model.id == name) && model.asset_type == "lora" {
-            return Ok(Some(LoraRef {
-                name: model.name.clone(),
-                path: model.store_path.clone(),
-                weight,
-            }));
-        }
-    }
-    Ok(None)
+    model_resolve::resolve_lora(name, weight, db)
 }
-
-const SIZE_PRESETS: &[(&str, u32, u32)] = &[
-    ("1:1", 1024, 1024),
-    ("16:9", 1344, 768),
-    ("9:16", 768, 1344),
-    ("4:3", 1152, 896),
-    ("3:4", 896, 1152),
-];
 
 fn resolve_edit_size(size: &str) -> Result<(u32, u32)> {
-    for &(name, w, h) in SIZE_PRESETS {
-        if size == name {
-            return Ok((w, h));
-        }
-    }
-    if let Some((w, h)) = size.split_once('x') {
-        let w: u32 = w.parse().context("Invalid width in size")?;
-        let h: u32 = h.parse().context("Invalid height in size")?;
-        return Ok((w, h));
-    }
-    anyhow::bail!(
-        "Unknown size: {size}. Use a preset (1:1, 16:9, 9:16, 4:3, 3:4) or WxH (e.g. 1820x1024)"
-    );
+    model_resolve::resolve_size(size)
 }
 
 pub async fn run(args: EditArgs<'_>) -> Result<()> {

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -10,6 +10,7 @@ use crate::core::executor::{Executor, LocalExecutor};
 use crate::core::gpu_session;
 use crate::core::job::*;
 use crate::core::model_family;
+use crate::core::model_resolve;
 use crate::core::outputs::{SidecarMetadata, write_sidecar_yaml};
 use crate::core::preflight;
 use crate::core::remote_executor::RemoteExecutor;
@@ -45,15 +46,6 @@ fn detect_control_type_from_filename(path: &str) -> Option<String> {
     None
 }
 
-/// Size presets: aspect ratio → (width, height)
-const SIZE_PRESETS: &[(&str, u32, u32)] = &[
-    ("1:1", 1024, 1024),
-    ("16:9", 1344, 768),
-    ("9:16", 768, 1344),
-    ("4:3", 1152, 896),
-    ("3:4", 896, 1152),
-];
-
 /// Read image dimensions from a file on disk.
 fn image_dimensions(path: &str) -> Result<(u32, u32)> {
     let reader = image::ImageReader::open(path)
@@ -66,58 +58,15 @@ fn image_dimensions(path: &str) -> Result<(u32, u32)> {
     Ok(dims)
 }
 
-/// Resolve a size preset string to (width, height).
-fn resolve_size(size: &str) -> Result<(u32, u32)> {
-    // Check presets
-    for &(name, w, h) in SIZE_PRESETS {
-        if size == name {
-            return Ok((w, h));
-        }
-    }
-
-    // Try WxH format
-    if let Some((w, h)) = size.split_once('x') {
-        let w: u32 = w.parse().context("Invalid width in size")?;
-        let h: u32 = h.parse().context("Invalid height in size")?;
-        return Ok((w, h));
-    }
-
-    anyhow::bail!(
-        "Unknown size: {size}. Use a preset (1:1, 16:9, 9:16, 4:3, 3:4) or WxH (e.g. 1024x1024)"
-    );
-}
-
 /// Resolve a LoRA name to its store path by looking in the DB.
 fn resolve_lora(name: &str, weight: f32, db: &Database) -> Result<Option<LoraRef>> {
-    // Check if the name is a direct path to a .safetensors file
-    let path = PathBuf::from(name);
-    if path.exists() && path.extension().is_some_and(|e| e == "safetensors") {
-        return Ok(Some(LoraRef {
-            name: path
-                .file_stem()
-                .unwrap_or_default()
-                .to_string_lossy()
-                .to_string(),
-            path: path.to_string_lossy().to_string(),
-            weight,
-        }));
+    let result = model_resolve::resolve_lora(name, weight, db)?;
+    if result.is_none() {
+        anyhow::bail!(
+            "LoRA not found: {name}. Use `modl model ls --type lora` to see installed LoRAs, or provide a file path."
+        );
     }
-
-    // Look up in installed models (match by ID or display name)
-    let installed = db.list_installed(None)?;
-    for model in &installed {
-        if (model.name == name || model.id == name) && model.asset_type == "lora" {
-            return Ok(Some(LoraRef {
-                name: model.name.clone(),
-                path: model.store_path.clone(),
-                weight,
-            }));
-        }
-    }
-
-    anyhow::bail!(
-        "LoRA not found: {name}. Use `modl model ls --type lora` to see installed LoRAs, or provide a file path."
-    );
+    Ok(result)
 }
 
 /// Pick the best installed generation model, falling back to "flux-schnell".
@@ -152,37 +101,8 @@ fn default_guidance(base_model: &str) -> f32 {
     model_family::model_defaults(base_model).1
 }
 
-/// Resolve base model path from installed models (match by ID, display name, or family alias).
 fn resolve_base_model_path(base_model: &str, db: &Database) -> Option<String> {
-    let installed = db.list_installed(None).ok()?;
-    let gen_types = ["checkpoint", "diffusion_model"];
-
-    // Exact match by ID or display name
-    for model in &installed {
-        if (model.name == base_model || model.id == base_model)
-            && gen_types.contains(&model.asset_type.as_str())
-        {
-            return Some(model.store_path.clone());
-        }
-    }
-
-    // Fuzzy match via model_family (e.g. "sdxl" → "sdxl-base-1.0")
-    if let Some(family_info) = model_family::resolve_model(base_model) {
-        let family_id = family_info.id;
-        for model in &installed {
-            if gen_types.contains(&model.asset_type.as_str()) {
-                // Match if the installed model's ID contains the family ID or vice versa
-                if model.id == family_id
-                    || model.id.contains(family_id)
-                    || family_id.contains(&*model.id)
-                {
-                    return Some(model.store_path.clone());
-                }
-            }
-        }
-    }
-
-    None
+    model_resolve::resolve_base_model_path(base_model, db)
 }
 
 /// Check if a model ID is installed in the DB.
@@ -311,11 +231,11 @@ pub async fn run(args: GenerateArgs<'_>) -> Result<()> {
     // Resolve size: explicit --size wins, otherwise use init-image dims
     // -------------------------------------------------------------------
     let (width, height) = if let Some(s) = size {
-        resolve_size(s)?
+        model_resolve::resolve_size(s)?
     } else if let Some(path) = init_image {
         image_dimensions(path)?
     } else {
-        resolve_size("1:1")?
+        model_resolve::resolve_size("1:1")?
     };
 
     // -------------------------------------------------------------------

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -152,6 +152,194 @@ fn create_lora_symlinks(
 }
 
 // ---------------------------------------------------------------------------
+// Promote LoRA to library
+// ---------------------------------------------------------------------------
+
+use super::training::parse_step_from_filename;
+
+/// Parameters for promoting a training output LoRA to the library.
+pub struct PromoteLoraParams {
+    pub name: String,
+    pub trigger_word: Option<String>,
+    pub base_model: Option<String>,
+    pub lora_path: String,
+    pub thumbnail: Option<String>,
+    pub step: Option<u64>,
+    pub training_run: Option<String>,
+    pub config_json: Option<String>,
+    pub tags: Option<String>,
+}
+
+/// Promote a trained LoRA to the library: validate, register in DB, copy to
+/// content-addressed store, and register as installed artifact.
+///
+/// Returns the library LoRA ID on success.
+pub fn promote_lora(params: PromoteLoraParams) -> Result<String> {
+    let modl_root = super::paths::modl_root();
+    let lora_path = std::path::Path::new(&params.lora_path);
+
+    // Validate that lora_path is under the modl training_output directory
+    let allowed_dir = modl_root.join("training_output");
+    let canonical_lora = lora_path
+        .canonicalize()
+        .map_err(|e| anyhow::anyhow!("Invalid lora_path: {e}"))?;
+    let canonical_allowed = allowed_dir.canonicalize().unwrap_or(allowed_dir.clone());
+    if !canonical_lora.starts_with(&canonical_allowed) {
+        anyhow::bail!("lora_path must be under the training output directory");
+    }
+
+    let size_bytes = lora_path.metadata().map(|m| m.len()).unwrap_or(0);
+
+    // Auto-resolve thumbnail from training samples when not provided
+    let thumbnail = params.thumbnail.or_else(|| {
+        let run_name = params.training_run.as_deref()?;
+        let samples_dir = modl_root
+            .join("training_output")
+            .join(run_name)
+            .join(run_name)
+            .join("samples");
+        if !samples_dir.exists() {
+            return None;
+        }
+        let mut best: Option<(u64, String)> = None;
+        if let Ok(entries) = std::fs::read_dir(&samples_dir) {
+            for entry in entries.flatten() {
+                let fname = entry.file_name().to_string_lossy().to_string();
+                if let Some(step) = parse_step_from_filename(&fname)
+                    && best.as_ref().is_none_or(|(s, _)| step > *s)
+                {
+                    let rel = format!("training_output/{run_name}/{run_name}/samples/{fname}");
+                    best = Some((step, rel));
+                }
+            }
+        }
+        best.map(|(_, path)| path)
+    });
+
+    let id = format!(
+        "lib:{}:{}",
+        slug(&params.name),
+        &uuid::Uuid::new_v4().to_string()[..8]
+    );
+
+    // Fetch job spec for reproducibility metadata
+    let job_spec = params.training_run.as_deref().and_then(|run_name| {
+        let db = Database::open().ok()?;
+        let jobs = db.find_jobs_by_lora_name(run_name).ok()?;
+        let spec: serde_json::Value = serde_json::from_str(&jobs.first()?.spec_json).ok()?;
+        Some(spec)
+    });
+
+    // Merge ai-toolkit config + job spec into one JSON blob
+    let merged_config = {
+        let mut obj = serde_json::Map::new();
+        if let Some(ref cfg) = params.config_json
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(cfg)
+        {
+            obj.insert("toolkit_config".into(), v);
+        }
+        if let Some(ref spec) = job_spec {
+            obj.insert("job_spec".into(), spec.clone());
+        }
+        if obj.is_empty() {
+            None
+        } else {
+            Some(serde_json::Value::Object(obj).to_string())
+        }
+    };
+
+    let auto_tag = job_spec.as_ref().and_then(|spec| {
+        spec.pointer("/params/lora_type")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+    });
+
+    let record = crate::core::db::LibraryLoraRecord {
+        id: id.clone(),
+        name: params.name.clone(),
+        trigger_word: params.trigger_word,
+        base_model: params.base_model.clone(),
+        lora_path: params.lora_path.clone(),
+        thumbnail,
+        step: params.step,
+        training_run: params.training_run.clone(),
+        config_json: merged_config,
+        tags: params.tags.or(auto_tag),
+        notes: None,
+        size_bytes,
+        created_at: String::new(),
+    };
+
+    let db = Database::open()?;
+    db.insert_library_lora(&record)?;
+
+    // Copy to content-addressed store so the LoRA survives training run deletion
+    let install_id = record.id.clone();
+    let already_installed = db.is_installed(&install_id).unwrap_or(true);
+    if !already_installed {
+        let file_name = lora_path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("checkpoint.safetensors");
+
+        let sha256 = Store::hash_file(lora_path).unwrap_or_else(|_| "unknown".to_string());
+
+        let store = Store::new(modl_root.join("store"));
+        let store_path = store.path_for(&AssetType::Lora, &sha256, file_name);
+        store.ensure_dir(&store_path)?;
+        if !store_path.exists() {
+            std::fs::copy(lora_path, &store_path)?;
+        }
+        let store_path_str = store_path.to_string_lossy();
+
+        db.update_library_lora_path(&record.id, &store_path_str)?;
+
+        db.insert_installed(&crate::core::db::InstalledModelRecord {
+            id: &install_id,
+            name: &record.name,
+            asset_type: "lora",
+            variant: None,
+            sha256: &sha256,
+            size: size_bytes,
+            file_name,
+            store_path: &store_path_str,
+        })?;
+
+        let meta = serde_json::json!({
+            "base_model": record.base_model,
+            "trigger_word": record.trigger_word,
+            "lora_name": record.name,
+        });
+        db.insert_artifact(
+            &install_id,
+            None,
+            "lora",
+            &store_path_str,
+            &sha256,
+            size_bytes,
+            Some(&meta.to_string()),
+        )?;
+    }
+
+    Ok(id)
+}
+
+/// Slugify a name for use in IDs.
+fn slug(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' {
+                c.to_ascii_lowercase()
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/src/core/db/mod.rs
+++ b/src/core/db/mod.rs
@@ -28,6 +28,9 @@ impl Database {
             std::fs::create_dir_all(parent).context("Failed to create database directory")?;
         }
         let conn = Connection::open(&path).context("Failed to open database")?;
+        // WAL mode allows concurrent reads and reduces lock contention when
+        // multiple requests open short-lived connections (e.g., web UI routes).
+        let _ = conn.pragma_update(None, "journal_mode", "WAL");
         let db = Self { conn };
         db.migrate()?;
         Ok(db)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -19,6 +19,7 @@ pub mod job;
 pub mod llm;
 pub mod manifest;
 pub mod model_family;
+pub mod model_resolve;
 pub mod outputs;
 pub mod paths;
 pub mod preflight;

--- a/src/core/model_resolve.rs
+++ b/src/core/model_resolve.rs
@@ -1,0 +1,102 @@
+use anyhow::Result;
+use std::path::PathBuf;
+
+use super::db::Database;
+use super::job::LoraRef;
+use super::model_family;
+
+/// Resolve a base model path from installed models (match by ID, display name, or family alias).
+pub fn resolve_base_model_path(base_model: &str, db: &Database) -> Option<String> {
+    let installed = db.list_installed(None).ok()?;
+    let gen_types = ["checkpoint", "diffusion_model"];
+
+    // Exact match by ID or display name
+    for model in &installed {
+        if (model.name == base_model || model.id == base_model)
+            && gen_types.contains(&model.asset_type.as_str())
+        {
+            return Some(model.store_path.clone());
+        }
+    }
+
+    // Fuzzy match via model_family (e.g. "sdxl" → "sdxl-base-1.0")
+    if let Some(family_info) = model_family::resolve_model(base_model) {
+        let family_id = family_info.id;
+        for model in &installed {
+            if gen_types.contains(&model.asset_type.as_str())
+                && (model.id == family_id
+                    || model.id.contains(family_id)
+                    || family_id.contains(&*model.id))
+            {
+                return Some(model.store_path.clone());
+            }
+        }
+    }
+
+    None
+}
+
+/// Resolve a LoRA name to its store path by looking in the DB.
+///
+/// Accepts either a direct path to a `.safetensors` file or a name/ID lookup.
+pub fn resolve_lora(name: &str, weight: f32, db: &Database) -> Result<Option<LoraRef>> {
+    // Check if the name is a direct path to a .safetensors file
+    let path = PathBuf::from(name);
+    if path.exists() && path.extension().is_some_and(|e| e == "safetensors") {
+        return Ok(Some(LoraRef {
+            name: path
+                .file_stem()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string(),
+            path: path.to_string_lossy().to_string(),
+            weight,
+        }));
+    }
+
+    // Look up in installed models (match by ID or display name)
+    let installed = db.list_installed(None)?;
+    for model in &installed {
+        if (model.name == name || model.id == name) && model.asset_type == "lora" {
+            return Ok(Some(LoraRef {
+                name: model.name.clone(),
+                path: model.store_path.clone(),
+                weight,
+            }));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Size presets: aspect ratio → (width, height)
+pub const SIZE_PRESETS: &[(&str, u32, u32)] = &[
+    ("1:1", 1024, 1024),
+    ("16:9", 1344, 768),
+    ("9:16", 768, 1344),
+    ("4:3", 1152, 896),
+    ("3:4", 896, 1152),
+];
+
+/// Resolve a size preset string to (width, height).
+pub fn resolve_size(size: &str) -> Result<(u32, u32)> {
+    for &(name, w, h) in SIZE_PRESETS {
+        if size == name {
+            return Ok((w, h));
+        }
+    }
+
+    if let Some((w, h)) = size.split_once('x') {
+        let w: u32 = w
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid width in size"))?;
+        let h: u32 = h
+            .parse()
+            .map_err(|_| anyhow::anyhow!("Invalid height in size"))?;
+        return Ok((w, h));
+    }
+
+    anyhow::bail!(
+        "Unknown size: {size}. Use a preset (1:1, 16:9, 9:16, 4:3, 3:4) or WxH (e.g. 1024x1024)"
+    );
+}

--- a/src/ui/routes/datasets.rs
+++ b/src/ui/routes/datasets.rs
@@ -60,12 +60,12 @@ pub async fn api_list_datasets() -> impl IntoResponse {
         }
         Ok(Err(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error listing datasets: {e}"),
+            Json(serde_json::json!({ "error": format!("Error listing datasets: {e}") })),
         )
             .into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Task failed: {e}"),
+            Json(serde_json::json!({ "error": format!("Task failed: {e}") })),
         )
             .into_response(),
     }
@@ -116,12 +116,12 @@ pub async fn api_get_dataset(
         Ok(Ok(overview)) => Json(overview).into_response(),
         Ok(Err(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Error scanning dataset: {e}"),
+            Json(serde_json::json!({ "error": format!("Error scanning dataset: {e}") })),
         )
             .into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Task failed: {e}"),
+            Json(serde_json::json!({ "error": format!("Task failed: {e}") })),
         )
             .into_response(),
     }

--- a/src/ui/routes/generate.rs
+++ b/src/ui/routes/generate.rs
@@ -128,6 +128,75 @@ struct EnhanceApiResponse {
     backend: String,
 }
 
+impl GenerateRequest {
+    fn validate(&self) -> Result<(), String> {
+        if self.width == 0 || self.width > 4096 {
+            return Err(format!(
+                "width must be between 1 and 4096, got {}",
+                self.width
+            ));
+        }
+        if self.height == 0 || self.height > 4096 {
+            return Err(format!(
+                "height must be between 1 and 4096, got {}",
+                self.height
+            ));
+        }
+        if self.steps == 0 || self.steps > 200 {
+            return Err(format!(
+                "steps must be between 1 and 200, got {}",
+                self.steps
+            ));
+        }
+        if self.num_images == 0 || self.num_images > 100 {
+            return Err(format!(
+                "num_images must be between 1 and 100, got {}",
+                self.num_images
+            ));
+        }
+        if self.guidance < 0.0 || self.guidance > 100.0 {
+            return Err(format!(
+                "guidance must be between 0 and 100, got {}",
+                self.guidance
+            ));
+        }
+        if self.loras.len() > 10 {
+            return Err(format!(
+                "at most 10 LoRAs supported, got {}",
+                self.loras.len()
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl EditRequest {
+    fn validate(&self) -> Result<(), String> {
+        if self.steps == 0 || self.steps > 200 {
+            return Err(format!(
+                "steps must be between 1 and 200, got {}",
+                self.steps
+            ));
+        }
+        if self.num_images == 0 || self.num_images > 100 {
+            return Err(format!(
+                "num_images must be between 1 and 100, got {}",
+                self.num_images
+            ));
+        }
+        if self.guidance < 0.0 || self.guidance > 100.0 {
+            return Err(format!(
+                "guidance must be between 0 and 100, got {}",
+                self.guidance
+            ));
+        }
+        if self.images.is_empty() {
+            return Err("at least one image is required".to_string());
+        }
+        Ok(())
+    }
+}
+
 /// Run a single generation request, sending progress to the broadcast channel.
 async fn run_single_generate(sender: &broadcast::Sender<String>, req: GenerateRequest) {
     eprintln!(
@@ -310,6 +379,15 @@ pub async fn api_generate(
     State(state): State<UiState>,
     Json(req): Json<GenerateRequest>,
 ) -> impl IntoResponse {
+    // Validate request parameters
+    if let Err(msg) = req.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": msg })),
+        )
+            .into_response();
+    }
+
     // Preflight: validate model + runtime before accepting
     if let Err(err) = crate::core::preflight::for_generation(&req.model_id) {
         let msg = format!("{err:#}");
@@ -392,6 +470,15 @@ pub async fn api_edit(
     State(state): State<UiState>,
     Json(req): Json<EditRequest>,
 ) -> impl IntoResponse {
+    // Validate request parameters
+    if let Err(msg) = req.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": msg })),
+        )
+            .into_response();
+    }
+
     // Preflight: validate model
     if let Err(err) = crate::core::preflight::for_generation(&req.model_id) {
         let msg = format!("{err:#}");

--- a/src/ui/routes/studio.rs
+++ b/src/ui/routes/studio.rs
@@ -181,12 +181,12 @@ pub async fn api_studio_delete_session(Path(id): Path<String>) -> impl IntoRespo
         Ok(Ok(())) => Json(serde_json::json!({ "deleted": true })).into_response(),
         Ok(Err(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Failed to delete session: {e}"),
+            Json(serde_json::json!({ "error": format!("Failed to delete session: {e}") })),
         )
             .into_response(),
         Err(e) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Task failed: {e}"),
+            Json(serde_json::json!({ "error": format!("Task failed: {e}") })),
         )
             .into_response(),
     }
@@ -198,7 +198,11 @@ pub async fn api_studio_upload_images(
 ) -> impl IntoResponse {
     let inputs_dir = modl_root().join("studio").join(&id).join("inputs");
     if !inputs_dir.exists() {
-        return (StatusCode::NOT_FOUND, "Session not found").into_response();
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "Session not found" })),
+        )
+            .into_response();
     }
 
     let mut uploaded = Vec::new();
@@ -214,7 +218,7 @@ pub async fn api_studio_upload_images(
             Err(e) => {
                 return (
                     StatusCode::BAD_REQUEST,
-                    format!("Failed to read upload: {e}"),
+                    Json(serde_json::json!({ "error": format!("Failed to read upload: {e}") })),
                 )
                     .into_response();
             }
@@ -224,7 +228,7 @@ pub async fn api_studio_upload_images(
         if let Err(e) = tokio::fs::write(&dest, &data).await {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to save file: {e}"),
+                Json(serde_json::json!({ "error": format!("Failed to save file: {e}") })),
             )
                 .into_response();
         }
@@ -271,12 +275,16 @@ pub async fn api_studio_start_session(
     {
         Ok(Ok(data)) => data,
         Ok(Err(e)) => {
-            return (StatusCode::NOT_FOUND, format!("{e}")).into_response();
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": format!("{e}") })),
+            )
+                .into_response();
         }
         Err(e) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Task failed: {e}"),
+                Json(serde_json::json!({ "error": format!("Task failed: {e}") })),
             )
                 .into_response();
         }
@@ -310,7 +318,7 @@ pub async fn api_studio_start_session(
         Err(e) => {
             return (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to resolve LLM backend: {e}"),
+                Json(serde_json::json!({ "error": format!("Failed to resolve LLM backend: {e}") })),
             )
                 .into_response();
         }

--- a/src/ui/routes/training.rs
+++ b/src/ui/routes/training.rs
@@ -1,8 +1,8 @@
 use axum::{Json, extract::Path, http::StatusCode, response::IntoResponse};
 use serde::{Deserialize, Serialize};
 
-use crate::core::db::{Database, LibraryLoraRecord};
-use crate::core::training::{self, parse_step_from_filename};
+use crate::core::db::Database;
+use crate::core::training;
 use crate::core::training_status;
 
 use crate::core::paths::modl_root;
@@ -472,7 +472,42 @@ pub struct StartTrainingRequest {
     class_word: Option<String>,
 }
 
+impl StartTrainingRequest {
+    fn validate(&self) -> Result<(), String> {
+        if let Some(steps) = self.steps
+            && (steps == 0 || steps > 100_000)
+        {
+            return Err(format!("steps must be between 1 and 100000, got {steps}"));
+        }
+        if let Some(rank) = self.rank
+            && (rank == 0 || rank > 256)
+        {
+            return Err(format!("rank must be between 1 and 256, got {rank}"));
+        }
+        if let Some(lr) = self.lr
+            && (lr <= 0.0 || lr > 1.0)
+        {
+            return Err(format!("lr must be between 0 and 1, got {lr}"));
+        }
+        if self.name.is_empty() {
+            return Err("name is required".to_string());
+        }
+        if self.dataset.is_empty() {
+            return Err("dataset is required".to_string());
+        }
+        Ok(())
+    }
+}
+
 pub async fn api_start_training(Json(req): Json<StartTrainingRequest>) -> impl IntoResponse {
+    if let Err(msg) = req.validate() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": msg })),
+        )
+            .into_response();
+    }
+
     let modl_bin = std::env::current_exe().unwrap_or_else(|_| "modl".into());
 
     let result = tokio::task::spawn_blocking(move || {
@@ -715,176 +750,33 @@ pub struct PromoteLoraRequest {
 
 /// POST /api/library/loras — promote a LoRA to the library
 pub async fn api_promote_lora(Json(req): Json<PromoteLoraRequest>) -> impl IntoResponse {
+    use crate::core::artifacts::{PromoteLoraParams, promote_lora};
+
     let result = tokio::task::spawn_blocking(move || {
-        let lora_path_str = req.lora_path.clone();
-        let lora_path = std::path::Path::new(&lora_path_str);
-
-        // Validate that lora_path is under the modl training_output directory
-        // to prevent path traversal attacks.
-        let allowed_dir = modl_root().join("training_output");
-        let canonical_lora = lora_path
-            .canonicalize()
-            .map_err(|e| anyhow::anyhow!("Invalid lora_path: {e}"))?;
-        let canonical_allowed = allowed_dir.canonicalize().unwrap_or(allowed_dir.clone());
-        if !canonical_lora.starts_with(&canonical_allowed) {
-            anyhow::bail!(
-                "lora_path must be under {}, got {}",
-                canonical_allowed.display(),
-                canonical_lora.display()
-            );
-        }
-
-        let size_bytes = lora_path.metadata().map(|m| m.len()).unwrap_or(0);
-
-        // Auto-resolve thumbnail from training samples when not provided
-        let thumbnail = req.thumbnail.or_else(|| {
-            let run_name = req.training_run.as_deref()?;
-            let samples_dir = modl_root()
-                .join("training_output")
-                .join(run_name)
-                .join(run_name)
-                .join("samples");
-            if !samples_dir.exists() {
-                return None;
-            }
-            // Find the sample image with the highest step number
-            let mut best: Option<(u64, String)> = None;
-            if let Ok(entries) = std::fs::read_dir(&samples_dir) {
-                for entry in entries.flatten() {
-                    let fname = entry.file_name().to_string_lossy().to_string();
-                    if let Some(step) = parse_step_from_filename(&fname)
-                        && best.as_ref().is_none_or(|(s, _)| step > *s)
-                    {
-                        let rel = format!("training_output/{run_name}/{run_name}/samples/{fname}");
-                        best = Some((step, rel));
-                    }
-                }
-            }
-            best.map(|(_, path)| path)
-        });
-
-        let id = format!(
-            "lib:{}:{}",
-            slug(&req.name),
-            &uuid::Uuid::new_v4().to_string()[..8]
-        );
-
-        // Fetch job spec for reproducibility metadata (dataset, LR, rank, etc.)
-        let job_spec = req.training_run.as_deref().and_then(|run_name| {
-            let db = Database::open().ok()?;
-            let jobs = db.find_jobs_by_lora_name(run_name).ok()?;
-            let spec: serde_json::Value = serde_json::from_str(&jobs.first()?.spec_json).ok()?;
-            Some(spec)
-        });
-
-        // Merge ai-toolkit config + job spec into one JSON blob for
-        // full reproducibility.  The job spec has dataset ref, LR,
-        // rank, lora_type, preset — everything needed to re-run.
-        let merged_config = {
-            let mut obj = serde_json::Map::new();
-            if let Some(ref cfg) = req.config_json
-                && let Ok(v) = serde_json::from_str::<serde_json::Value>(cfg)
-            {
-                obj.insert("toolkit_config".into(), v);
-            }
-            if let Some(ref spec) = job_spec {
-                obj.insert("job_spec".into(), spec.clone());
-            }
-            if obj.is_empty() {
-                None
-            } else {
-                Some(serde_json::Value::Object(obj).to_string())
-            }
-        };
-
-        let auto_tag = job_spec.as_ref().and_then(|spec| {
-            spec.pointer("/params/lora_type")
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string())
-        });
-
-        let record = LibraryLoraRecord {
-            id: id.clone(),
+        promote_lora(PromoteLoraParams {
             name: req.name,
             trigger_word: req.trigger_word,
             base_model: req.base_model,
             lora_path: req.lora_path,
-            thumbnail,
+            thumbnail: req.thumbnail,
             step: req.step,
-            training_run: req.training_run.clone(),
-            config_json: merged_config,
-            tags: req.tags.or(auto_tag),
-            notes: None,
-            size_bytes,
-            created_at: String::new(), // DB default
-        };
-
-        let db = Database::open()?;
-        db.insert_library_lora(&record)?;
-
-        // Copy to content-addressed store so the LoRA survives training
-        // run deletion, then register in installed + artifacts so it
-        // appears in the generate LoRA picker.
-        let install_id = record.id.clone(); // "lib:name:hash"
-        let already_installed = db.is_installed(&install_id).unwrap_or(true);
-        if !already_installed {
-            let file_name = lora_path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("checkpoint.safetensors");
-
-            let sha256 = crate::core::store::Store::hash_file(lora_path)
-                .unwrap_or_else(|_| "unknown".to_string());
-
-            // Copy into content-addressed store (~/.modl/store/lora/<sha>/<file>)
-            let store = crate::core::store::Store::new(modl_root().join("store"));
-            let store_path =
-                store.path_for(&crate::core::manifest::AssetType::Lora, &sha256, file_name);
-            store.ensure_dir(&store_path)?;
-            if !store_path.exists() {
-                std::fs::copy(lora_path, &store_path)?;
-            }
-            let store_path_str = store_path.to_string_lossy();
-
-            // Update library record to point to store path (not training dir)
-            db.update_library_lora_path(&record.id, &store_path_str)?;
-
-            db.insert_installed(&crate::core::db::InstalledModelRecord {
-                id: &install_id,
-                name: &record.name,
-                asset_type: "lora",
-                variant: None,
-                sha256: &sha256,
-                size: size_bytes,
-                file_name,
-                store_path: &store_path_str,
-            })?;
-
-            let meta = serde_json::json!({
-                "base_model": record.base_model,
-                "trigger_word": record.trigger_word,
-                "lora_name": record.name,
-            });
-            db.insert_artifact(
-                &install_id,
-                None,
-                "lora",
-                &store_path_str,
-                &sha256,
-                size_bytes,
-                Some(&meta.to_string()),
-            )?;
-        }
-
-        Ok::<_, anyhow::Error>(id)
+            training_run: req.training_run,
+            config_json: req.config_json,
+            tags: req.tags,
+        })
     })
     .await;
 
     match result {
         Ok(Ok(id)) => (StatusCode::CREATED, Json(serde_json::json!({ "id": id }))).into_response(),
-        _ => (
+        Ok(Err(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(serde_json::json!({ "error": "Failed to promote LoRA" })),
+            Json(serde_json::json!({ "error": format!("Failed to promote LoRA: {e}") })),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({ "error": format!("Task failed: {e}") })),
         )
             .into_response(),
     }
@@ -939,18 +831,4 @@ pub async fn api_delete_library_lora(Path(id): Path<String>) -> impl IntoRespons
         )
             .into_response(),
     }
-}
-
-fn slug(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c == '-' {
-                c.to_ascii_lowercase()
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>()
-        .trim_matches('-')
-        .to_string()
 }


### PR DESCRIPTION
## Summary

Addresses 5 items from a code quality review:

- **Request validation** — add bounds checking on generate (width/height/steps/num_images/guidance/loras), edit, and training API endpoints; return 400 with structured JSON errors
- **JSON error responses** — standardize all route error responses to `{"error": "..."}` JSON format instead of plain text strings (datasets, studio, training routes)
- **Extract model/LoRA resolution** — new `core/model_resolve.rs` with `resolve_base_model_path`, `resolve_lora`, `resolve_size`; CLI generate.rs and edit.rs now delegate instead of duplicating
- **SQLite WAL mode** — enable WAL journal mode on `Database::open()` to reduce lock contention for concurrent web UI requests
- **Extract promote_lora service** — move 175-line route handler business logic to `core/artifacts::promote_lora()`, route handler is now a thin delegate

## Test plan

- [x] `cargo check` — clean build, no warnings
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)