### PR TITLE
fix: modl info falls back to installed DB; refresh stale --help model lists

### DIFF
--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -10,11 +10,20 @@ pub async fn run(id: &str) -> Result<()> {
     let index = RegistryIndex::load_or_fetch().await?;
     let db = Database::open()?;
 
-    // Try registry first, fall back to trained artifact lookup
-    match index.find(id) {
-        Some(manifest) => show_registry_model(&db, id, manifest),
-        None => show_trained_artifact(&db, id),
+    // 1. Registry match — the rich path.
+    if let Some(manifest) = index.find(id) {
+        return show_registry_model(&db, id, manifest);
     }
+
+    // 2. Installed locally but missing from the registry (stale cache,
+    //    sideloaded pull, or model added upstream since last update).
+    //    Show what we can from the DB + models.toml specs.
+    if let Some(installed) = db.list_installed(None)?.into_iter().find(|m| m.id == id) {
+        return show_installed_model(&installed);
+    }
+
+    // 3. Trained LoRA artifact.
+    show_trained_artifact(&db, id)
 }
 
 fn show_registry_model(
@@ -297,6 +306,125 @@ fn show_registry_model(
             println!(
                 "    {}",
                 style(format!("modl train --base {} --dataset ./my-images", id)).dim()
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Show info for a model that's installed locally but not present in the
+/// cached registry index. Falls back to DB fields + models.toml specs.
+fn show_installed_model(model: &crate::core::db::InstalledModel) -> Result<()> {
+    println!(
+        "{} {}",
+        style(&model.name).bold().cyan(),
+        style("[installed]").green()
+    );
+    println!(
+        "  {} · {}",
+        style(&model.asset_type).dim(),
+        style(&model.id).dim()
+    );
+    println!();
+    println!(
+        "  {} Not in registry index — showing installed metadata only.",
+        style("ℹ").yellow()
+    );
+    println!(
+        "  {} {} to refresh the registry.",
+        style("Run").dim(),
+        style("modl system update").cyan()
+    );
+    println!();
+
+    // Specs from models.toml when available.
+    if let Some(spec) = model_family::find_model(&model.id) {
+        println!("  {}", style("Specs:").bold());
+        if spec.text_encoder_b > 0.0 {
+            println!(
+                "    Parameters:    {:.0}B transformer + {:.0}B text encoder ({:.0}B total)",
+                spec.transformer_b, spec.text_encoder_b, spec.total_b
+            );
+        } else {
+            println!("    Parameters:    {:.0}B", spec.total_b);
+        }
+        if spec.vram_fp8_gb > 0 {
+            println!(
+                "    VRAM:          {}GB bf16 / {}GB fp8",
+                spec.vram_bf16_gb, spec.vram_fp8_gb
+            );
+        } else {
+            println!("    VRAM:          {}GB bf16", spec.vram_bf16_gb);
+        }
+        let mut caps = Vec::new();
+        if spec.capabilities.txt2img {
+            caps.push("generate");
+        }
+        if spec.capabilities.edit {
+            caps.push("edit");
+        }
+        if spec.capabilities.img2img {
+            caps.push("img2img");
+        }
+        if spec.capabilities.inpaint {
+            caps.push("inpaint");
+        }
+        if spec.capabilities.lora {
+            caps.push("lora");
+        }
+        if spec.capabilities.training {
+            caps.push("training");
+        }
+        if !caps.is_empty() {
+            println!("    Capabilities:  {}", caps.join(", "));
+        }
+        println!(
+            "    Defaults:      {} steps, {:.1} CFG, {}px",
+            spec.default_steps, spec.default_guidance, spec.default_resolution
+        );
+        println!();
+    }
+
+    println!("  {}", style("Installed:").bold().green());
+    if let Some(ref v) = model.variant {
+        println!("    Variant:  {}", v);
+    }
+    println!("    Size:     {}", HumanBytes(model.size));
+    println!("    Path:     {}", model.store_path);
+
+    // Usage examples (mirror the registry-path behavior).
+    if let Some(spec) = model_family::find_model(&model.id) {
+        println!();
+        println!("  {}", style("Usage:").bold());
+        if spec.capabilities.txt2img {
+            println!(
+                "    {}",
+                style(format!(
+                    "modl generate \"a photo of a sunset\" --base {}",
+                    model.id
+                ))
+                .dim()
+            );
+        }
+        if spec.capabilities.edit {
+            println!(
+                "    {}",
+                style(format!(
+                    "modl edit \"change background to white\" --image photo.jpg --base {}",
+                    model.id
+                ))
+                .dim()
+            );
+        }
+        if spec.capabilities.training {
+            println!(
+                "    {}",
+                style(format!(
+                    "modl train --base {} --dataset ./my-images",
+                    model.id
+                ))
+                .dim()
             );
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -528,14 +528,8 @@ pub enum Commands {
     ///   img2img:    modl generate "prompt" --init-image photo.png --strength 0.6
     ///   inpainting: modl generate "prompt" --init-image photo.png --mask mask.png
     ///
-    /// Models:
-    ///   flux-schnell (default)   4 steps, 12B, fastest
-    ///   flux-dev                28 steps, 12B, best quality
-    ///   z-image-turbo            8 steps, 6B, fast
-    ///   z-image                 30 steps, 6B, quality
-    ///   qwen-image              40 steps, 20B, text rendering
-    ///   chroma                  45 steps, 12B, artistic
-    ///   sdxl                    30 steps, 3.5B, huge LoRA ecosystem
+    /// To see available models: `modl ls` (installed), `modl search <query>`
+    /// (registry), or `modl info <id>` (details for one model).
     ///
     /// Use --lora to apply a trained LoRA. Use --controlnet for structural guidance.
     #[command(verbatim_doc_comment, after_help = GENERATE_EXAMPLES)]
@@ -630,11 +624,8 @@ pub enum Commands {
     /// Unlike generate --mask (pixel-level inpainting), edit uses instruction-following
     /// models that understand "change X to Y" without needing a mask.
     ///
-    /// Models:
-    ///   qwen-image-edit-2511 (default)  40 steps, 20B, best quality
-    ///   klein-4b                         4 steps, 4B, fastest
-    ///   klein-9b                         4 steps, 9B, balanced
-    ///   flux2-dev                       28 steps, 24B, flux-based
+    /// To see available edit models: `modl ls` (installed), `modl search edit`
+    /// (registry), or `modl info <id>` (details for one model).
     ///
     /// Examples:
     ///   modl edit "make the sky sunset orange" --image photo.png


### PR DESCRIPTION
## Summary

Two small CLI paper cuts discovered while working with a locally installed `ernie-image`:

1. **`modl info <installed-model>` fails with a misleading error** when the model is present in the installed DB (as shown by `modl ls`) but absent from the cached registry index. This happens whenever the registry has moved on from the user's cached `index.json` (stale cache) or for sideloaded models that were never in the registry. The existing fallthrough goes straight to trained-artifact lookup and surfaces `'ernie-image' not found in registry or trained outputs. Run \`modl system update\` first?` — confusing, because `modl system update` may or may not help (depending on GitHub's raw content cache) and the model is clearly installed.

2. **`modl generate --help` and `modl edit --help` hardcode a curated list of models** in their clap doc comments. That list has gone stale: no ERNIE-Image, no Klein 4B/9B, no qwen-image-edit, etc. Every new model PR would need to remember to update it, and every time it's missed the CLI lies about what's supported.

## Fix

1. **`info` fallback chain** now:
   - Registry match → full rich output (unchanged)
   - **New:** installed-DB match → render from `InstalledModel` + `models.toml` specs with a hint to run `modl system update`
   - Trained artifact match → unchanged
   - Only fails if all three miss

2. **Doc comments** on `Generate` and `Edit` no longer embed a model list. They point at `modl ls` (installed), `modl search <query>` (registry), and `modl info <id>` (per-model detail) — commands that reflect live state.

## Before / after

\`\`\`console
$ modl info ernie-image  # (before)
Error: 'ernie-image' not found in registry or trained outputs. Run \`modl system update\` first?

$ modl info ernie-image  # (after)
ERNIE-Image [installed]
  diffusion_model · ernie-image

  ℹ Not in registry index — showing installed metadata only.
  Run modl system update to refresh the registry.

  Specs:
    Parameters:    8B transformer + 3B text encoder (11B total)
    VRAM:          28GB bf16 / 16GB fp8
    Capabilities:  generate
    Defaults:      50 steps, 4.0 CFG, 1024px

  Installed:
    Variant:  gguf-q4-k-m
    Size:     4.67 GiB
    Path:     /home/…/store/diffusion_model/…/ernie-image-Q4_K_M.gguf

  Usage:
    modl generate "a photo of a sunset" --base ernie-image
\`\`\`

\`\`\`
# before
$ modl generate --help | sed -n '/Models:/,/Use --lora/p'
Models:
  flux-schnell (default)   4 steps, 12B, fastest
  flux-dev                28 steps, 12B, best quality
  z-image-turbo            8 steps, 6B, fast
  z-image                 30 steps, 6B, quality
  qwen-image              40 steps, 20B, text rendering
  chroma                  45 steps, 12B, artistic
  sdxl                    30 steps, 3.5B, huge LoRA ecosystem

# after
$ modl generate --help | grep -A2 "available models"
To see available models: \`modl ls\` (installed), \`modl search <query>\`
(registry), or \`modl info <id>\` (details for one model).
\`\`\`

## Out of scope (known follow-ups)

A third paper cut surfaced during this investigation but is out of scope here because it touches the Python worker:

- **Persistent worker does not auto-evict on `--base` change with insufficient VRAM.** Repro: `modl generate … --base qwen-image` (loads 20B), then `modl generate … --base ernie-image` → CUDA OOM. The LRU cache honors `max_models` count but not available VRAM. Workaround today is `modl worker stop` between runs. A proper fix needs VRAM-aware eviction in `python/modl_worker/serve.py`. Happy to file as a separate issue.

- **`load_or_fetch` bails if the remote is unreachable,** even when the user is only asking about an installed model. Low-pri but worth a follow-up: on fetch failure, degrade to cached index + installed DB instead of hard-failing.

## Test plan

- [x] `cargo build --release`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `cargo test` (155 passed, 0 failed)
- [x] `modl info ernie-image` — now renders installed model info
- [x] `modl info flux-schnell` — registry path unchanged
- [x] `modl info nonexistent-xyz` — still produces the trained-artifact error
- [x] `modl generate --help` / `modl edit --help` — new guidance displayed

🤖 Generated with [Claude Code](https://claude.com/claude-code)