### PR TITLE
docs: fix link command syntax + document storage.root and uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,11 +152,34 @@ Every command supports `--json` for scripting and agent pipelines.
 ## Already Have Models?
 
 ```bash
-modl link --comfyui ~/ComfyUI
-modl link --a1111 ~/stable-diffusion-webui
+modl system link --comfyui ~/ComfyUI
+modl system link --a1111 ~/stable-diffusion-webui
 ```
 
 modl scans your model folders, hashes files, and moves recognized models into the store — replacing them with symlinks. Your tools keep working, nothing breaks.
+
+---
+
+## Storage Location
+
+By default, models live in `~/modl/store/`. To put them on a bigger disk:
+
+```bash
+modl config storage.root /srv/disk2/modl-store
+```
+
+Existing models are not moved automatically — set this before pulling, or move the directory and update the config.
+
+---
+
+## Uninstall
+
+```bash
+sudo rm -rf /usr/local/bin/modl /usr/local/bin/python   # binary + bundled Python runtime
+rm -rf ~/modl                                           # model store, configs, DB
+```
+
+If you set a custom `storage.root`, remove that path too.
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix README to use \`modl system link\` (the command was moved under \`system\` in the 0.2.0 restructure but the README still advertised the old top-level form)
- Add a **Storage Location** section explaining \`modl config storage.root\` for users who don't want models on the home SSD
- Add an **Uninstall** section — the install path wasn't documented anywhere

Fixes #95

## Test plan
- [x] \`grep "modl link" README.md\` returns nothing
- [x] \`modl system link --help\` matches the documented syntax
- [x] \`modl config storage.root\` is a real config key (verified in src/cli/config.rs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)