### PR TITLE
feat: modl run — batch workflow execution from YAML

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,0 +1,366 @@
+# Workflows — `modl run`
+
+Batch image generation from a single YAML file. Declare a list of generate/edit
+steps, hit run, walk away, come back to finished artifacts. Think "Makefile for
+image generation."
+
+> **Note for maintainers:** This guide is written to be extractable for the
+> public modl-site marketing docs after the feature is polished and shipped.
+> The "Why workflows", "Quickstart", and "Real example" sections are designed
+> to drop cleanly into an MDX page. Keep them self-contained and narrative.
+
+---
+
+## Why workflows
+
+If you're generating one image at a time, `modl generate "a cat"` is the right
+tool. If you're producing a **collection** — a book chapter, a product sheet,
+a mood board, a series of variations you'll pick winners from — you quickly hit
+the "I'm retyping the same flags with different prompts" problem.
+
+A workflow is a YAML file that declares the whole batch up front:
+
+- **Model + LoRA once, used by every step.** No retyping.
+- **Seed exploration.** Generate N variations of a prompt with explicit seeds so
+  you can pick the winner later and reproduce it.
+- **Cross-step references.** Step 3 can edit the output of step 1 without
+  juggling file paths.
+- **Shared defaults** (size, steps, guidance) with per-step overrides.
+- **One run, one batch.** Kick it off, walk away. Everything lands in
+  `~/.modl/outputs/<date>/` and shows up in `modl serve` alongside your regular
+  generations.
+
+It's the same batch pipeline you'd script yourself, but declarative, portable
+across local and cloud (cloud path coming soon), and reproducible by seed.
+
+## Quickstart
+
+Create a file `hello-workflow.yaml`:
+
+```yaml
+name: hello
+model: sdxl
+
+defaults:
+  width: 1024
+  height: 1024
+  steps: 28
+  guidance: 7.0
+
+steps:
+  - id: cat
+    generate: "a tiny cat reading a book"
+    seed: 42
+
+  - id: dog
+    generate: "a tiny dog catching a frisbee"
+    seed: 99
+```
+
+Then:
+
+```bash
+modl run hello-workflow.yaml
+```
+
+You'll see each step execute in order with live progress, and the two PNGs
+will land in `~/.modl/outputs/<today>/` where `modl serve` can see them.
+
+## The spec, field by field
+
+### Top-level
+
+```yaml
+name: <string>           # required — used for display and DB labels
+model: <model-id>        # required — e.g. "flux2-klein-4b", "sdxl", "qwen-image"
+lora: <lora-id>          # optional — applied to every step
+defaults:                # optional — inherited by every step unless overridden
+  seed: <int>
+  width: <int>
+  height: <int>
+  steps: <int>
+  guidance: <float>
+  count: <int>
+steps:                   # required — ordered list, one or more
+  - ...
+```
+
+### Steps
+
+Every step has a unique `id` and is either a **generate** or an **edit** step
+(exactly one — never both). Edit steps also require a `prompt:` field.
+
+**Generate step:**
+
+```yaml
+- id: scene-1                          # required — must be unique within the workflow
+  generate: "a misty forest at dawn"   # required — the prompt
+  seed: 42                             # optional — overrides defaults.seed
+  seeds: [42, 7, 99, 333]              # optional — mutually exclusive with seed+count
+  width: 1024                          # optional — overrides defaults.width
+  height: 1024                         # optional — overrides defaults.height
+  steps: 4                             # optional — overrides defaults.steps
+  guidance: 1.0                        # optional — overrides defaults.guidance
+  count: 2                             # optional — overrides defaults.count
+```
+
+**Edit step:**
+
+```yaml
+- id: rain-variant
+  edit: "./draft.png"                  # required — local path OR $step-id.outputs[N]
+  prompt: "add heavy rain"             # required — the edit instruction
+  seed: 42                             # same optional fields as generate
+  seeds: [1, 2, 3]                     # ...including seeds
+```
+
+### Defaults and overrides
+
+Anything declared in `defaults:` becomes the step value when the step doesn't
+set it. Any field set on the step wins over the default.
+
+```yaml
+defaults:
+  seed: 42
+  steps: 28
+steps:
+  - id: a
+    generate: "foo"                    # uses defaults: seed=42, steps=28
+  - id: b
+    generate: "bar"
+    seed: 999                          # overrides: seed=999, steps=28 (from defaults)
+```
+
+If neither defaults nor the step sets `steps`/`guidance`/`width`/`height`,
+modl falls back to the model's sensible defaults from `models.toml` (e.g.
+Klein 4B → 4 steps, guidance 1.0, 1024×1024).
+
+### Seeds: exploration vs noise variation
+
+Two different use cases, two different fields:
+
+**`seeds: [42, 7, 99, 333]`** — explicit variation exploration. Runs one
+generation per seed. Every output is reproducible by its seed number. This is
+what you want when making a book chapter and you'll pick winners later.
+
+**`seed: 42` + `count: 4`** — four images at the same seed. The worker varies
+internal noise per image, so you get a small spread without changing the base
+seed. Useful when you have a prompt you trust and just want a few options.
+
+Setting **both** `seed` and `seeds` is a parse error — pick one. Setting
+`seeds` with `count` is also a parse error, since `seeds.len()` is the count.
+
+### Cross-step references: `$step-id.outputs[N]`
+
+Edit steps can consume earlier step outputs without knowing the file path:
+
+```yaml
+steps:
+  - id: forest
+    generate: "a misty cabin in a forest"
+    seeds: [42, 7, 99]           # produces 3 outputs
+
+  - id: rain-variant
+    edit: "$forest.outputs[0]"   # refers to the first forest output (seed=42)
+    prompt: "add heavy rain"
+
+  - id: lightning-variant
+    edit: "$forest.outputs[2]"   # refers to the third forest output (seed=99)
+    prompt: "add lightning in the background"
+```
+
+**Rules:**
+
+- References must point to **earlier** steps (no forward references, no self-references).
+- The `[N]` index is resolved at runtime. `[0]` is always the first output
+  from the referenced step; if `seeds: [...]` was used, the index follows the
+  seed order you declared.
+- If `[N]` is out of bounds (e.g. the referenced step produced fewer outputs
+  than expected), you get a clean runtime error — the workflow fails at that
+  step, nothing downstream runs.
+- Bounds can't be checked at parse time because `count` / `seeds.len()`
+  determines cardinality at execution time.
+
+## Where outputs go
+
+Every artifact lands in `~/.modl/outputs/<YYYY-MM-DD>/`, flat. No per-workflow
+subdirectory. **This is deliberate.**
+
+- `modl serve` already scans the date directory — your workflow outputs appear
+  in the Outputs tab alongside anything you generated manually with
+  `modl generate`.
+- Each step becomes a row in the local jobs database with labels
+  `workflow=<name>`, `workflow_run=<timestamp-name>`, `workflow_step=<id>`.
+- `modl serve` gets full spec + prompt + seed for every image, same as regular
+  generations.
+
+If you need to find just one workflow's outputs, query the DB directly:
+
+```bash
+sqlite3 ~/.modl/state.db \
+  "SELECT spec_json FROM jobs WHERE json_extract(spec_json, '\$.labels.workflow') = 'book-chapter-3'"
+```
+
+A dedicated "workflow runs" view in `modl serve` is on the roadmap — the data
+is already there, just needs a UI.
+
+## LoRA support
+
+Declare a LoRA at the top level and it applies to every step:
+
+```yaml
+name: character-sheet
+model: qwen-image
+lora: qwen-image-2512-lightning
+
+defaults:
+  steps: 8
+  guidance: 1.0
+
+steps:
+  - id: front
+    generate: "character portrait, front view, white background"
+  - id: side
+    generate: "character portrait, side profile, white background"
+  - id: back
+    generate: "character portrait, back view, white background"
+```
+
+The LoRA is resolved **once** at the start of the run. If it's not installed
+locally, the workflow fails immediately before any compute happens — you fix
+the problem and re-run, no wasted GPU time.
+
+Per-step LoRA override (different LoRAs for different steps) is not currently
+supported. If you need it, open an issue with the use case.
+
+## Real example: KDP book chapter
+
+This is the actual use case the feature was built for — generating scenes for
+a print-on-demand children's book where you want seed variations so you can
+pick the winner for each spread.
+
+```yaml
+# book-chapter-3.yaml
+name: book-chapter-3-treehouse
+model: flux2-klein-4b
+lora: my-son-v2               # trained character LoRA
+
+defaults:
+  width: 1024
+  height: 1024
+  steps: 4
+  guidance: 1.0
+
+steps:
+  # Page 1: hero climbs the treehouse ladder
+  - id: climb
+    generate: "OHWX climbing a wooden ladder to a treehouse, morning light, children's book illustration style"
+    seeds: [10, 20, 30, 40]     # 4 variations, pick winner later
+
+  # Page 2: interior reveal
+  - id: interior
+    generate: "inside a cozy wooden treehouse, OHWX peeking through a window, warm afternoon light, children's book illustration style"
+    seeds: [11, 21, 31, 41]
+
+  # Page 3: sunset from the treehouse window
+  - id: sunset
+    generate: "view from a treehouse window at sunset, golden hour, wistful mood, children's book illustration style"
+    seeds: [12, 22, 32, 42]
+
+  # Rainy-day variation of page 1 (references the first winner)
+  - id: climb-rainy
+    edit: "$climb.outputs[0]"
+    prompt: "add gentle rain and wet leaves, still children's book illustration style"
+    seed: 10
+```
+
+Run it:
+
+```bash
+modl run book-chapter-3.yaml
+```
+
+Output: 13 artifacts (4+4+4+1) in `~/.modl/outputs/<today>/`. Open
+`modl serve`, flip to the Outputs tab, pick your winner per scene. If you want
+to re-run a single scene with a new seed, you know the prompts and seeds —
+they're in the spec file.
+
+The edit step (`climb-rainy`) uses `$climb.outputs[0]` to reference the
+*first* variation of `climb` (seed=10). If you later decide seed=20 was the
+winner, change the index to `[1]` and re-run — no path juggling.
+
+## Troubleshooting
+
+### "LoRA `my-son-v2` not found in local store"
+
+The LoRA isn't pulled. Train it (`modl train ...`) or pull it if it's on the
+hub (`modl pull hub:username/my-son-v2`). The error happens at workflow start
+before any GPU work, so you don't waste compute.
+
+### "Model `flux-dev` is not installed locally"
+
+Same idea — run `modl pull flux-dev` first.
+
+### "step `forest`: local image `./input.png` does not exist"
+
+Edit step source path is relative to the workflow YAML file's directory, not
+your current working directory. Either use an absolute path or put `input.png`
+next to the YAML file.
+
+### "step `forest` produced 3 output(s), index [5] is out of bounds"
+
+You referenced `$forest.outputs[5]` but the forest step only produced 3
+outputs. Check your `seeds` or `count` on the referenced step.
+
+### "duplicate step id `scene-1` at step 3"
+
+Two steps share the same id. Ids must be unique within a workflow — renaming
+fixes it.
+
+### Images don't appear in `modl serve`
+
+- Are they in today's date directory? `ls ~/.modl/outputs/$(date +%Y-%m-%d)/`
+- Is the UI pointed at the right data dir? Check `modl serve` startup logs for
+  the outputs path.
+- Did the worker actually emit `Artifact` events? Check the workflow run's
+  stderr — if a step says `✓ 0 artifacts`, the worker failed silently.
+
+### Workflow stops mid-run after one step fails
+
+That's the design — **fail fast, don't continue on broken state**. Fix the
+error, re-run the full workflow. Step resumption is not supported today.
+
+## What's not in workflows (yet)
+
+These are out of scope for the current implementation. Several are planned;
+open an issue before assuming something is coming.
+
+- **`modl run --cloud`** — run the whole workflow on a rented GPU instead of
+  locally. Architected, coming in the next phase. See
+  `docs/plans/workflow-run.md`.
+- **Upscale / analysis steps** — `upscale`, `face-restore`, `score`, etc. as
+  first-class step kinds. Deferred to Phase B.2.
+- **Per-step LoRA or model override** — one workflow uses one model + one
+  LoRA for all steps. If this becomes a real blocker, we'll add it.
+- **Conditionals, variables, templating** — no `if:`, no `{{ }}`. If the spec
+  can't be a flat ordered list, it's probably two workflows.
+- **Parallel step execution** — sequential only.
+- **Step resumption after failure** — re-run the whole workflow.
+- **`modl run --watch`** — no file-watcher mode.
+- **Workflow-grouped view in `modl serve`** — labels are in the DB for when
+  the UI catches up.
+
+## Reference
+
+- **Plan doc:** `docs/plans/workflow-run.md` (private)
+- **Smoke tests:** `docs/plans/smoke-test-workflow.md` (private)
+- **Source:**
+  - Parser / validator: `src/core/workflow.rs`
+  - CLI + execution: `src/cli/run.rs`
+- **Related commands:** `modl generate`, `modl edit`, `modl serve`
+
+## Feedback
+
+If you build a workflow that hits a wall — a missing field, awkward syntax,
+unclear error — say so. The spec is deliberately minimal; the only way to know
+what's missing is to use it on real work.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -29,6 +29,7 @@ mod popular;
 mod preprocess;
 mod push;
 mod remove_bg;
+mod run;
 mod runtime;
 mod score;
 mod search;
@@ -1016,10 +1017,46 @@ pub enum Commands {
 
     // ── Workflow ─────────────────────────────────────────────────────
     /// Execute a workflow from a YAML spec file
+    #[command(long_about = "\
+Execute a batch workflow of generate/edit steps from a YAML spec.
+
+A workflow declares a model, an optional LoRA, shared defaults, and an ordered \
+list of steps. Each step is a generate or edit job. Outputs of earlier steps \
+can be referenced by later steps via $step-id.outputs[N].
+
+All outputs land in ~/.modl/outputs/<date>/ alongside regular `modl generate` \
+results and are visible in `modl serve`. Each step is registered as a job \
+row tagged with the workflow name for later filtering.
+
+EXAMPLE
+
+    name: book-chapter-3
+    model: flux2-klein-4b
+    lora: my-son-v2
+
+    defaults:
+      width: 1024
+      height: 1024
+      steps: 4
+      guidance: 1.0
+
+    steps:
+      - id: scene-1
+        generate: \"OHWX reading a book under a tree\"
+        seeds: [42, 7, 99, 333]     # 4 variations for winner selection
+
+      - id: scene-1-rain
+        edit: \"$scene-1.outputs[0]\"  # reference first seed variation
+        prompt: \"add heavy rain and puddles\"
+        seed: 42
+
+Run with:  modl run book-chapter-3.yaml
+
+See `modl/docs/guides/workflows.md` for the full reference.")]
     Run {
         /// Workflow spec file (.yaml)
         spec: String,
-        /// Auto-pull missing models before running
+        /// Auto-pull missing models before running (not yet implemented)
         #[arg(long)]
         auto_pull: bool,
     },
@@ -1529,9 +1566,7 @@ pub async fn run(cli: Cli) -> Result<()> {
         },
 
         // ── Workflow ────────────────────────────────────────────────
-        Commands::Run { spec, auto_pull: _ } => {
-            anyhow::bail!("modl run is not yet implemented (spec: {spec})")
-        }
+        Commands::Run { spec, auto_pull } => run::run(&spec, auto_pull).await,
 
         // ── Hidden ───────────────────────────────────────────────────
         Commands::Init { defaults, root } => init::run(defaults, root.as_deref()).await,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,0 +1,575 @@
+//! `modl run <workflow.yaml>` — execute a workflow spec locally.
+//!
+//! Phase B of the workflow-run plan. See `docs/plans/workflow-run.md`.
+//!
+//! Sequential execution: parse + validate spec, resolve model/lora once upfront,
+//! then iterate steps, materializing each into a GenerateJobSpec/EditJobSpec and
+//! handing it to LocalExecutor. Outputs of step N are available as inputs to
+//! step N+1 via the `$step-id.outputs[N]` reference.
+
+use anyhow::{Context, Result, anyhow, bail};
+use console::style;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc;
+
+use crate::core::db::Database;
+use crate::core::executor::{Executor, LocalExecutor};
+use crate::core::job::{
+    EditJobSpec, EditParams, EventPayload, ExecutionTarget, GenerateJobSpec, GenerateOutputRef,
+    GenerateParams, JobEvent, LoraRef, ModelRef, RuntimeRef,
+};
+use crate::core::workflow::{EditStep, GenerateStep, ImageRef, StepKind, parse_file};
+use crate::core::{model_family, model_resolve, paths, registry, runtime};
+
+pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
+    // -------------------------------------------------------------------
+    // 1. Parse + validate
+    // -------------------------------------------------------------------
+    let wf = parse_file(Path::new(spec_path))
+        .with_context(|| format!("Failed to load workflow from {spec_path}"))?;
+
+    println!(
+        "{} Running workflow {} ({} step{})",
+        style("→").cyan(),
+        style(&wf.name).bold(),
+        wf.steps.len(),
+        if wf.steps.len() == 1 { "" } else { "s" }
+    );
+    println!("  Model: {}", wf.model);
+    if let Some(ref l) = wf.lora {
+        println!("  LoRA:  {}", l);
+    }
+
+    // -------------------------------------------------------------------
+    // 2. Resolve model + lora once upfront (fail fast before any step runs)
+    // -------------------------------------------------------------------
+    let db = Database::open()?;
+    let spec_model_id = resolve_registry_model_id(&wf.model);
+    let base_model_path = model_resolve::resolve_base_model_path(&spec_model_id, &db);
+    if base_model_path.is_none() {
+        bail!(
+            "Model `{}` is not installed locally. Run `modl pull {}`.",
+            spec_model_id,
+            spec_model_id
+        );
+    }
+    let arch_key = model_family::find_model(&spec_model_id).map(|m| m.arch_key.to_string());
+
+    let lora_ref = match wf.lora.as_deref() {
+        Some(name) => Some(
+            model_resolve::resolve_lora(name, 1.0, &db)?
+                .ok_or_else(|| anyhow!("LoRA `{name}` not found in local store"))?,
+        ),
+        None => None,
+    };
+
+    // -------------------------------------------------------------------
+    // 3. Output directory — flat under today's date so `modl serve` sees
+    // workflow outputs alongside regular `modl generate` outputs. Per-step
+    // grouping is preserved in DB metadata via job labels, not the filesystem.
+    // -------------------------------------------------------------------
+    let date = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let output_dir = paths::modl_root().join("outputs").join(&date);
+    std::fs::create_dir_all(&output_dir)?;
+
+    // A stable run id used only for grouping jobs in the DB (labels).
+    let run_id = format!(
+        "{}-{}",
+        chrono::Local::now().format("%Y%m%d-%H%M%S"),
+        sanitize_for_path(&wf.name)
+    );
+    println!("  Output: {}", output_dir.display());
+    println!("  Run ID: {}\n", run_id);
+
+    // -------------------------------------------------------------------
+    // 4. Bootstrap executor (shared across all steps to reuse the worker)
+    // -------------------------------------------------------------------
+    println!("{} Preparing runtime...", style("→").cyan());
+    let mut executor = LocalExecutor::for_generation().await?;
+
+    // -------------------------------------------------------------------
+    // 5. Execute steps sequentially
+    // -------------------------------------------------------------------
+    let mut step_outputs: HashMap<String, Vec<PathBuf>> = HashMap::new();
+    let total_steps = wf.steps.len();
+
+    for (idx, step) in wf.steps.iter().enumerate() {
+        println!(
+            "\n{} [{}/{}] {} ({})",
+            style("▸").cyan().bold(),
+            idx + 1,
+            total_steps,
+            style(&step.id).bold(),
+            step_kind_label(&step.kind),
+        );
+
+        let step_labels = build_step_labels(&wf.name, &run_id, &step.id);
+
+        let mut step_artifacts: Vec<PathBuf> = Vec::new();
+
+        match &step.kind {
+            StepKind::Generate(g) => {
+                let sub_jobs = expand_seeds(g.seed, g.count, &g.seeds);
+                print_generate_preview(g, sub_jobs.len());
+                for (sub_idx, (seed, count)) in sub_jobs.iter().enumerate() {
+                    if sub_jobs.len() > 1 {
+                        println!(
+                            "  {} [{}/{}] seed={}",
+                            style("·").dim(),
+                            sub_idx + 1,
+                            sub_jobs.len(),
+                            seed.map(|s| s.to_string())
+                                .unwrap_or_else(|| "?".to_string()),
+                        );
+                    }
+                    let spec = build_generate_spec(
+                        &wf.model,
+                        &spec_model_id,
+                        base_model_path.clone(),
+                        arch_key.clone(),
+                        lora_ref.clone(),
+                        g,
+                        *seed,
+                        *count,
+                        &output_dir,
+                        step_labels.clone(),
+                    );
+                    let artifacts = execute_generate_step(&mut executor, &spec, &step.id, &db)?;
+                    step_artifacts.extend(artifacts);
+                }
+            }
+            StepKind::Edit(e) => {
+                let source_path = resolve_image_ref(&e.source, &step_outputs, &step.id)?;
+                let sub_jobs = expand_seeds(e.seed, e.count, &e.seeds);
+                print_edit_preview(e, &source_path, sub_jobs.len());
+                for (sub_idx, (seed, count)) in sub_jobs.iter().enumerate() {
+                    if sub_jobs.len() > 1 {
+                        println!(
+                            "  {} [{}/{}] seed={}",
+                            style("·").dim(),
+                            sub_idx + 1,
+                            sub_jobs.len(),
+                            seed.map(|s| s.to_string())
+                                .unwrap_or_else(|| "?".to_string()),
+                        );
+                    }
+                    let spec = build_edit_spec(
+                        &wf.model,
+                        &spec_model_id,
+                        base_model_path.clone(),
+                        arch_key.clone(),
+                        lora_ref.clone(),
+                        e,
+                        &source_path,
+                        *seed,
+                        *count,
+                        &output_dir,
+                        step_labels.clone(),
+                    );
+                    let artifacts = execute_edit_step(&mut executor, &spec, &step.id, &db)?;
+                    step_artifacts.extend(artifacts);
+                }
+            }
+        };
+
+        if step_artifacts.is_empty() {
+            bail!("step `{}` produced no artifacts", step.id);
+        }
+
+        println!(
+            "  {} {} artifact{}",
+            style("✓").green(),
+            step_artifacts.len(),
+            if step_artifacts.len() == 1 { "" } else { "s" }
+        );
+        step_outputs.insert(step.id.clone(), step_artifacts);
+    }
+
+    // -------------------------------------------------------------------
+    // 6. Summary
+    // -------------------------------------------------------------------
+    let total_artifacts: usize = step_outputs.values().map(|v| v.len()).sum();
+    println!(
+        "\n{} workflow {} complete: {} step{}, {} artifact{}",
+        style("✓").green().bold(),
+        style(&wf.name).bold(),
+        total_steps,
+        if total_steps == 1 { "" } else { "s" },
+        total_artifacts,
+        if total_artifacts == 1 { "" } else { "s" },
+    );
+    println!("  {}", output_dir.display());
+
+    Ok(())
+}
+
+/// Labels attached to every step's job row so the UI can group workflow outputs.
+fn build_step_labels(workflow_name: &str, run_id: &str, step_id: &str) -> HashMap<String, String> {
+    let mut labels = HashMap::new();
+    labels.insert("workflow".to_string(), workflow_name.to_string());
+    labels.insert("workflow_run".to_string(), run_id.to_string());
+    labels.insert("workflow_step".to_string(), step_id.to_string());
+    labels
+}
+
+/// Expand a step's seed/count/seeds fields into a list of concrete
+/// (seed, count) sub-jobs. When `seeds` is set, one sub-job per seed with
+/// count=1. Otherwise a single sub-job that delegates count to the worker
+/// (existing behavior — worker varies internal noise at a fixed seed).
+fn expand_seeds(
+    seed: Option<u64>,
+    count: Option<u32>,
+    seeds: &Option<Vec<u64>>,
+) -> Vec<(Option<u64>, u32)> {
+    if let Some(seeds) = seeds {
+        seeds.iter().map(|s| (Some(*s), 1u32)).collect()
+    } else {
+        vec![(seed, count.unwrap_or(1))]
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Spec builders
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn build_generate_spec(
+    wf_model: &str,
+    spec_model_id: &str,
+    base_model_path: Option<String>,
+    arch_key: Option<String>,
+    lora: Option<LoraRef>,
+    step: &GenerateStep,
+    seed: Option<u64>,
+    count: u32,
+    output_dir: &Path,
+    labels: HashMap<String, String>,
+) -> GenerateJobSpec {
+    let (default_steps, default_guidance) = model_family::model_defaults(wf_model);
+    let steps = step.steps.unwrap_or(default_steps);
+    let guidance = step.guidance.unwrap_or(default_guidance);
+    let width = step.width.unwrap_or(1024);
+    let height = step.height.unwrap_or(1024);
+
+    GenerateJobSpec {
+        prompt: step.prompt.clone(),
+        model: ModelRef {
+            base_model_id: spec_model_id.to_string(),
+            base_model_path: base_model_path.clone(),
+            arch_key: arch_key.clone(),
+        },
+        lora,
+        output: GenerateOutputRef {
+            output_dir: output_dir.to_string_lossy().to_string(),
+        },
+        params: GenerateParams {
+            width,
+            height,
+            steps,
+            guidance,
+            seed,
+            count,
+            init_image: None,
+            mask: None,
+            strength: None,
+            scheduler_overrides: HashMap::new(),
+            controlnet: Vec::new(),
+            style_ref: Vec::new(),
+            inpaint_method: None,
+        },
+        runtime: RuntimeRef {
+            profile: runtime::resolved_generation_profile().to_string(),
+            python_version: Some("3.11.12".to_string()),
+        },
+        target: ExecutionTarget::Local,
+        labels,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_edit_spec(
+    wf_model: &str,
+    spec_model_id: &str,
+    base_model_path: Option<String>,
+    arch_key: Option<String>,
+    lora: Option<LoraRef>,
+    step: &EditStep,
+    source_path: &Path,
+    seed: Option<u64>,
+    count: u32,
+    output_dir: &Path,
+    labels: HashMap<String, String>,
+) -> EditJobSpec {
+    let (default_steps, default_guidance) = model_family::model_defaults(wf_model);
+    let steps = step.steps.unwrap_or(default_steps);
+    let guidance = step.guidance.unwrap_or(default_guidance);
+
+    EditJobSpec {
+        prompt: step.prompt.clone(),
+        model: ModelRef {
+            base_model_id: spec_model_id.to_string(),
+            base_model_path: base_model_path.clone(),
+            arch_key: arch_key.clone(),
+        },
+        lora,
+        output: GenerateOutputRef {
+            output_dir: output_dir.to_string_lossy().to_string(),
+        },
+        params: EditParams {
+            image_paths: vec![source_path.to_string_lossy().to_string()],
+            steps,
+            guidance,
+            seed,
+            count,
+            width: step.width,
+            height: step.height,
+            scheduler_overrides: HashMap::new(),
+        },
+        runtime: RuntimeRef {
+            profile: runtime::resolved_generation_profile().to_string(),
+            python_version: Some("3.11.12".to_string()),
+        },
+        target: ExecutionTarget::Local,
+        labels,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Execution + event consumption
+// ---------------------------------------------------------------------------
+
+fn execute_generate_step(
+    executor: &mut LocalExecutor,
+    spec: &GenerateJobSpec,
+    step_id: &str,
+    db: &Database,
+) -> Result<Vec<PathBuf>> {
+    let handle = executor.submit_generate(spec)?;
+    let job_id = handle.job_id.clone();
+    register_job(db, &job_id, "generate", spec)?;
+    let rx = executor.events(&job_id)?;
+    let result = consume_events(rx, step_id, db, &job_id);
+    match &result {
+        Ok(_) => {
+            let _ = db.update_job_status(&job_id, "completed");
+        }
+        Err(_) => {
+            let _ = db.update_job_status(&job_id, "error");
+        }
+    }
+    result
+}
+
+fn execute_edit_step(
+    executor: &mut LocalExecutor,
+    spec: &EditJobSpec,
+    step_id: &str,
+    db: &Database,
+) -> Result<Vec<PathBuf>> {
+    let handle = executor.submit_edit(spec)?;
+    let job_id = handle.job_id.clone();
+    register_job(db, &job_id, "edit", spec)?;
+    let rx = executor.events(&job_id)?;
+    let result = consume_events(rx, step_id, db, &job_id);
+    match &result {
+        Ok(_) => {
+            let _ = db.update_job_status(&job_id, "completed");
+        }
+        Err(_) => {
+            let _ = db.update_job_status(&job_id, "error");
+        }
+    }
+    result
+}
+
+/// Insert a job row so the UI can discover workflow outputs alongside
+/// regular `modl generate` / `modl edit` results. Mirrors what those CLI
+/// handlers do directly.
+fn register_job<S: serde::Serialize>(
+    db: &Database,
+    job_id: &str,
+    kind: &str,
+    spec: &S,
+) -> Result<()> {
+    let spec_json = serde_json::to_string(spec).unwrap_or_else(|_| "{}".to_string());
+    db.insert_job(job_id, kind, "running", &spec_json, "local", None)?;
+    Ok(())
+}
+
+/// Drain the worker's event stream for a single step. Returns the list of
+/// artifact paths produced, or an error on worker failure. Persists every
+/// event to the job_events table so `modl serve` can reconstruct step details.
+fn consume_events(
+    rx: mpsc::Receiver<JobEvent>,
+    step_id: &str,
+    db: &Database,
+    job_id: &str,
+) -> Result<Vec<PathBuf>> {
+    let mut artifacts: Vec<PathBuf> = Vec::new();
+    let mut last_progress_len: usize = 0;
+
+    for event in rx {
+        // Persist every event so the UI can rehydrate step details.
+        let event_json = serde_json::to_string(&event).unwrap_or_default();
+        let _ = db.insert_job_event(job_id, event.sequence, &event_json);
+
+        match &event.event {
+            EventPayload::Progress {
+                stage,
+                step: cur,
+                total_steps,
+                ..
+            } => {
+                if stage == "step" {
+                    let msg = format!("  step {}/{}", cur, total_steps);
+                    // Overwrite previous progress line
+                    eprint!(
+                        "\r{}{}",
+                        msg,
+                        " ".repeat(last_progress_len.saturating_sub(msg.len()))
+                    );
+                    last_progress_len = msg.len();
+                }
+            }
+            EventPayload::Artifact { path, .. } => {
+                artifacts.push(PathBuf::from(path));
+            }
+            EventPayload::Completed { .. } => {
+                if last_progress_len > 0 {
+                    eprint!("\r{}\r", " ".repeat(last_progress_len));
+                }
+                break;
+            }
+            EventPayload::Error { message, code, .. } => {
+                if last_progress_len > 0 {
+                    eprint!("\r{}\r", " ".repeat(last_progress_len));
+                }
+                bail!("step `{step_id}` failed ({code}): {message}");
+            }
+            EventPayload::Cancelled => {
+                if last_progress_len > 0 {
+                    eprint!("\r{}\r", " ".repeat(last_progress_len));
+                }
+                bail!("step `{step_id}` cancelled");
+            }
+            EventPayload::Log { message, level } if level == "warning" || level == "error" => {
+                eprintln!("  [{level}] {message}");
+            }
+            _ => {}
+        }
+    }
+
+    Ok(artifacts)
+}
+
+// ---------------------------------------------------------------------------
+// Image ref resolution
+// ---------------------------------------------------------------------------
+
+/// Resolve an `ImageRef` to a local filesystem path. Handles runtime bounds
+/// checking for `$step.outputs[N]` references since cardinality isn't known
+/// until the referenced step has executed.
+fn resolve_image_ref(
+    r: &ImageRef,
+    step_outputs: &HashMap<String, Vec<PathBuf>>,
+    current_step_id: &str,
+) -> Result<PathBuf> {
+    match r {
+        ImageRef::Local(p) => Ok(p.clone()),
+        ImageRef::StepOutput { step_id, index } => {
+            let outputs = step_outputs.get(step_id).ok_or_else(|| {
+                anyhow!(
+                    "step `{current_step_id}`: referenced step `{step_id}` produced no outputs (bug — should have been caught at parse time)"
+                )
+            })?;
+            outputs.get(*index).cloned().ok_or_else(|| {
+                anyhow!(
+                    "step `{current_step_id}`: step `{step_id}` produced {} output(s), index [{}] is out of bounds",
+                    outputs.len(),
+                    index
+                )
+            })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a family-alias model name (e.g. `"sdxl"`) to the canonical registry
+/// ID (e.g. `"sdxl-base-1.0"`). Mirrors the logic in `cli::generate` so specs
+/// submitted via `modl run` use the same naming Python workers understand.
+fn resolve_registry_model_id(effective_model: &str) -> String {
+    let index = registry::RegistryIndex::load();
+    if let Ok(ref idx) = index {
+        if idx.find(effective_model).is_some() {
+            return effective_model.to_string();
+        }
+        if let Some(info) = model_family::resolve_model(effective_model) {
+            let candidates = [info.id.to_string(), format!("{}-base-1.0", info.id)];
+            if let Some(c) = candidates.into_iter().find(|c| idx.find(c).is_some()) {
+                return c;
+            }
+        }
+    }
+    effective_model.to_string()
+}
+
+fn sanitize_for_path(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+fn step_kind_label(kind: &StepKind) -> &'static str {
+    match kind {
+        StepKind::Generate(_) => "generate",
+        StepKind::Edit(_) => "edit",
+    }
+}
+
+fn print_generate_preview(step: &GenerateStep, sub_job_count: usize) {
+    println!("  Prompt: {}", style(&step.prompt).italic());
+    let width = step.width.unwrap_or(1024);
+    let height = step.height.unwrap_or(1024);
+    println!("  Size:   {}×{}", width, height);
+    if let Some(ref seeds) = step.seeds {
+        println!(
+            "  Seeds:  {:?} ({} variation{})",
+            seeds,
+            seeds.len(),
+            if seeds.len() == 1 { "" } else { "s" }
+        );
+    } else if let Some(seed) = step.seed {
+        println!("  Seed:   {}  Count: {}", seed, step.count.unwrap_or(1));
+    } else {
+        println!("  Count:  {}", step.count.unwrap_or(1));
+    }
+    let _ = sub_job_count; // accepted for symmetry with edit preview; no current use
+}
+
+fn print_edit_preview(step: &EditStep, source_path: &Path, sub_job_count: usize) {
+    println!("  Source: {}", source_path.display());
+    println!("  Prompt: {}", style(&step.prompt).italic());
+    if let Some(ref seeds) = step.seeds {
+        println!(
+            "  Seeds:  {:?} ({} variation{})",
+            seeds,
+            seeds.len(),
+            if seeds.len() == 1 { "" } else { "s" }
+        );
+    } else if let Some(seed) = step.seed {
+        println!("  Seed:   {}  Count: {}", seed, step.count.unwrap_or(1));
+    } else {
+        println!("  Count:  {}", step.count.unwrap_or(1));
+    }
+    let _ = sub_job_count;
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -35,3 +35,4 @@ pub mod symlink;
 pub mod training;
 pub mod training_status;
 pub mod update_check;
+pub mod workflow;

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -1,0 +1,742 @@
+//! Workflow spec parser and validator for `modl run`.
+//!
+//! A workflow is a sequentially-executed list of generate/edit jobs with shared
+//! model/lora defaults. See `docs/plans/workflow-run.md` for the design.
+//!
+//! This module only parses and validates. Materialization into
+//! `GenerateJobSpec` / `EditJobSpec` happens at execution time (Phase B).
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::Deserialize;
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+// ---------------------------------------------------------------------------
+// Public types (materialized after parse + validate)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+pub struct Workflow {
+    pub name: String,
+    pub model: String,
+    pub lora: Option<String>,
+    pub steps: Vec<Step>,
+}
+
+#[derive(Debug, Clone)]
+pub struct Step {
+    pub id: String,
+    pub kind: StepKind,
+}
+
+#[derive(Debug, Clone)]
+pub enum StepKind {
+    Generate(GenerateStep),
+    Edit(EditStep),
+}
+
+#[derive(Debug, Clone)]
+pub struct GenerateStep {
+    pub prompt: String,
+    pub seed: Option<u64>,
+    /// Explicit seed list for variation exploration — one output per seed.
+    /// Mutually exclusive with `seed` + `count`. Empty list is rejected at parse time.
+    pub seeds: Option<Vec<u64>>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub steps: Option<u32>,
+    pub guidance: Option<f32>,
+    pub count: Option<u32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct EditStep {
+    pub source: ImageRef,
+    pub prompt: String,
+    pub seed: Option<u64>,
+    /// Explicit seed list for variation exploration — one output per seed.
+    /// Mutually exclusive with `seed` + `count`. Empty list is rejected at parse time.
+    pub seeds: Option<Vec<u64>>,
+    pub width: Option<u32>,
+    pub height: Option<u32>,
+    pub steps: Option<u32>,
+    pub guidance: Option<f32>,
+    pub count: Option<u32>,
+}
+
+/// Reference to a source image: either a local file (uploaded at submit time
+/// when running `--cloud`) or an output of a prior step (resolved at runtime
+/// from disk).
+///
+/// The output index cannot be bounds-checked statically: a `generate` step's
+/// `count` determines its output cardinality at execution time, so `[N]`
+/// out-of-bounds surfaces as a runtime error during the referencing step's
+/// image resolution — not at parse time.
+#[derive(Debug, Clone)]
+pub enum ImageRef {
+    Local(PathBuf),
+    StepOutput { step_id: String, index: usize },
+}
+
+// ---------------------------------------------------------------------------
+// Raw YAML types (deserialization only)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RawWorkflow {
+    name: String,
+    model: String,
+    #[serde(default)]
+    lora: Option<String>,
+    #[serde(default)]
+    defaults: StepDefaults,
+    steps: Vec<RawStep>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct StepDefaults {
+    #[serde(default)]
+    seed: Option<u64>,
+    #[serde(default)]
+    width: Option<u32>,
+    #[serde(default)]
+    height: Option<u32>,
+    #[serde(default)]
+    steps: Option<u32>,
+    #[serde(default)]
+    guidance: Option<f32>,
+    #[serde(default)]
+    count: Option<u32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawStep {
+    id: String,
+    #[serde(default)]
+    generate: Option<String>,
+    #[serde(default)]
+    edit: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    seed: Option<u64>,
+    #[serde(default)]
+    seeds: Option<Vec<u64>>,
+    #[serde(default)]
+    width: Option<u32>,
+    #[serde(default)]
+    height: Option<u32>,
+    #[serde(default)]
+    steps: Option<u32>,
+    #[serde(default)]
+    guidance: Option<f32>,
+    #[serde(default)]
+    count: Option<u32>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+pub fn parse_file(path: &Path) -> Result<Workflow> {
+    let yaml = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read workflow file: {}", path.display()))?;
+    let base_dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    parse_str(&yaml, &base_dir).with_context(|| format!("In workflow file: {}", path.display()))
+}
+
+pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
+    let raw: RawWorkflow = serde_yaml::from_str(yaml).context("Failed to parse workflow YAML")?;
+
+    if raw.name.trim().is_empty() {
+        bail!("workflow `name` is required");
+    }
+    if raw.model.trim().is_empty() {
+        bail!("workflow `model` is required");
+    }
+    if raw.steps.is_empty() {
+        bail!("workflow must have at least one step");
+    }
+
+    let mut seen_ids: HashSet<String> = HashSet::new();
+    let mut materialized: Vec<Step> = Vec::with_capacity(raw.steps.len());
+
+    for (idx, raw_step) in raw.steps.iter().enumerate() {
+        // --- id validation
+        if raw_step.id.trim().is_empty() {
+            bail!("step {idx}: `id` is required");
+        }
+        if !is_valid_id(&raw_step.id) {
+            bail!(
+                "step {idx}: id `{}` must contain only letters, digits, `-`, `_`",
+                raw_step.id
+            );
+        }
+        if !seen_ids.insert(raw_step.id.clone()) {
+            bail!(
+                "duplicate step id `{}` at step {idx} (ids must be unique)",
+                raw_step.id
+            );
+        }
+
+        // --- kind validation: exactly one of generate/edit
+        let kind_count = raw_step.generate.is_some() as u8 + raw_step.edit.is_some() as u8;
+        if kind_count == 0 {
+            bail!(
+                "step `{}`: must have exactly one of `generate:` or `edit:`",
+                raw_step.id
+            );
+        }
+        if kind_count > 1 {
+            bail!(
+                "step `{}`: cannot have both `generate:` and `edit:`",
+                raw_step.id
+            );
+        }
+
+        // --- seeds validation (shared between generate + edit kinds)
+        validate_seeds(&raw_step.id, &raw_step.seeds, raw_step.seed, raw_step.count)?;
+
+        let kind = if let Some(prompt) = &raw_step.generate {
+            StepKind::Generate(GenerateStep {
+                prompt: prompt.clone(),
+                seed: raw_step.seed.or(raw.defaults.seed),
+                seeds: raw_step.seeds.clone(),
+                width: raw_step.width.or(raw.defaults.width),
+                height: raw_step.height.or(raw.defaults.height),
+                steps: raw_step.steps.or(raw.defaults.steps),
+                guidance: raw_step.guidance.or(raw.defaults.guidance),
+                count: raw_step.count.or(raw.defaults.count),
+            })
+        } else {
+            let source_str = raw_step.edit.as_ref().unwrap();
+            let edit_prompt = raw_step.prompt.as_ref().ok_or_else(|| {
+                anyhow!(
+                    "step `{}`: edit steps require a `prompt:` field",
+                    raw_step.id
+                )
+            })?;
+            let source = parse_image_ref(source_str, base_dir, &seen_ids, &raw_step.id)?;
+            StepKind::Edit(EditStep {
+                source,
+                prompt: edit_prompt.clone(),
+                seed: raw_step.seed.or(raw.defaults.seed),
+                seeds: raw_step.seeds.clone(),
+                width: raw_step.width.or(raw.defaults.width),
+                height: raw_step.height.or(raw.defaults.height),
+                steps: raw_step.steps.or(raw.defaults.steps),
+                guidance: raw_step.guidance.or(raw.defaults.guidance),
+                count: raw_step.count.or(raw.defaults.count),
+            })
+        };
+
+        materialized.push(Step {
+            id: raw_step.id.clone(),
+            kind,
+        });
+    }
+
+    Ok(Workflow {
+        name: raw.name,
+        model: raw.model,
+        lora: raw.lora,
+        steps: materialized,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn is_valid_id(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+/// Validate seed-related fields on a single step.
+///
+/// Rules:
+/// - `seeds: []` (empty list) is rejected — must have at least one seed.
+/// - `seeds` + `seed` both set is rejected — ambiguous.
+/// - `seeds` + `count` both set is rejected — `seeds.len()` is the count.
+/// - `seed` alone or `seed` + `count` is allowed (existing worker behavior).
+/// - Neither is allowed (model/defaults take over).
+fn validate_seeds(
+    step_id: &str,
+    seeds: &Option<Vec<u64>>,
+    seed: Option<u64>,
+    count: Option<u32>,
+) -> Result<()> {
+    let Some(seeds) = seeds else {
+        return Ok(());
+    };
+    if seeds.is_empty() {
+        bail!(
+            "step `{step_id}`: `seeds: []` is empty — provide at least one seed, or remove the field"
+        );
+    }
+    if seed.is_some() {
+        bail!(
+            "step `{step_id}`: cannot set both `seed` and `seeds` — pick one (use `seeds` for variation exploration, `seed` + `count` for noise variation at a fixed seed)"
+        );
+    }
+    if count.is_some() {
+        bail!(
+            "step `{step_id}`: cannot set both `seeds` and `count` — the length of `seeds` is the count"
+        );
+    }
+    Ok(())
+}
+
+/// Parse an `edit:` source image reference.
+///
+/// Two forms:
+/// - `$step-id.outputs[N]` → resolved at runtime to the Nth output of an earlier step
+/// - Anything else → filesystem path relative to `base_dir`, must exist
+fn parse_image_ref(
+    s: &str,
+    base_dir: &Path,
+    earlier_step_ids: &HashSet<String>,
+    current_step_id: &str,
+) -> Result<ImageRef> {
+    if let Some(rest) = s.strip_prefix('$') {
+        let (step_id, bracket_part) = rest.split_once(".outputs[").ok_or_else(|| {
+            anyhow!(
+                "step `{current_step_id}`: invalid step-output ref `{s}` — expected `$step-id.outputs[N]`"
+            )
+        })?;
+        let index_str = bracket_part.strip_suffix(']').ok_or_else(|| {
+            anyhow!("step `{current_step_id}`: invalid step-output ref `{s}` — missing closing `]`")
+        })?;
+        let index: usize = index_str.parse().map_err(|_| {
+            anyhow!(
+                "step `{current_step_id}`: invalid step-output ref `{s}` — `{index_str}` is not a valid index"
+            )
+        })?;
+
+        if step_id == current_step_id {
+            bail!("step `{current_step_id}`: cannot reference its own outputs via `{s}`");
+        }
+        // Note: earlier_step_ids is built as we iterate, so this naturally
+        // rejects forward references and self-references.
+        if !earlier_step_ids.contains(step_id) {
+            bail!(
+                "step `{current_step_id}`: step-output ref `{s}` points to unknown or later step `{step_id}` (only earlier steps can be referenced)"
+            );
+        }
+        Ok(ImageRef::StepOutput {
+            step_id: step_id.to_string(),
+            index,
+        })
+    } else {
+        let path = if Path::new(s).is_absolute() {
+            PathBuf::from(s)
+        } else {
+            base_dir.join(s)
+        };
+        if !path.exists() {
+            bail!(
+                "step `{current_step_id}`: local image `{}` does not exist",
+                path.display()
+            );
+        }
+        Ok(ImageRef::Local(path))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn parse(yaml: &str) -> Result<Workflow> {
+        parse_str(yaml, Path::new("."))
+    }
+
+    #[test]
+    fn parses_minimal_workflow() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+"#;
+        let wf = parse(yaml).unwrap();
+        assert_eq!(wf.name, "test");
+        assert_eq!(wf.model, "flux-dev");
+        assert_eq!(wf.steps.len(), 1);
+        assert_eq!(wf.steps[0].id, "a");
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => assert_eq!(g.prompt, "a cat"),
+            _ => panic!("expected generate"),
+        }
+    }
+
+    #[test]
+    fn defaults_inherited_by_steps() {
+        let yaml = r#"
+name: test
+model: flux-dev
+defaults:
+  seed: 42
+  width: 512
+  height: 512
+  steps: 28
+  guidance: 3.5
+  count: 2
+steps:
+  - id: a
+    generate: "a cat"
+"#;
+        let wf = parse(yaml).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => {
+                assert_eq!(g.seed, Some(42));
+                assert_eq!(g.width, Some(512));
+                assert_eq!(g.height, Some(512));
+                assert_eq!(g.steps, Some(28));
+                assert_eq!(g.guidance, Some(3.5));
+                assert_eq!(g.count, Some(2));
+            }
+            _ => panic!("expected generate"),
+        }
+    }
+
+    #[test]
+    fn step_overrides_default() {
+        let yaml = r#"
+name: test
+model: flux-dev
+defaults:
+  seed: 42
+steps:
+  - id: a
+    generate: "a cat"
+    seed: 99
+"#;
+        let wf = parse(yaml).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => assert_eq!(g.seed, Some(99)),
+            _ => panic!("expected generate"),
+        }
+    }
+
+    #[test]
+    fn duplicate_step_ids_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "cat"
+  - id: a
+    generate: "dog"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("duplicate step id"), "got: {err}");
+    }
+
+    #[test]
+    fn missing_model_rejected() {
+        let yaml = r#"
+name: test
+model: ""
+steps:
+  - id: a
+    generate: "cat"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("model"), "got: {err}");
+    }
+
+    #[test]
+    fn empty_steps_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps: []
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("at least one step"), "got: {err}");
+    }
+
+    #[test]
+    fn both_generate_and_edit_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "cat"
+    edit: "./input.png"
+    prompt: "add rain"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("both"), "got: {err}");
+    }
+
+    #[test]
+    fn neither_generate_nor_edit_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    prompt: "hi"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("generate") || err.contains("edit"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn edit_without_prompt_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let img = tmp.path().join("input.png");
+        std::fs::write(&img, b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    edit: "input.png"
+"#;
+        let err = parse_str(yaml, tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("prompt"), "got: {err}");
+    }
+
+    #[test]
+    fn step_ref_to_earlier_step_works() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: scene
+    generate: "cat"
+  - id: rain
+    edit: "$scene.outputs[0]"
+    prompt: "add rain"
+"#;
+        let wf = parse(yaml).unwrap();
+        match &wf.steps[1].kind {
+            StepKind::Edit(e) => match &e.source {
+                ImageRef::StepOutput { step_id, index } => {
+                    assert_eq!(step_id, "scene");
+                    assert_eq!(*index, 0);
+                }
+                _ => panic!("expected step output ref"),
+            },
+            _ => panic!("expected edit"),
+        }
+    }
+
+    #[test]
+    fn step_ref_to_unknown_step_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    edit: "$ghost.outputs[0]"
+    prompt: "hi"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("unknown or later"), "got: {err}");
+    }
+
+    #[test]
+    fn step_ref_to_later_step_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    edit: "$b.outputs[0]"
+    prompt: "hi"
+  - id: b
+    generate: "cat"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("unknown or later"), "got: {err}");
+    }
+
+    #[test]
+    fn step_ref_to_self_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    edit: "$a.outputs[0]"
+    prompt: "hi"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("own outputs") || err.contains("unknown or later"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn local_path_that_doesnt_exist_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    edit: "./nope.png"
+    prompt: "hi"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("does not exist"), "got: {err}");
+    }
+
+    #[test]
+    fn local_path_that_exists_resolved_to_absolute() {
+        let tmp = TempDir::new().unwrap();
+        let img = tmp.path().join("input.png");
+        std::fs::write(&img, b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    edit: "input.png"
+    prompt: "hi"
+"#;
+        let wf = parse_str(yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Edit(e) => match &e.source {
+                ImageRef::Local(p) => assert!(p.ends_with("input.png")),
+                _ => panic!("expected local ref"),
+            },
+            _ => panic!("expected edit"),
+        }
+    }
+
+    #[test]
+    fn invalid_id_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: "bad id with spaces"
+    generate: "cat"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("id"), "got: {err}");
+    }
+
+    #[test]
+    fn seeds_list_parsed() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "cat"
+    seeds: [42, 7, 99]
+"#;
+        let wf = parse(yaml).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => {
+                assert_eq!(g.seeds, Some(vec![42, 7, 99]));
+                assert_eq!(g.seed, None);
+                assert_eq!(g.count, None);
+            }
+            _ => panic!("expected generate"),
+        }
+    }
+
+    #[test]
+    fn seeds_empty_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "cat"
+    seeds: []
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("empty"), "got: {err}");
+    }
+
+    #[test]
+    fn seeds_plus_seed_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "cat"
+    seed: 42
+    seeds: [7, 99]
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("both `seed` and `seeds`"), "got: {err}");
+    }
+
+    #[test]
+    fn seeds_plus_count_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "cat"
+    count: 4
+    seeds: [7, 99]
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("both `seeds` and `count`"), "got: {err}");
+    }
+
+    #[test]
+    fn seeds_on_edit_step_allowed() {
+        let tmp = TempDir::new().unwrap();
+        let img = tmp.path().join("input.png");
+        std::fs::write(&img, b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    edit: "input.png"
+    prompt: "add rain"
+    seeds: [1, 2, 3]
+"#;
+        let wf = parse_str(yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Edit(e) => assert_eq!(e.seeds, Some(vec![1, 2, 3])),
+            _ => panic!("expected edit"),
+        }
+    }
+
+    #[test]
+    fn malformed_step_ref_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "cat"
+  - id: b
+    edit: "$a.outputs"
+    prompt: "hi"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("step-output ref"), "got: {err}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `modl run <workflow.yaml>` — execute a batch of generate/edit steps from a single YAML spec. The unit of work shifts from one-off CLI invocations to a declarative plan.

**The book-chapter problem this solves:** producing a collection (KDP book, product sheet, mood board) today means retyping the same flags with different prompts and juggling output paths between steps. With workflows, declare the whole batch once — model, LoRA, shared defaults, ordered steps, seed exploration, cross-step image references — hit run, walk away, come back to finished artifacts in `modl serve`.

```yaml
name: book-chapter-3
model: flux2-klein-4b
lora: my-son-v2

defaults:
  width: 1024
  height: 1024
  steps: 4
  guidance: 1.0

steps:
  - id: scene-1
    generate: "OHWX reading a book under a tree"
    seeds: [42, 7, 99, 333]     # 4 variations → pick winner later

  - id: rain-variant
    edit: "$scene-1.outputs[0]"  # edit the first seed variation
    prompt: "add heavy rain and puddles"
    seed: 42
```

```bash
modl run book-chapter-3.yaml
```

## What's in the PR

### `src/core/workflow.rs` — parser + validator
- Types: `Workflow`, `Step`, `StepKind::{Generate, Edit}`, `GenerateStep`, `EditStep`, `ImageRef`
- Public entry points: `parse_file(path)` and `parse_str(yaml, base_dir)`
- Validations (all with clean, step-scoped error messages):
  - Unique step IDs within a workflow
  - Exactly one of `generate:` / `edit:` per step
  - Edit steps require `prompt:`
  - `$step-id.outputs[N]` refs point to an earlier step (self / forward / unknown all rejected)
  - Local `image:` paths exist on disk
  - `seeds: []` empty list rejected
  - `seed` and `seeds` mutually exclusive
  - `count` and `seeds` mutually exclusive
- **22 unit tests** covering every validation path
- `[N]` index deliberately **not** statically validated — a generate step's `count` determines output cardinality at execution time, so bounds-check happens at runtime with a clear error

### `src/cli/run.rs` — execution
- Parses workflow, resolves model + LoRA **once upfront** (fail fast before GPU work)
- Reuses one `LocalExecutor::for_generation()` across every step (keeps the Python worker warm between generations — big speedup for multi-step workflows)
- Sequential execution with per-step preview + live progress output
- Seed expansion: `seeds: [42, 7, 99]` → 3 sub-jobs, each a separate DB row, each reproducible by its seed number
- Runtime `$step.outputs[N]` resolution with bounds-check errors pointing at the offending step and index
- Outputs land in `~/.modl/outputs/<YYYY-MM-DD>/` — same date directory `modl serve` scans, so workflow outputs appear alongside regular `modl generate` results immediately, with no UI changes needed
- Each step registers a job row via `db.insert_job` with labels `workflow`, `workflow_run`, `workflow_step` — data is in place for a future grouped-by-workflow view in the UI

### `src/cli/mod.rs` — CLI wiring
- Registered `mod run;`
- Replaced the `modl run` stub at the dispatch match arm with `run::run(&spec, auto_pull).await`
- Added `long_about` help text with a worked example so `modl run --help` actually teaches

### `docs/guides/workflows.md` — user reference
- Why workflows, quickstart, field-by-field reference
- Real KDP book-chapter example
- Troubleshooting table for the failure modes that come up in practice
- Explicit "what's not supported yet" section to set expectations
- Written to be extractable for the public modl-site marketing docs post-release (self-contained narrative sections)

## Validated end-to-end on a 4090

**Klein 4B smoke** (primary):
- 3 forest seed variations (`seeds: [42, 7, 99]`) + 1 beach (`seed: 333`) + 1 rain edit (`$forest.outputs[0]`) = **5 artifacts**
- All visible in `~/.modl/outputs/2026-04-14/` and registered as 5 individual DB job rows, each tagged with `workflow_run` label
- Under 2 minutes total wall time

**Qwen Image + Lightning LoRA smoke** (secondary):
- 2 artifacts with 20B-param model + 8-step distilled LoRA
- Validates LoRA resolution + propagation through every step

## What's NOT in this PR (tracked for follow-up)

- `modl run --cloud` — execute workflows on a rented Vast.ai GPU. Architected, coming in the next phase.
- **Upscale / analysis as step kinds** (`upscale`, `face-restore`, `score`). Deferred because it depends on an `Executor` trait design decision that shouldn't ride on this PR.
- **Per-step LoRA or model override.** One workflow = one model + one LoRA for now. Waiting for a real use case before adding.
- **Workflow-grouped view in `modl serve`** — the DB labels are there, just needs frontend work.
- **`auto_pull` flag** — accepted but not implemented. Missing models currently fail fast with a clear error telling you to `modl pull`.

## Test plan

- [ ] `cargo test core::workflow` — 22 unit tests pass
- [ ] `cargo build --release` — clean compile, no warnings
- [ ] `cargo clippy` — clean (enforced by pre-commit hook)
- [ ] `modl run --help` shows the long help with inline example
- [ ] Klein smoke: `modl run ~/modl-smoke/workflow.yaml` produces 5 artifacts in today's date dir
- [ ] Qwen+LoRA smoke: `modl run ~/modl-smoke/workflow-lora.yaml` produces 2 artifacts
- [ ] `modl serve` shows all 7 smoke artifacts in the Outputs tab
- [ ] `sqlite3 ~/.modl/state.db "SELECT json_extract(spec_json, '\$.labels.workflow_step') FROM jobs WHERE json_extract(spec_json, '\$.labels.workflow') IS NOT NULL"` returns the step IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)