### PR TITLE
feat: VRAM-aware model cache eviction and OOM recovery

### DIFF
--- a/python/modl_worker/serve.py
+++ b/python/modl_worker/serve.py
@@ -177,6 +177,11 @@ class ModelCache:
             if len(self._cache) >= self._max_models:
                 self._evict_lru(emitter)
 
+            # VRAM-aware eviction: loading a fresh model while a large one is
+            # already resident OOMs even within the max_models count limit.
+            # Evict LRU models until there's headroom before attempting load.
+            self._ensure_vram_headroom(emitter)
+
             # Load fresh pipeline
             emitter.info(f"Model cache MISS: loading {base_model_id}...")
             cls_name = _resolve_pipeline_class(base_model_id)
@@ -187,7 +192,9 @@ class ModelCache:
             is_native_inpaint = "Fill" in cls_name
 
             if is_native_inpaint:
-                pipe = load_pipeline(base_model_id, base_model_path, cls_name, emitter)
+                pipe = self._load_with_oom_recovery(
+                    base_model_id, base_model_path, cls_name, emitter
+                )
                 now = time.time()
                 cached = CachedPipeline(
                     pipeline=pipe,
@@ -201,7 +208,9 @@ class ModelCache:
                 return pipe, cls_name
 
             # Standard model: load txt2img base first, then switch if needed
-            pipe = load_pipeline(base_model_id, base_model_path, cls_name, emitter)
+            pipe = self._load_with_oom_recovery(
+                base_model_id, base_model_path, cls_name, emitter
+            )
             now = time.time()
 
             cached = CachedPipeline(
@@ -342,6 +351,84 @@ class ModelCache:
         del self._cache[lru_key]
         gc.collect()
         torch.cuda.empty_cache()
+
+    # Minimum free VRAM (MB) we want before attempting to load a new model.
+    # Diffusion pipelines need a few GB of headroom for activations on top
+    # of weights; 4 GB covers small/quantized models. Bigger models still
+    # get a second chance via _load_with_oom_recovery.
+    _VRAM_HEADROOM_MB = 4096
+
+    def _free_vram_mb(self) -> int | None:
+        """Return currently free VRAM in MB, or None when unprobeable
+        (CPU-only host, CUDA driver missing, nvml failure). None disables
+        the pre-flight check so CPU/MPS paths still work."""
+        try:
+            import torch
+            if not torch.cuda.is_available():
+                return None
+            free, _total = torch.cuda.mem_get_info()
+            return int(free // (1024 * 1024))
+        except Exception:
+            return None
+
+    def _ensure_vram_headroom(self, emitter: EventEmitter) -> None:
+        """Evict LRU diffusion models until free VRAM >= headroom or cache empty.
+
+        Called before loading a fresh pipeline so a big model sitting in
+        VRAM doesn't cause the new load to OOM inside diffusers (where the
+        error is harder to recover from cleanly)."""
+        free_mb = self._free_vram_mb()
+        if free_mb is None:
+            return
+        while self._cache and free_mb < self._VRAM_HEADROOM_MB:
+            emitter.info(
+                f"Low VRAM ({free_mb} MB free, need {self._VRAM_HEADROOM_MB} MB) — evicting LRU"
+            )
+            self._evict_lru(emitter)
+            free_mb = self._free_vram_mb()
+            if free_mb is None:
+                return
+
+    def _load_with_oom_recovery(
+        self,
+        base_model_id: str,
+        base_model_path: Any,
+        cls_name: str,
+        emitter: EventEmitter,
+    ) -> Any:
+        """Load a pipeline; on CUDA OOM, evict everything and retry once.
+
+        Covers the case where _ensure_vram_headroom's static threshold
+        wasn't enough for a particularly large model, by falling back to
+        a cold cache before giving up."""
+        import gc
+        import torch
+        from modl_worker.adapters.pipeline_loader import load_pipeline
+
+        try:
+            return load_pipeline(base_model_id, base_model_path, cls_name, emitter)
+        except torch.cuda.OutOfMemoryError as exc:
+            if not self._cache:
+                # Nothing left to evict — propagate with a clearer message.
+                raise RuntimeError(
+                    f"CUDA out of memory loading {base_model_id}: {exc}. "
+                    f"Try a smaller variant (fp8/GGUF) or run with --no-worker."
+                ) from exc
+            emitter.warning(
+                "VRAM_RETRY",
+                f"CUDA OOM loading {base_model_id} — evicting all cached models and retrying.",
+            )
+            self.evict_all(emitter)
+            gc.collect()
+            torch.cuda.empty_cache()
+            try:
+                return load_pipeline(base_model_id, base_model_path, cls_name, emitter)
+            except torch.cuda.OutOfMemoryError as exc2:
+                raise RuntimeError(
+                    f"CUDA out of memory loading {base_model_id} even after evicting "
+                    f"cached models: {exc2}. Try a smaller variant (fp8/GGUF) or a "
+                    f"larger GPU."
+                ) from exc2
 
     @staticmethod
     def _estimate_vram(pipeline: Any) -> int:

--- a/python/tests/test_serve_vram.py
+++ b/python/tests/test_serve_vram.py
@@ -1,0 +1,194 @@
+"""Tests for ModelCache VRAM-aware eviction and OOM recovery."""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+# If torch isn't importable (CPU-only CI, minimal env), install a lightweight
+# stub so ModelCache's deferred `import torch` inside its methods doesn't
+# crash. When torch IS installed we leave it alone — polluting sys.modules
+# would break every other test that exercises real diffusers code.
+try:
+    import torch  # noqa: F401
+except ImportError:
+    torch_stub = types.ModuleType("torch")
+    cuda_stub = types.ModuleType("torch.cuda")
+    cuda_stub.is_available = lambda: True
+    cuda_stub.mem_get_info = lambda: (0, 0)
+    cuda_stub.empty_cache = lambda: None
+    cuda_stub.memory_allocated = lambda: 0
+    cuda_stub.OutOfMemoryError = type("OutOfMemoryError", (RuntimeError,), {})
+    torch_stub.cuda = cuda_stub
+    sys.modules["torch"] = torch_stub
+    sys.modules["torch.cuda"] = cuda_stub
+
+
+def _install_loader_stub(load_pipeline_impl):
+    """Replace modl_worker.adapters.pipeline_loader with a stub module.
+
+    The real loader depends on diffusers and is unsafe to import in a CPU-only
+    test environment. Serve.py does a deferred `from … import load_pipeline`
+    inside _load_with_oom_recovery, so replacing the sys.modules entry is
+    enough."""
+    pkg = sys.modules.get("modl_worker.adapters")
+    if pkg is None:
+        pkg = types.ModuleType("modl_worker.adapters")
+        sys.modules["modl_worker.adapters"] = pkg
+    loader = types.ModuleType("modl_worker.adapters.pipeline_loader")
+    loader.load_pipeline = load_pipeline_impl
+    sys.modules["modl_worker.adapters.pipeline_loader"] = loader
+    pkg.pipeline_loader = loader
+
+
+from modl_worker.protocol import EventEmitter  # noqa: E402
+from modl_worker.serve import CacheKey, CachedPipeline, ModelCache  # noqa: E402
+
+
+class _RecordingEmitter(EventEmitter):
+    """Captures events in-memory for assertions."""
+
+    def __init__(self) -> None:
+        super().__init__(source="test", job_id="")
+        self.events: list[dict] = []
+
+    def emit(self, event: dict) -> None:
+        self.events.append(event)
+
+
+def _stub_pipeline(tag: str = "fake") -> object:
+    """Cheap sentinel for a diffusers pipeline."""
+    return types.SimpleNamespace(kind=tag)
+
+
+def _seed_cache(cache: ModelCache, ids: list[str]) -> None:
+    """Pre-populate the cache with fake pipelines so eviction has victims."""
+    now = 0.0
+    for i, model_id in enumerate(ids):
+        key = CacheKey(model_id=model_id, dtype="bfloat16", mode="txt2img")
+        now += 1.0
+        cache._cache[key] = CachedPipeline(
+            pipeline=_stub_pipeline(model_id),
+            cls_name="FakePipeline",
+            loaded_at=now,
+            last_used=now,
+            vram_estimate_mb=8000,
+        )
+
+
+def test_ensure_vram_headroom_no_eviction_when_plenty_free():
+    cache = ModelCache(max_models=4)
+    _seed_cache(cache, ["a", "b"])
+    emitter = _RecordingEmitter()
+
+    # Simulate 20 GB free — well above the 4 GB headroom.
+    with patch.object(ModelCache, "_free_vram_mb", return_value=20_000):
+        cache._ensure_vram_headroom(emitter)
+
+    assert len(cache._cache) == 2, "no models should be evicted when VRAM is plentiful"
+
+
+def test_ensure_vram_headroom_evicts_lru_until_enough_free():
+    cache = ModelCache(max_models=4)
+    _seed_cache(cache, ["oldest", "newer", "newest"])
+    emitter = _RecordingEmitter()
+
+    # 500 MB free to start — below 4 GB headroom; rises after each eviction.
+    free_values = iter([500, 2_000, 5_000])
+
+    def fake_free_mb(self):
+        return next(free_values)
+
+    with patch.object(ModelCache, "_free_vram_mb", fake_free_mb):
+        cache._ensure_vram_headroom(emitter)
+
+    # 500 → evict → 2000 (still < 4096) → evict → 5000 → stop. One model left.
+    assert len(cache._cache) == 1
+    remaining_ids = [k.model_id for k in cache._cache.keys()]
+    assert remaining_ids == ["newest"], "oldest entries should evict first"
+
+
+def test_ensure_vram_headroom_stops_when_cache_empty():
+    cache = ModelCache(max_models=4)
+    _seed_cache(cache, ["only"])
+    emitter = _RecordingEmitter()
+
+    # Free VRAM never crosses the headroom — would loop forever without the
+    # cache-empty guard.
+    with patch.object(ModelCache, "_free_vram_mb", return_value=100):
+        cache._ensure_vram_headroom(emitter)
+
+    assert cache._cache == {}, "cache should be empty after exhausting evictions"
+
+
+def test_ensure_vram_headroom_skips_when_cuda_unavailable():
+    cache = ModelCache(max_models=4)
+    _seed_cache(cache, ["a", "b"])
+    emitter = _RecordingEmitter()
+
+    # _free_vram_mb returns None when CUDA is unavailable — no eviction.
+    with patch.object(ModelCache, "_free_vram_mb", return_value=None):
+        cache._ensure_vram_headroom(emitter)
+
+    assert len(cache._cache) == 2, "CPU-only hosts must not trigger eviction"
+
+
+def test_load_with_oom_recovery_retries_after_evicting_all():
+    cache = ModelCache(max_models=4)
+    _seed_cache(cache, ["stale"])
+    emitter = _RecordingEmitter()
+
+    import torch
+    calls = {"n": 0}
+    succeeded_pipeline = _stub_pipeline("new")
+
+    def flaky_loader(model_id, path, cls_name, em):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise torch.cuda.OutOfMemoryError("simulated OOM")
+        return succeeded_pipeline
+
+    _install_loader_stub(flaky_loader)
+    result = cache._load_with_oom_recovery(
+        "new-model", None, "FakePipeline", emitter
+    )
+
+    assert result is succeeded_pipeline
+    assert calls["n"] == 2, "should have retried exactly once"
+    assert cache._cache == {}, "retry path must evict everything before retrying"
+
+
+def test_load_with_oom_recovery_raises_on_second_oom():
+    cache = ModelCache(max_models=4)
+    _seed_cache(cache, ["stale"])
+    emitter = _RecordingEmitter()
+
+    import torch
+
+    def always_oom(model_id, path, cls_name, em):
+        raise torch.cuda.OutOfMemoryError("won't fit at any price")
+
+    _install_loader_stub(always_oom)
+    with pytest.raises(RuntimeError, match="even after evicting"):
+        cache._load_with_oom_recovery(
+            "huge-model", None, "FakePipeline", emitter
+        )
+
+
+def test_load_with_oom_recovery_raises_when_cache_already_empty():
+    cache = ModelCache(max_models=4)
+    emitter = _RecordingEmitter()
+
+    import torch
+
+    def always_oom(model_id, path, cls_name, em):
+        raise torch.cuda.OutOfMemoryError("nothing to evict")
+
+    _install_loader_stub(always_oom)
+    with pytest.raises(RuntimeError, match="CUDA out of memory loading huge-model"):
+        cache._load_with_oom_recovery(
+            "huge-model", None, "FakePipeline", emitter
+        )


### PR DESCRIPTION
## Summary
- Proactive VRAM headroom check before loading new models — evicts LRU cached pipelines until free VRAM >= 4GB threshold
- OOM recovery: on CUDA OOM during pipeline load, evicts all cached models and retries once before failing with an actionable error message
- Gracefully skips VRAM checks on CPU-only hosts (returns `None`, no eviction triggered)

Split out from #91 (compose PR) to keep concerns separate.

## Test plan
- [x] Unit tests for VRAM headroom eviction (plenty free, evict until enough, empty cache guard, CPU-only skip)
- [x] Unit tests for OOM recovery (retry success, double OOM failure, empty cache failure)
- [ ] Manual test with large model swap on GPU (e.g. Qwen 20B → Flux Dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)