### PR TITLE
feat: modl run --dry-run + agent-friendly JSON plan

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -181,6 +181,90 @@ steps:
 - Bounds can't be checked at parse time because `count` / `seeds.len()`
   determines cardinality at execution time.
 
+## Validating before you run
+
+Every `modl run` invocation supports `--dry-run`, which parses the spec,
+validates the schema, resolves the model + LoRA locally, expands seeds, and
+prints the execution plan — without touching the GPU, the DB, or writing any
+files.
+
+```bash
+modl run book-chapter-3.yaml --dry-run
+```
+
+You'll see per-step resolved params (defaults merged, seeds expanded), the
+total number of planned artifacts, and either `✓ Workflow is valid` or a
+specific error pointing at the offending step.
+
+**Human mode** (default): exit code is `0` on success, nonzero on any
+validation failure. Shell-friendly: `modl run x.yaml --dry-run && modl run x.yaml`.
+
+**JSON mode** (`--dry-run --json`): exit code is **always 0** and validity
+is signalled by the top-level `"valid"` field. Agent-friendly — a
+workflow-writing agent can pipe through `jq` or a JSON parser without
+branching on exit codes.
+
+```bash
+modl run book-chapter-3.yaml --dry-run --json
+```
+
+```json
+{
+  "valid": true,
+  "workflow": { "name": "book-chapter-3", "model": "flux2-klein-4b", "lora": "my-son-v2" },
+  "total_planned_artifacts": 13,
+  "steps": [
+    {
+      "id": "scene-1",
+      "kind": "generate",
+      "prompt": "OHWX climbing a wooden ladder...",
+      "seeds": [10, 20, 30, 40],
+      "effective": { "width": 1024, "height": 1024, "steps": 4, "guidance": 1.0, "count": 1 },
+      "expected_artifacts": 4
+    }
+  ]
+}
+```
+
+On failure:
+
+```json
+{
+  "valid": false,
+  "error": {
+    "kind": "lora_not_found",
+    "message": "LoRA `my-son-v2` not found in local store",
+    "fix": "modl pull my-son-v2 or train it with `modl train`"
+  }
+}
+```
+
+### Error kinds (stable enum for agents)
+
+| Kind | What it means | Typical fix |
+|------|---------------|-------------|
+| `parse_error` | YAML doesn't parse or fails schema validation | Fix the YAML syntax / structure |
+| `model_not_installed` | Model declared in `model:` isn't pulled | `modl pull <model>` |
+| `lora_not_found` | LoRA declared in `lora:` isn't in the local store | `modl pull <lora>` or train it |
+| `other` | Anything else (network, IO, etc.) | Read the `message` |
+
+The `fix:` field is a human-readable suggestion — optional, present when modl
+knows a likely remediation. The `kind` values are stable; agents can depend
+on them.
+
+### Agent iteration loop
+
+Once `--dry-run --json` exists, an agent writing workflows has a complete
+tight loop:
+
+1. Agent writes `workflow.yaml` (one tool call)
+2. Agent runs `modl run workflow.yaml --dry-run --json` (~100ms)
+3. If `valid: true` → agent runs `modl run workflow.yaml` (executes on GPU)
+4. If `valid: false` → agent reads `error.kind`, fixes the YAML, back to step 2
+
+No GPU wasted on bad YAML. Agents can iterate 10 times before ever touching
+the runtime.
+
 ## Where outputs go
 
 Every artifact lands in `~/.modl/outputs/<YYYY-MM-DD>/`, flat. No per-workflow

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1050,7 +1050,9 @@ EXAMPLE
         prompt: \"add heavy rain and puddles\"
         seed: 42
 
-Run with:  modl run book-chapter-3.yaml
+Run with:         modl run book-chapter-3.yaml
+Validate only:    modl run book-chapter-3.yaml --dry-run
+Agent JSON plan:  modl run book-chapter-3.yaml --dry-run --json
 
 See `modl/docs/guides/workflows.md` for the full reference.")]
     Run {
@@ -1059,6 +1061,15 @@ See `modl/docs/guides/workflows.md` for the full reference.")]
         /// Auto-pull missing models before running (not yet implemented)
         #[arg(long)]
         auto_pull: bool,
+        /// Validate the workflow and print the execution plan without running it.
+        /// Exits 0 if valid and ready to run, nonzero with an error otherwise.
+        /// Combine with --json for machine-readable output (agents).
+        #[arg(long)]
+        dry_run: bool,
+        /// Emit machine-readable JSON instead of human-formatted output.
+        /// Only meaningful with --dry-run today; ignored otherwise.
+        #[arg(long)]
+        json: bool,
     },
 
     // ── Hidden ───────────────────────────────────────────────────────
@@ -1566,7 +1577,12 @@ pub async fn run(cli: Cli) -> Result<()> {
         },
 
         // ── Workflow ────────────────────────────────────────────────
-        Commands::Run { spec, auto_pull } => run::run(&spec, auto_pull).await,
+        Commands::Run {
+            spec,
+            auto_pull,
+            dry_run,
+            json,
+        } => run::run(&spec, auto_pull, dry_run, json).await,
 
         // ── Hidden ───────────────────────────────────────────────────
         Commands::Init { defaults, root } => init::run(defaults, root.as_deref()).await,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -1,17 +1,24 @@
 //! `modl run <workflow.yaml>` — execute a workflow spec locally.
 //!
-//! Phase B of the workflow-run plan. See `docs/plans/workflow-run.md`.
+//! Phase B + B.1.5 of the workflow-run plan. See `docs/plans/workflow-run.md`.
 //!
-//! Sequential execution: parse + validate spec, resolve model/lora once upfront,
-//! then iterate steps, materializing each into a GenerateJobSpec/EditJobSpec and
-//! handing it to LocalExecutor. Outputs of step N are available as inputs to
-//! step N+1 via the `$step-id.outputs[N]` reference.
+//! Two-phase flow:
+//!   1. `build_plan()` — pure: parse, validate, resolve model/lora, expand seeds.
+//!      No side effects. Returns a `Plan` or a structured `PlanError`.
+//!   2. `execute_plan()` — impure: bootstrap executor, run each step, stream events,
+//!      insert DB jobs. Takes a `Plan` and runs it.
+//!
+//! `--dry-run` stops after phase 1 and prints the plan (human or JSON). Agents
+//! can depend on the JSON schema to validate/iterate workflows without burning
+//! GPU cycles.
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Result, anyhow, bail};
 use console::style;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
+use thiserror::Error;
 
 use crate::core::db::Database;
 use crate::core::executor::{Executor, LocalExecutor};
@@ -19,15 +26,207 @@ use crate::core::job::{
     EditJobSpec, EditParams, EventPayload, ExecutionTarget, GenerateJobSpec, GenerateOutputRef,
     GenerateParams, JobEvent, LoraRef, ModelRef, RuntimeRef,
 };
-use crate::core::workflow::{EditStep, GenerateStep, ImageRef, StepKind, parse_file};
+use crate::core::workflow::{EditStep, GenerateStep, ImageRef, StepKind, Workflow, parse_file};
 use crate::core::{model_family, model_resolve, paths, registry, runtime};
 
-pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
-    // -------------------------------------------------------------------
-    // 1. Parse + validate
-    // -------------------------------------------------------------------
-    let wf = parse_file(Path::new(spec_path))
-        .with_context(|| format!("Failed to load workflow from {spec_path}"))?;
+// ---------------------------------------------------------------------------
+// Plan — the fully-validated + resolved workflow, ready for execution or
+// inspection via --dry-run.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct Plan {
+    pub workflow: Workflow,
+    pub resolved_model_id: String,
+    pub base_model_path: String,
+    pub arch_key: Option<String>,
+    pub lora_ref: Option<LoraRef>,
+    pub run_id: String,
+    pub output_dir: PathBuf,
+    pub planned_steps: Vec<PlannedStep>,
+    pub total_artifacts: usize,
+}
+
+#[derive(Debug)]
+pub struct PlannedStep {
+    /// Copy of the step id; kept for symmetry with `Workflow.steps` and for
+    /// future queries that don't zip with the original workflow.
+    #[allow(dead_code)]
+    pub id: String,
+    pub sub_jobs: Vec<(Option<u64>, u32)>,
+}
+
+impl PlannedStep {
+    pub fn expected_artifacts(&self) -> usize {
+        self.sub_jobs.iter().map(|(_, c)| *c as usize).sum()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PlanError — structured errors for JSON dry-run output. Converts to
+// anyhow::Error for the normal execution path so callers don't have to know
+// about this type.
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum PlanError {
+    #[error("Failed to parse workflow spec: {0}")]
+    Parse(String),
+
+    #[error("Model `{model}` is not installed locally. Run `modl pull {model}`.")]
+    ModelNotInstalled { model: String },
+
+    #[error("LoRA `{lora}` not found in local store")]
+    LoraNotFound { lora: String },
+
+    #[error("{0}")]
+    Other(String),
+}
+
+impl PlanError {
+    /// Stable error kind string for JSON consumers. Agents can branch on this.
+    fn kind(&self) -> &'static str {
+        match self {
+            PlanError::Parse(_) => "parse_error",
+            PlanError::ModelNotInstalled { .. } => "model_not_installed",
+            PlanError::LoraNotFound { .. } => "lora_not_found",
+            PlanError::Other(_) => "other",
+        }
+    }
+
+    /// Human-actionable fix suggestion for JSON consumers.
+    fn fix(&self) -> Option<String> {
+        match self {
+            PlanError::ModelNotInstalled { model } => Some(format!("modl pull {model}")),
+            PlanError::LoraNotFound { lora } => {
+                Some(format!("modl pull {lora} or train it with `modl train`"))
+            }
+            _ => None,
+        }
+    }
+}
+
+// (No manual `From<PlanError> for anyhow::Error` — `thiserror`'s derived
+// `std::error::Error` impl + anyhow's blanket `From<E>` already covers it.)
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+pub async fn run(spec_path: &str, _auto_pull: bool, dry_run: bool, json: bool) -> Result<()> {
+    let db = Database::open()?;
+
+    let plan_result = build_plan(spec_path, &db);
+
+    if dry_run {
+        return run_dry_run(plan_result, json);
+    }
+
+    let plan = plan_result?;
+    execute_plan(plan, &db).await
+}
+
+// ---------------------------------------------------------------------------
+// Dry-run path
+// ---------------------------------------------------------------------------
+
+fn run_dry_run(plan_result: Result<Plan, PlanError>, json: bool) -> Result<()> {
+    match plan_result {
+        Ok(plan) => {
+            if json {
+                print_plan_json(&plan)?;
+            } else {
+                print_plan_human(&plan);
+            }
+            Ok(())
+        }
+        Err(e) => {
+            if json {
+                // In JSON mode we exit 0 regardless so agents can reliably
+                // parse the result — validity is signalled by `"valid": false`.
+                print_error_json(&e)?;
+                Ok(())
+            } else {
+                // In human mode, bubble up so the shell exit code is nonzero.
+                Err(e.into())
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// build_plan — the pure validation + resolution phase. No side effects.
+// Used by both dry-run and normal execution.
+// ---------------------------------------------------------------------------
+
+pub fn build_plan(spec_path: &str, db: &Database) -> Result<Plan, PlanError> {
+    // 1. Parse + validate YAML
+    let wf = parse_file(Path::new(spec_path)).map_err(|e| PlanError::Parse(format!("{e:#}")))?;
+
+    // 2. Resolve model to canonical registry ID + local path
+    let resolved_model_id = resolve_registry_model_id(&wf.model);
+    let base_model_path = model_resolve::resolve_base_model_path(&resolved_model_id, db)
+        .ok_or_else(|| PlanError::ModelNotInstalled {
+            model: resolved_model_id.clone(),
+        })?;
+    let arch_key = model_family::find_model(&resolved_model_id).map(|m| m.arch_key.to_string());
+
+    // 3. Resolve LoRA if set
+    let lora_ref = match wf.lora.as_deref() {
+        Some(name) => Some(
+            model_resolve::resolve_lora(name, 1.0, db)
+                .map_err(|e| PlanError::Other(format!("LoRA resolution error: {e}")))?
+                .ok_or_else(|| PlanError::LoraNotFound {
+                    lora: name.to_string(),
+                })?,
+        ),
+        None => None,
+    };
+
+    // 4. Compute run id + output dir (dry-run uses these only for display)
+    let date = chrono::Local::now().format("%Y-%m-%d").to_string();
+    let output_dir = paths::modl_root().join("outputs").join(&date);
+    let run_id = format!(
+        "{}-{}",
+        chrono::Local::now().format("%Y%m%d-%H%M%S"),
+        sanitize_for_path(&wf.name)
+    );
+
+    // 5. Expand seeds per step + compute artifact totals
+    let mut planned_steps = Vec::with_capacity(wf.steps.len());
+    let mut total_artifacts = 0usize;
+    for step in &wf.steps {
+        let sub_jobs = match &step.kind {
+            StepKind::Generate(g) => expand_seeds(g.seed, g.count, &g.seeds),
+            StepKind::Edit(e) => expand_seeds(e.seed, e.count, &e.seeds),
+        };
+        total_artifacts += sub_jobs.iter().map(|(_, c)| *c as usize).sum::<usize>();
+        planned_steps.push(PlannedStep {
+            id: step.id.clone(),
+            sub_jobs,
+        });
+    }
+
+    Ok(Plan {
+        workflow: wf,
+        resolved_model_id,
+        base_model_path,
+        arch_key,
+        lora_ref,
+        run_id,
+        output_dir,
+        planned_steps,
+        total_artifacts,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// execute_plan — the GPU work. Runs every step, streams events, registers
+// each step as a DB job row with workflow labels for UI filtering.
+// ---------------------------------------------------------------------------
+
+pub async fn execute_plan(plan: Plan, db: &Database) -> Result<()> {
+    let wf = &plan.workflow;
 
     println!(
         "{} Running workflow {} ({} step{})",
@@ -40,61 +239,17 @@ pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
     if let Some(ref l) = wf.lora {
         println!("  LoRA:  {}", l);
     }
+    std::fs::create_dir_all(&plan.output_dir)?;
+    println!("  Output: {}", plan.output_dir.display());
+    println!("  Run ID: {}\n", plan.run_id);
 
-    // -------------------------------------------------------------------
-    // 2. Resolve model + lora once upfront (fail fast before any step runs)
-    // -------------------------------------------------------------------
-    let db = Database::open()?;
-    let spec_model_id = resolve_registry_model_id(&wf.model);
-    let base_model_path = model_resolve::resolve_base_model_path(&spec_model_id, &db);
-    if base_model_path.is_none() {
-        bail!(
-            "Model `{}` is not installed locally. Run `modl pull {}`.",
-            spec_model_id,
-            spec_model_id
-        );
-    }
-    let arch_key = model_family::find_model(&spec_model_id).map(|m| m.arch_key.to_string());
-
-    let lora_ref = match wf.lora.as_deref() {
-        Some(name) => Some(
-            model_resolve::resolve_lora(name, 1.0, &db)?
-                .ok_or_else(|| anyhow!("LoRA `{name}` not found in local store"))?,
-        ),
-        None => None,
-    };
-
-    // -------------------------------------------------------------------
-    // 3. Output directory — flat under today's date so `modl serve` sees
-    // workflow outputs alongside regular `modl generate` outputs. Per-step
-    // grouping is preserved in DB metadata via job labels, not the filesystem.
-    // -------------------------------------------------------------------
-    let date = chrono::Local::now().format("%Y-%m-%d").to_string();
-    let output_dir = paths::modl_root().join("outputs").join(&date);
-    std::fs::create_dir_all(&output_dir)?;
-
-    // A stable run id used only for grouping jobs in the DB (labels).
-    let run_id = format!(
-        "{}-{}",
-        chrono::Local::now().format("%Y%m%d-%H%M%S"),
-        sanitize_for_path(&wf.name)
-    );
-    println!("  Output: {}", output_dir.display());
-    println!("  Run ID: {}\n", run_id);
-
-    // -------------------------------------------------------------------
-    // 4. Bootstrap executor (shared across all steps to reuse the worker)
-    // -------------------------------------------------------------------
     println!("{} Preparing runtime...", style("→").cyan());
     let mut executor = LocalExecutor::for_generation().await?;
 
-    // -------------------------------------------------------------------
-    // 5. Execute steps sequentially
-    // -------------------------------------------------------------------
     let mut step_outputs: HashMap<String, Vec<PathBuf>> = HashMap::new();
     let total_steps = wf.steps.len();
 
-    for (idx, step) in wf.steps.iter().enumerate() {
+    for (idx, (step, planned)) in wf.steps.iter().zip(plan.planned_steps.iter()).enumerate() {
         println!(
             "\n{} [{}/{}] {} ({})",
             style("▸").cyan().bold(),
@@ -104,13 +259,13 @@ pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
             step_kind_label(&step.kind),
         );
 
-        let step_labels = build_step_labels(&wf.name, &run_id, &step.id);
+        let step_labels = build_step_labels(&wf.name, &plan.run_id, &step.id);
+        let sub_jobs = &planned.sub_jobs;
 
         let mut step_artifacts: Vec<PathBuf> = Vec::new();
 
         match &step.kind {
             StepKind::Generate(g) => {
-                let sub_jobs = expand_seeds(g.seed, g.count, &g.seeds);
                 print_generate_preview(g, sub_jobs.len());
                 for (sub_idx, (seed, count)) in sub_jobs.iter().enumerate() {
                     if sub_jobs.len() > 1 {
@@ -125,23 +280,22 @@ pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
                     }
                     let spec = build_generate_spec(
                         &wf.model,
-                        &spec_model_id,
-                        base_model_path.clone(),
-                        arch_key.clone(),
-                        lora_ref.clone(),
+                        &plan.resolved_model_id,
+                        Some(plan.base_model_path.clone()),
+                        plan.arch_key.clone(),
+                        plan.lora_ref.clone(),
                         g,
                         *seed,
                         *count,
-                        &output_dir,
+                        &plan.output_dir,
                         step_labels.clone(),
                     );
-                    let artifacts = execute_generate_step(&mut executor, &spec, &step.id, &db)?;
+                    let artifacts = execute_generate_step(&mut executor, &spec, &step.id, db)?;
                     step_artifacts.extend(artifacts);
                 }
             }
             StepKind::Edit(e) => {
                 let source_path = resolve_image_ref(&e.source, &step_outputs, &step.id)?;
-                let sub_jobs = expand_seeds(e.seed, e.count, &e.seeds);
                 print_edit_preview(e, &source_path, sub_jobs.len());
                 for (sub_idx, (seed, count)) in sub_jobs.iter().enumerate() {
                     if sub_jobs.len() > 1 {
@@ -156,18 +310,18 @@ pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
                     }
                     let spec = build_edit_spec(
                         &wf.model,
-                        &spec_model_id,
-                        base_model_path.clone(),
-                        arch_key.clone(),
-                        lora_ref.clone(),
+                        &plan.resolved_model_id,
+                        Some(plan.base_model_path.clone()),
+                        plan.arch_key.clone(),
+                        plan.lora_ref.clone(),
                         e,
                         &source_path,
                         *seed,
                         *count,
-                        &output_dir,
+                        &plan.output_dir,
                         step_labels.clone(),
                     );
-                    let artifacts = execute_edit_step(&mut executor, &spec, &step.id, &db)?;
+                    let artifacts = execute_edit_step(&mut executor, &spec, &step.id, db)?;
                     step_artifacts.extend(artifacts);
                 }
             }
@@ -187,7 +341,7 @@ pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
     }
 
     // -------------------------------------------------------------------
-    // 6. Summary
+    // Summary
     // -------------------------------------------------------------------
     let total_artifacts: usize = step_outputs.values().map(|v| v.len()).sum();
     println!(
@@ -199,10 +353,247 @@ pub async fn run(spec_path: &str, _auto_pull: bool) -> Result<()> {
         total_artifacts,
         if total_artifacts == 1 { "" } else { "s" },
     );
-    println!("  {}", output_dir.display());
+    println!("  {}", plan.output_dir.display());
 
     Ok(())
 }
+
+// ---------------------------------------------------------------------------
+// Plan printers — human + JSON output for `--dry-run`.
+// ---------------------------------------------------------------------------
+
+fn print_plan_human(plan: &Plan) {
+    let wf = &plan.workflow;
+    println!("Workflow: {}", style(&wf.name).bold());
+    println!(
+        "  Model: {} ({})",
+        plan.resolved_model_id,
+        style("installed ✓").green()
+    );
+    if let Some(ref lora) = plan.lora_ref {
+        println!("  LoRA:  {} ({})", lora.name, style("installed ✓").green());
+    }
+    println!(
+        "  Total planned artifacts: {}",
+        style(plan.total_artifacts.to_string()).bold()
+    );
+
+    println!("\nSteps ({}):", wf.steps.len());
+    for (i, (step, planned)) in wf.steps.iter().zip(plan.planned_steps.iter()).enumerate() {
+        let kind_label = step_kind_label(&step.kind);
+        let expected = planned.expected_artifacts();
+        let (default_steps, default_guidance) = model_family::model_defaults(&wf.model);
+
+        match &step.kind {
+            StepKind::Generate(g) => {
+                let width = g.width.unwrap_or(1024);
+                let height = g.height.unwrap_or(1024);
+                let steps = g.steps.unwrap_or(default_steps);
+                let guidance = g.guidance.unwrap_or(default_guidance);
+                let seed_desc = if let Some(ref seeds) = g.seeds {
+                    format!("{} seeds {:?}", seeds.len(), seeds)
+                } else if let Some(s) = g.seed {
+                    format!("seed={} count={}", s, g.count.unwrap_or(1))
+                } else {
+                    format!("count={}", g.count.unwrap_or(1))
+                };
+                println!(
+                    "  [{}] {:<12} {:<8} {}  {}×{}  {} steps  g={}",
+                    i + 1,
+                    style(&step.id).cyan(),
+                    kind_label,
+                    seed_desc,
+                    width,
+                    height,
+                    steps,
+                    guidance
+                );
+                println!("      {}", style(truncate(&g.prompt, 80)).italic());
+            }
+            StepKind::Edit(e) => {
+                let steps = e.steps.unwrap_or(default_steps);
+                let guidance = e.guidance.unwrap_or(default_guidance);
+                let source = match &e.source {
+                    ImageRef::Local(p) => format!("local: {}", p.display()),
+                    ImageRef::StepOutput { step_id, index } => {
+                        format!("${step_id}.outputs[{index}]")
+                    }
+                };
+                let seed_desc = if let Some(ref seeds) = e.seeds {
+                    format!("{} seeds {:?}", seeds.len(), seeds)
+                } else if let Some(s) = e.seed {
+                    format!("seed={}", s)
+                } else {
+                    format!("count={}", e.count.unwrap_or(1))
+                };
+                println!(
+                    "  [{}] {:<12} {:<8} {}  {} steps  g={}",
+                    i + 1,
+                    style(&step.id).cyan(),
+                    kind_label,
+                    seed_desc,
+                    steps,
+                    guidance
+                );
+                println!("      source: {}", source);
+                println!("      {}", style(truncate(&e.prompt, 80)).italic());
+            }
+        }
+        let _ = expected;
+    }
+
+    println!(
+        "\n{} Workflow is valid. Run without --dry-run to execute.",
+        style("✓").green().bold()
+    );
+}
+
+fn print_plan_json(plan: &Plan) -> Result<()> {
+    let wf = &plan.workflow;
+    let (default_steps, default_guidance) = model_family::model_defaults(&wf.model);
+
+    let steps: Vec<StepJson> = wf
+        .steps
+        .iter()
+        .zip(plan.planned_steps.iter())
+        .map(|(step, planned)| match &step.kind {
+            StepKind::Generate(g) => StepJson {
+                id: step.id.clone(),
+                kind: "generate",
+                prompt: g.prompt.clone(),
+                source_ref: None,
+                seed: g.seed,
+                seeds: g.seeds.clone(),
+                effective: EffectiveJson {
+                    width: g.width.unwrap_or(1024),
+                    height: g.height.unwrap_or(1024),
+                    steps: g.steps.unwrap_or(default_steps),
+                    guidance: g.guidance.unwrap_or(default_guidance),
+                    count: g.count.unwrap_or(1),
+                },
+                expected_artifacts: planned.expected_artifacts(),
+            },
+            StepKind::Edit(e) => StepJson {
+                id: step.id.clone(),
+                kind: "edit",
+                prompt: e.prompt.clone(),
+                source_ref: Some(match &e.source {
+                    ImageRef::Local(p) => p.to_string_lossy().into_owned(),
+                    ImageRef::StepOutput { step_id, index } => {
+                        format!("${step_id}.outputs[{index}]")
+                    }
+                }),
+                seed: e.seed,
+                seeds: e.seeds.clone(),
+                effective: EffectiveJson {
+                    width: e.width.unwrap_or(0),
+                    height: e.height.unwrap_or(0),
+                    steps: e.steps.unwrap_or(default_steps),
+                    guidance: e.guidance.unwrap_or(default_guidance),
+                    count: e.count.unwrap_or(1),
+                },
+                expected_artifacts: planned.expected_artifacts(),
+            },
+        })
+        .collect();
+
+    let output = PlanJson {
+        valid: true,
+        workflow: WorkflowJson {
+            name: wf.name.clone(),
+            model: plan.resolved_model_id.clone(),
+            lora: plan.lora_ref.as_ref().map(|l| l.name.clone()),
+        },
+        total_planned_artifacts: plan.total_artifacts,
+        steps,
+    };
+
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn print_error_json(err: &PlanError) -> Result<()> {
+    let output = ErrorJson {
+        valid: false,
+        error: ErrorInfoJson {
+            kind: err.kind(),
+            message: format!("{err}"),
+            fix: err.fix(),
+        },
+    };
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max.saturating_sub(1)])
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON output types — stable schema for agent consumption.
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct PlanJson {
+    valid: bool,
+    workflow: WorkflowJson,
+    total_planned_artifacts: usize,
+    steps: Vec<StepJson>,
+}
+
+#[derive(Serialize)]
+struct WorkflowJson {
+    name: String,
+    model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    lora: Option<String>,
+}
+
+#[derive(Serialize)]
+struct StepJson {
+    id: String,
+    kind: &'static str,
+    prompt: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_ref: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seed: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    seeds: Option<Vec<u64>>,
+    effective: EffectiveJson,
+    expected_artifacts: usize,
+}
+
+#[derive(Serialize)]
+struct EffectiveJson {
+    width: u32,
+    height: u32,
+    steps: u32,
+    guidance: f32,
+    count: u32,
+}
+
+#[derive(Serialize)]
+struct ErrorJson {
+    valid: bool,
+    error: ErrorInfoJson,
+}
+
+#[derive(Serialize)]
+struct ErrorInfoJson {
+    kind: &'static str,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fix: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 /// Labels attached to every step's job row so the UI can group workflow outputs.
 fn build_step_labels(workflow_name: &str, run_id: &str, step_id: &str) -> HashMap<String, String> {


### PR DESCRIPTION
Re-targeted from the stacked chain after #79 merged.

Original PR: #80

## Summary
- `modl run --dry-run` validates workflows without side effects
- Agent-friendly JSON plan output via `--json`
- `build_plan` is pure (no GPU bootstrap, no DB writes, no mkdir)
- `PlanError` uses `thiserror`, structured error kinds

## Follow-up tracked
- Add `schema_version: 1` to `PlanJson` before agent docs go public