### PR TITLE
feat: schema_version in workflow plan JSON

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -210,6 +210,7 @@ modl run book-chapter-3.yaml --dry-run --json
 
 ```json
 {
+  "schema_version": 1,
   "valid": true,
   "workflow": { "name": "book-chapter-3", "model": "flux2-klein-4b", "lora": "my-son-v2" },
   "total_planned_artifacts": 13,
@@ -230,6 +231,7 @@ On failure:
 
 ```json
 {
+  "schema_version": 1,
   "valid": false,
   "error": {
     "kind": "lora_not_found",
@@ -251,6 +253,15 @@ On failure:
 The `fix:` field is a human-readable suggestion — optional, present when modl
 knows a likely remediation. The `kind` values are stable; agents can depend
 on them.
+
+### Schema version
+
+Both the success and error JSON outputs include a top-level `schema_version`
+integer. **Current version: `1`.** It bumps only on **breaking** changes
+(renamed or removed fields, type changes). Additive changes — a new optional
+field, a new `kind` enum value, a new `fix` for an existing kind — do **not**
+bump it. Agents should check `schema_version` and warn (or refuse) if they
+see a number higher than they were written against.
 
 ### Agent iteration loop
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -959,6 +959,7 @@ fn print_plan_json(plan: &Plan, in_order: bool) -> Result<()> {
     };
 
     let output = PlanJson {
+        schema_version: PLAN_JSON_SCHEMA_VERSION,
         valid: true,
         workflow: WorkflowJson {
             name: wf.name.clone(),
@@ -976,6 +977,7 @@ fn print_plan_json(plan: &Plan, in_order: bool) -> Result<()> {
 
 fn print_error_json(err: &PlanError) -> Result<()> {
     let output = ErrorJson {
+        schema_version: PLAN_JSON_SCHEMA_VERSION,
         valid: false,
         error: ErrorInfoJson {
             kind: err.kind(),
@@ -999,8 +1001,14 @@ fn truncate(s: &str, max: usize) -> String {
 // JSON output types — stable schema for agent consumption.
 // ---------------------------------------------------------------------------
 
+/// Version of the JSON schema emitted by `--dry-run --json`. Bump on any
+/// breaking change (renamed/removed fields, type changes). Additive changes
+/// (new optional fields) do NOT bump this.
+const PLAN_JSON_SCHEMA_VERSION: u32 = 1;
+
 #[derive(Serialize)]
 struct PlanJson {
+    schema_version: u32,
     valid: bool,
     workflow: WorkflowJson,
     total_planned_artifacts: usize,
@@ -1069,6 +1077,7 @@ struct EffectiveJson {
 
 #[derive(Serialize)]
 struct ErrorJson {
+    schema_version: u32,
     valid: bool,
     error: ErrorInfoJson,
 }


### PR DESCRIPTION
## Summary
- Top-level \`schema_version: 1\` on both \`PlanJson\` and \`ErrorJson\`
- Bumps only on breaking changes (renamed/removed fields, type changes); additive fields don't bump
- Doc updated with example output + a "Schema version" subsection explaining the contract

Locks the agent-facing contract before consumers depend on it (follow-up to #80/#83).

## Test plan
- [x] cargo build clean
- [ ] manual: \`modl run x.yaml --dry-run --json\` shows \`"schema_version": 1\` in both success and error output