### PR TITLE
fix: Qwen-Image-Edit-2511 pipeline support

### DIFF
--- a/python/modl_worker/adapters/edit_adapter.py
+++ b/python/modl_worker/adapters/edit_adapter.py
@@ -85,18 +85,27 @@ def run_edit_with_pipeline(spec: dict, emitter: EventEmitter, pipeline: object) 
         _apply_scheduler_overrides(pipeline, sched_overrides, emitter)
         lightning_sigmas = _compute_lightning_sigmas(steps)
 
-    # Qwen-Image-Edit-2511: always apply shift=3.1 and simple scheduler
-    # (matching ComfyUI's ModelSamplingAuraFlow node). Without this, the
-    # default dynamic shifting produces wrong sigma values and degraded quality.
+    # Qwen-Image-Edit-2511: override scheduler to use fixed shift=3.1
+    # (matching ComfyUI's ModelSamplingAuraFlow node).
+    #
+    # The diffusers QwenImageEditPlusPipeline computes mu = calculate_shift(
+    #   seq_len, base_shift, max_shift) which feeds into the scheduler's
+    # exponential time_shift: shift = exp(mu). By setting base_shift = max_shift
+    # = log(3.1), we get a constant mu → constant shift=3.1 regardless of
+    # image sequence length.
     if arch == "qwen_image_edit_2511" and hasattr(pipeline, "scheduler"):
+        import math
+        shift_val = 3.1
+        log_shift = math.log(shift_val)
         sched = pipeline.scheduler
         config = dict(sched.config)
-        config["use_dynamic_shifting"] = False
-        config["shift"] = 3.1
-        config.pop("shift_terminal", None)
+        config["use_dynamic_shifting"] = True
+        config["base_shift"] = log_shift
+        config["max_shift"] = log_shift
+        config["time_shift_type"] = "exponential"
         sched_class = type(sched)
         pipeline.scheduler = sched_class.from_config(config)
-        emitter.info("Qwen 2511: applied shift=3.1 (matching ComfyUI ModelSamplingAuraFlow)")
+        emitter.info(f"Qwen 2511: scheduler shift={shift_val} (base_shift=max_shift=log({shift_val})={log_shift:.4f})")
 
     image_paths = params.get("image_paths", [])
 
@@ -159,6 +168,7 @@ def run_edit_with_pipeline(spec: dict, emitter: EventEmitter, pipeline: object) 
     # Lightning mode: use ComfyUI-style simple linear sigmas.
     if lightning_sigmas is not None:
         gen_kwargs["sigmas"] = lightning_sigmas
+
 
     artifact_paths = []
 

--- a/python/modl_worker/adapters/edit_adapter.py
+++ b/python/modl_worker/adapters/edit_adapter.py
@@ -73,6 +73,10 @@ def run_edit_with_pipeline(spec: dict, emitter: EventEmitter, pipeline: object) 
     seed = params.get("seed")
     count = params.get("count", 1)
 
+    # Detect architecture early — needed for scheduler and kwarg decisions
+    from .arch_config import detect_arch
+    arch = detect_arch(base_model_id)
+
     # Apply scheduler overrides (Lightning mode)
     sched_overrides = params.get("scheduler_overrides")
     lightning_sigmas = None
@@ -80,6 +84,20 @@ def run_edit_with_pipeline(spec: dict, emitter: EventEmitter, pipeline: object) 
         from .gen_adapter import _apply_scheduler_overrides, _compute_lightning_sigmas
         _apply_scheduler_overrides(pipeline, sched_overrides, emitter)
         lightning_sigmas = _compute_lightning_sigmas(steps)
+
+    # Qwen-Image-Edit-2511: always apply shift=3.1 and simple scheduler
+    # (matching ComfyUI's ModelSamplingAuraFlow node). Without this, the
+    # default dynamic shifting produces wrong sigma values and degraded quality.
+    if arch == "qwen_image_edit_2511" and hasattr(pipeline, "scheduler"):
+        sched = pipeline.scheduler
+        config = dict(sched.config)
+        config["use_dynamic_shifting"] = False
+        config["shift"] = 3.1
+        config.pop("shift_terminal", None)
+        sched_class = type(sched)
+        pipeline.scheduler = sched_class.from_config(config)
+        emitter.info("Qwen 2511: applied shift=3.1 (matching ComfyUI ModelSamplingAuraFlow)")
+
     image_paths = params.get("image_paths", [])
 
     if not image_paths:
@@ -106,9 +124,6 @@ def run_edit_with_pipeline(spec: dict, emitter: EventEmitter, pipeline: object) 
         generator.manual_seed(seed)
 
     # Build inference kwargs — different pipelines need different params
-    from .arch_config import detect_arch
-    arch = detect_arch(base_model_id)
-
     if arch in ("flux2_klein", "flux2_klein_9b"):
         # Klein: native image editing via the `image` parameter.
         # Supports multiple input images (e.g. source + reference).


### PR DESCRIPTION
## Summary
- Add `qwen_image_edit_2511` arch config with `QwenImageEditPlusPipeline` (2511 uses a different pipeline class than the original — without this, edits are silently no-ops)
- `detect_arch` routes "2511" model IDs correctly
- Apply `shift=3.1` scheduler override (matching ComfyUI `ModelSamplingAuraFlow`)
- Add `guidance_scale=1.0` to Qwen edit kwargs (per upstream docs)

## Still TODO for full ComfyUI parity
- [ ] `CFGNorm` — normalize CFG output per step (prevents color drift)
- [ ] `FluxKontextMultiReferenceLatentMethod` — reference latent injection at timestep 0 only (critical for identity preservation)
- [ ] `FluxKontextImageScale` — auto-scale input to model resolution

## Test plan
- [x] `modl edit "change hoodie to red leather jacket" --base local/checkpoint/qwen-image-edit-2511-Q5_K_M.gguf` — produces output (was no-op before)
- [ ] Compare with ComfyUI workflow results after remaining fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)