### PR TITLE
feat: add Klein 9B-KV model support + reference image limit warning

### DIFF
--- a/python/modl_worker/adapters/arch_config.py
+++ b/python/modl_worker/adapters/arch_config.py
@@ -274,6 +274,41 @@ ARCH_CONFIGS: dict[str, dict] = {
         "default_resolution": 1024,
         "sample": {"sampler": "flowmatch", "steps": 4, "guidance": 1.0, "neg": ""},
     },
+    "flux2_klein_9b_kv": {
+        "pipeline_class": "Flux2KleinKVPipeline",
+        "gen_components": {
+            "transformer": {
+                "model_class": "Flux2Transformer2DModel",
+                "config_dir": "flux2-klein-9b-transformer",
+            },
+            "text_encoder": {
+                "model_id": "flux2-qwen3-8b-text-encoder",
+                "model_class": "Qwen3ForCausalLM",
+                "config_dir": "qwen3-8b",
+            },
+            "tokenizer": {
+                "model_class": "AutoTokenizer",
+                "config_dir": "qwen3-tokenizer",
+            },
+            "vae": {
+                "model_id": "flux2-vae",
+                "model_class": "AutoencoderKLFlux2",
+                "config_dir": "flux2-vae",
+            },
+            "scheduler": {
+                "model_class": "FlowMatchEulerDiscreteScheduler",
+                "config_dir": "flux2-klein-scheduler",
+            },
+        },
+        "pipeline_kwargs": {"is_distilled": True},
+        "model_flags": {"arch": "flux2_klein_9b"},
+        "noise_scheduler": "flowmatch",
+        "dtype": "bf16",
+        "train_text_encoder": False,
+        "resolutions": [512, 768, 1024],
+        "default_resolution": 1024,
+        "sample": {"sampler": "flowmatch", "steps": 4, "guidance": 1.0, "neg": ""},
+    },
     "flux2_klein_base_9b": {
         "pipeline_class": "Flux2KleinPipeline",
         "gen_components": {
@@ -641,6 +676,7 @@ MODEL_REGISTRY: dict[str, tuple[str, str]] = {
     "flux2-dev":      ("flux2",         "black-forest-labs/FLUX.2-dev"),
     "flux2-klein-4b": ("flux2_klein",   "black-forest-labs/FLUX.2-klein-4b-fp8"),
     "flux2-klein-9b": ("flux2_klein_9b", "black-forest-labs/FLUX.2-klein-9b-fp8"),
+    "flux2-klein-9b-kv": ("flux2_klein_9b_kv", "black-forest-labs/FLUX.2-klein-9b-kv-fp8"),
     "flux2-klein-base-4b": ("flux2_klein_base", "black-forest-labs/FLUX.2-klein-base-4B"),
     "flux2-klein-base-9b": ("flux2_klein_base_9b", "black-forest-labs/FLUX.2-klein-base-9B"),
     "flux-dev":       ("flux",          "black-forest-labs/FLUX.1-dev"),
@@ -694,6 +730,9 @@ def detect_arch(base_model_id: str) -> str:
     if "klein" in bid and ("flux2" in bid or "flux.2" in bid or "flux-2" in bid):
         is_base = "base" in bid
         is_9b = "9b" in bid
+        is_kv = "kv" in bid
+        if is_kv and is_9b:
+            return "flux2_klein_9b_kv"
         if is_base and is_9b:
             return "flux2_klein_base_9b"
         if is_9b:

--- a/python/modl_worker/adapters/edit_adapter.py
+++ b/python/modl_worker/adapters/edit_adapter.py
@@ -109,7 +109,7 @@ def run_edit_with_pipeline(spec: dict, emitter: EventEmitter, pipeline: object) 
     from .arch_config import detect_arch
     arch = detect_arch(base_model_id)
 
-    if arch in ("flux2_klein", "flux2_klein_9b"):
+    if arch in ("flux2_klein", "flux2_klein_9b", "flux2_klein_9b_kv"):
         # Klein: native image editing via the `image` parameter.
         # Supports multiple input images (e.g. source + reference).
         # No guidance (distilled), no negative prompt.

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -222,6 +222,17 @@ pub async fn run(args: EditArgs<'_>) -> Result<()> {
         resolved_paths.push(path);
     }
 
+    // Warn if image count exceeds model's recommended max
+    if let Some(max_images) = model_family::max_edit_images(&base_model)
+        && resolved_paths.len() > max_images as usize
+    {
+        eprintln!(
+            "  {} {base_model} officially supports up to {max_images} reference images. \
+             Extra images may be ignored by the model.",
+            console::style("⚠").yellow(),
+        );
+    }
+
     // -------------------------------------------------------------------
     // Build output directory
     // -------------------------------------------------------------------

--- a/src/core/model_family.rs
+++ b/src/core/model_family.rs
@@ -59,6 +59,10 @@ pub struct ModelInfo {
 
     // -- Description --
     pub description: &'static str,
+
+    // -- Limits --
+    /// Maximum recommended number of reference images for edit mode (None = no limit).
+    pub max_edit_images: Option<u8>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize)]
@@ -113,6 +117,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 2,
                 text_rendering: false,
                 description: "High quality, strong prompt following, 28 steps",
+                max_edit_images: None,
             },
             ModelInfo {
                 id: "flux-schnell",
@@ -140,6 +145,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 5,
                 text_rendering: false,
                 description: "Distilled, 4 steps, fast iteration",
+                max_edit_images: None,
             },
             ModelInfo {
                 id: "chroma",
@@ -167,6 +173,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 2,
                 text_rendering: false,
                 description: "Apache 2.0 Flux fork, 8.9B, negative prompts, uncensored",
+                max_edit_images: None,
             },
         ],
     },
@@ -205,6 +212,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 2,
                 text_rendering: false,
                 description: "Dedicated inpainting model, 384-ch input, no boundary artifacts",
+                max_edit_images: None,
             },
             ModelInfo {
                 id: "flux-fill-dev-onereward",
@@ -232,6 +240,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 2,
                 text_rendering: false,
                 description: "RLHF-tuned Fill, outperforms Flux Fill Pro, best inpainting",
+                max_edit_images: None,
             },
         ],
     },
@@ -270,6 +279,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 1,
                 text_rendering: false,
                 description: "Best quality, 46B total params, needs 80GB+ GPU",
+                max_edit_images: None,
             },
             ModelInfo {
                 id: "flux2-klein-4b",
@@ -297,6 +307,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 5,
                 text_rendering: false,
                 description: "4B distilled, fits on consumer GPUs, 4 steps",
+                max_edit_images: Some(4),
             },
             ModelInfo {
                 id: "flux2-klein-9b",
@@ -324,6 +335,35 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 4,
                 text_rendering: false,
                 description: "9B distilled, good quality/size balance, 4 steps",
+                max_edit_images: Some(4),
+            },
+            ModelInfo {
+                id: "flux2-klein-9b-kv",
+                name: "Flux 2 Klein 9B KV",
+                arch_key: "flux2_klein_9b_kv",
+                transformer_b: 9.0,
+                text_encoder_name: "Qwen3 8B",
+                text_encoder_b: 9.0,
+                total_b: 18.0,
+                vram_bf16_gb: 24,
+                vram_fp8_gb: 16,
+                capabilities: Capabilities {
+                    txt2img: true,
+                    img2img: false,
+                    inpaint: false,
+                    edit: true,
+                    lora: true,
+                    training: true,
+                    lanpaint_inpaint: true,
+                },
+                default_steps: 4,
+                default_guidance: 1.0,
+                default_resolution: 1024,
+                quality: 4,
+                speed: 4,
+                text_rendering: false,
+                description: "9B with KV cache, faster multi-reference editing, 4 steps",
+                max_edit_images: Some(4),
             },
         ],
     },
@@ -362,6 +402,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 2,
                 text_rendering: false,
                 description: "Strong aesthetics, 6B transformer, 20 steps",
+                max_edit_images: None,
             },
             ModelInfo {
                 id: "z-image-turbo",
@@ -389,6 +430,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 4,
                 text_rendering: false,
                 description: "Distilled Z-Image, 8 steps, good speed/quality",
+                max_edit_images: None,
             },
         ],
     },
@@ -427,6 +469,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 2,
                 text_rendering: true,
                 description: "Best text rendering, Chinese/English, 20B transformer",
+                max_edit_images: None,
             },
             ModelInfo {
                 id: "qwen-image-edit",
@@ -454,6 +497,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 1,
                 text_rendering: true,
                 description: "Instruction-based editing, text editing, style transfer",
+                max_edit_images: None,
             },
         ],
     },
@@ -492,6 +536,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 2,
                 text_rendering: false,
                 description: "Mature ecosystem, huge LoRA library, needs negative prompts",
+                max_edit_images: None,
             },
             ModelInfo {
                 id: "sd-1.5",
@@ -519,6 +564,7 @@ pub static FAMILIES: &[ModelFamily] = &[
                 speed: 4,
                 text_rendering: false,
                 description: "Lightweight, runs on any GPU, dated quality",
+                max_edit_images: None,
             },
         ],
     },
@@ -653,6 +699,9 @@ pub fn resolve_model(model_id: &str) -> Option<&'static ModelInfo> {
     if lower.contains("z-image") || lower.contains("z_image") || lower.contains("zimage") {
         return find_model("z-image");
     }
+    if lower.contains("klein") && lower.contains("9b") && lower.contains("kv") {
+        return find_model("flux2-klein-9b-kv");
+    }
     if lower.contains("klein") && lower.contains("9b") {
         return find_model("flux2-klein-9b");
     }
@@ -685,6 +734,11 @@ pub fn resolve_model(model_id: &str) -> Option<&'static ModelInfo> {
     }
 
     None
+}
+
+/// Get the maximum recommended edit images for a model (None = no limit).
+pub fn max_edit_images(model_id: &str) -> Option<u8> {
+    resolve_model(model_id).and_then(|m| m.max_edit_images)
 }
 
 /// Get default steps and guidance for a model.


### PR DESCRIPTION
## Summary
- Add `flux2-klein-9b-kv` model variant across Rust model_family, Python arch_config, and edit_adapter — uses `Flux2KleinKVPipeline` for faster multi-reference editing with KV cache
- Add `max_edit_images` field to `ModelInfo` struct (set to 4 for all Klein variants) and a CLI warning in `modl edit` when users exceed the recommended reference image count
- Update fuzzy model resolution in both Rust and Python to correctly detect the KV variant before the plain 9B match

## Test plan
- [ ] `cargo check` passes (verified)
- [ ] `cargo clippy` passes (verified)
- [ ] Verify `resolve_model("flux2-klein-9b-kv")` returns the KV model
- [ ] Verify `resolve_model("flux2-klein-9b")` still returns the plain 9B (not KV)
- [ ] Verify `modl edit --image a.png --image b.png --image c.png --image d.png --image e.png --base flux2-klein-9b-kv` shows the max images warning
- [ ] Verify Python `detect_arch("flux2-klein-9b-kv")` returns `"flux2_klein_9b_kv"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)