### PR TITLE
fix: tune Chroma inference defaults (steps 40→20, guidance 5→4)

### DIFF
--- a/models.toml
+++ b/models.toml
@@ -79,7 +79,7 @@ capabilities = ["txt2img", "img2img", "inpaint", "lora", "training"]
 quality = 4
 speed = 2
 text_rendering = false
-defaults = { steps = 40, guidance = 5.0, resolution = 1024 }
+defaults = { steps = 20, guidance = 4.0, resolution = 1024 }
 
 # ─── Flux Fill ───────────────────────────────────────────────────────
 

--- a/python/modl_worker/adapters/arch_config.py
+++ b/python/modl_worker/adapters/arch_config.py
@@ -457,7 +457,7 @@ ARCH_CONFIGS: dict[str, dict] = {
         "train_text_encoder": False,
         "resolutions": [512, 768, 1024],
         "default_resolution": 1024,
-        "sample": {"sampler": "flowmatch", "steps": 25, "guidance": 4.0, "neg": ""},
+        "sample": {"sampler": "flowmatch", "steps": 20, "guidance": 4.0, "neg": ""},
         "inference": {"supports_negative_prompt": True, "default_negative_prompt": "low quality, ugly, unfinished, out of focus, deformed, disfigured, blurry"},
     },
     "qwen_image": {


### PR DESCRIPTION
Replaces #68, which was stale after the `models.toml` refactor.

## Summary
- `models.toml`: Chroma defaults steps 40→20, guidance 5.0→4.0
- `arch_config.py`: training sample config steps 25→20 (aligned)

Model card recommends 20-28 steps; 40 was overkill. Guidance sweet spot is 3.5–4.5 — 5.0 caused oversaturation.

## Test plan
- [ ] Generate with Chroma using defaults, verify quality at 20 steps
- [ ] Compare with previous 40-step output to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)