### PR TITLE
feat: multi-user store, modl status, MCP workflow tools, export ZIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1526,6 +1526,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "axum",
+ "base64",
  "chrono",
  "clap",
  "comfy-table",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ libc = "0.2"
 # LLM runtime (behind feature flag — heavy compile)
 llama-cpp-2 = { version = "0.1", optional = true }
 walkdir = "2.5.0"
+base64 = "0.22.1"
 
 [features]
 default = []

--- a/skills/modl/SKILL.md
+++ b/skills/modl/SKILL.md
@@ -60,6 +60,13 @@ triggers:
   - modl serve
   - modl dataset
   - modl gpu
+  - modl run
+  - modl status
+  - run a workflow
+  - batch generate
+  - multi-step workflow
+  - generate then edit
+  - fire and forget
 invocable: true
 argument-hint: "[action] [args...]"
 ---
@@ -500,6 +507,64 @@ Backup and restore.
 modl export <output.tar.zst> [--no-outputs] [--since YYYY-MM-DD]
 modl import <backup.tar.zst> [--dry-run] [--overwrite]
 ```
+
+### modl run
+
+Run a multi-step workflow from a YAML spec.
+
+```
+modl run <SPEC.yaml> [--json]
+modl run a.yaml b.yaml c.yaml      # sequential multi-spec
+
+YAML format:
+  name: "optional-display-name"
+  steps:
+    - id: draft
+      generate:
+        prompt: "..."
+        base: flux-schnell
+        size: "1:1"
+        count: 1
+        seed: 42          # optional
+    - id: refine
+      edit:
+        prompt: "enhance lighting"
+        base: klein-9b
+        image:
+          step_output: draft   # ← reference previous step output
+```
+
+JSON output: `{"run_id": "run-20260506-143022", "steps": 2, "status": "queued"}`
+
+### modl status
+
+Check the state of a workflow run.
+
+```
+modl status <run_id> [--json] [--watch]
+```
+
+`aggregate` values: `pending`, `running`, `completed`, `partial_failure`, `cancelled`
+
+### modl outputs export / ls
+
+```
+modl outputs export <run_id>           # download as ZIP
+modl outputs ls --run <run_id> --json  # list with URLs
+```
+
+### MCP Server
+
+modl exposes 15 tools over stdio JSON-RPC 2.0. Activate via `modl mcp` (configured in Claude Code's MCP settings).
+
+**Workflow tools:**
+- `run_workflow` — submit YAML spec, returns `run_id` (fire-and-forget)
+- `job_status` — poll a job or run_id for progress
+- `list_run_outputs` — fetch artifact URLs for a completed run
+
+Set `MODL_BASE_URL=http://server:3939` so returned URLs are reachable from the client.
+
+**Image ref limitation (issue #105):** `edit.image.path` must point to a path on the server where modl runs. Over a remote MCP/SSH connection, client-side file paths don't exist on the server. Workaround: use `step_output` refs to chain generate→edit within the same workflow, or pre-copy the source image to the server first.
 
 ## Common Workflows
 

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,10 +1,10 @@
 use anyhow::Result;
 use console::style;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use crate::core::config::Config;
 use crate::core::db::Database;
-use crate::core::registry::RegistryIndex;
+use crate::core::reconcile;
 use crate::core::store::Store;
 use crate::core::symlink;
 
@@ -142,64 +142,7 @@ pub async fn run(verify_hashes: bool, repair: bool) -> Result<()> {
             "{} Repairing — registering orphaned files...",
             style("→").cyan()
         );
-        let mut repaired = 0;
-
-        // Build a hash-prefix → (id, name, variant) lookup from the registry
-        let registry_lookup = build_registry_lookup();
-
-        for (store_path, asset_type, hash_prefix, file_name, size) in &orphans {
-            // Use the directory name as the SHA256 prefix — the store is
-            // content-addressed so the dir name IS the hash. Full verification
-            // can be done later with --verify-hashes. This avoids hashing
-            // multi-GB files during repair.
-            let sha256 = hash_prefix.clone();
-
-            // Try to match against the registry for proper ID/name
-            let (id, display_name, variant) = if let Some((reg_id, reg_name, reg_variant)) =
-                registry_lookup.get(hash_prefix.as_str())
-            {
-                (reg_id.clone(), reg_name.clone(), reg_variant.clone())
-            } else {
-                // Fallback: derive from filename
-                let stem = file_name
-                    .strip_suffix(".safetensors")
-                    .or_else(|| file_name.strip_suffix(".ckpt"))
-                    .or_else(|| file_name.strip_suffix(".bin"))
-                    .or_else(|| file_name.strip_suffix(".pt"))
-                    .unwrap_or(file_name);
-                let id = format!("local/{}/{}", asset_type, stem);
-                let display_name = stem.to_string();
-                (id, display_name, None)
-            };
-
-            if let Err(e) = db.insert_installed(&crate::core::db::InstalledModelRecord {
-                id: &id,
-                name: &display_name,
-                asset_type,
-                variant: variant.as_deref(),
-                sha256: &sha256,
-                size: *size,
-                file_name,
-                store_path,
-            }) {
-                println!(
-                    "  {} Failed to register {}: {}",
-                    style("✗").red(),
-                    file_name,
-                    e
-                );
-            } else {
-                println!(
-                    "  {} Registered [{}] {} ({})",
-                    style("✓").green(),
-                    asset_type,
-                    display_name,
-                    format_size(*size)
-                );
-                repaired += 1;
-            }
-        }
-
+        let repaired = reconcile::reconcile_store(&db).unwrap_or(0);
         println!();
         if repaired > 0 {
             println!(
@@ -207,7 +150,7 @@ pub async fn run(verify_hashes: bool, repair: bool) -> Result<()> {
                 style("✓").green(),
                 repaired,
                 if repaired == 1 { "" } else { "s" },
-                style("modl model list").cyan()
+                style("modl ls").cyan()
             );
         }
     }
@@ -334,38 +277,4 @@ fn scan_orphans(
             }
         }
     }
-}
-
-/// Build a HashMap from SHA256 prefix (16 chars) → (id, name, variant_label)
-/// by scanning the local registry index. Returns empty map if index is unavailable.
-fn build_registry_lookup() -> HashMap<String, (String, String, Option<String>)> {
-    let mut map = HashMap::new();
-    let Ok(index) = RegistryIndex::load() else {
-        return map;
-    };
-    for manifest in &index.items {
-        // Single-file models (LoRAs, VAEs, etc.)
-        if let Some(ref file) = manifest.file
-            && file.sha256.len() >= 16
-        {
-            map.insert(
-                file.sha256[..16].to_string(),
-                (manifest.id.clone(), manifest.name.clone(), None),
-            );
-        }
-        // Multi-variant models (checkpoints, text encoders)
-        for variant in &manifest.variants {
-            if variant.sha256.len() >= 16 {
-                map.insert(
-                    variant.sha256[..16].to_string(),
-                    (
-                        manifest.id.clone(),
-                        manifest.name.clone(),
-                        Some(variant.id.clone()),
-                    ),
-                );
-            }
-        }
-    }
-    map
 }

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -412,6 +412,7 @@ async fn execute_edit(
         &spec_json,
         target_str.trim_matches('"'),
         None,
+        None,
     )?;
 
     // Event loop

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -769,6 +769,7 @@ async fn execute_generate(
         &spec_json,
         target_str.trim_matches('"'),
         None,
+        None,
     )?;
 
     // -------------------------------------------------------------------

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -45,10 +45,13 @@ const INTERNAL_TYPES: &[&str] = &[
 pub async fn run(type_filter: Option<AssetType>, show_all: bool) -> Result<()> {
     let db = Database::open()?;
 
-    // Silently register any store files not yet tracked (supports symlinked stores).
-    if let Ok(n) = reconcile::reconcile_store(&db)
-        && n > 0
-    {
+    // Sync any store entries not yet in the local DB from the shared index.yaml.
+    // This is an O(index-size) read — no directory walking. Falls back to a full
+    // scan only when the index doesn't exist yet (first run on a bare store).
+    let n = reconcile::reconcile_from_index(&db)
+        .or_else(|_| reconcile::reconcile_store(&db))
+        .unwrap_or(0);
+    if n > 0 {
         println!(
             "  {} Auto-registered {} model{} found on disk",
             style("ℹ").dim(),

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -5,6 +5,7 @@ use indicatif::HumanBytes;
 
 use crate::core::db::Database;
 use crate::core::manifest::AssetType;
+use crate::core::reconcile;
 
 /// Display sections for user-visible grouping
 struct Section {
@@ -43,6 +44,20 @@ const INTERNAL_TYPES: &[&str] = &[
 
 pub async fn run(type_filter: Option<AssetType>, show_all: bool) -> Result<()> {
     let db = Database::open()?;
+
+    // Silently register any store files not yet tracked (supports symlinked stores).
+    if let Ok(n) = reconcile::reconcile_store(&db)
+        && n > 0
+    {
+        println!(
+            "  {} Auto-registered {} model{} found on disk",
+            style("ℹ").dim(),
+            n,
+            if n == 1 { "" } else { "s" }
+        );
+        println!();
+    }
+
     let filter_str = type_filter.as_ref().map(|t| t.to_string());
     let models = db.list_installed(filter_str.as_deref())?;
 

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -932,9 +932,13 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         .map_err(|e| (-32603, format!("Failed to write workflow tempfile: {e}")))?;
     let tmp_path = tmp.path().to_path_buf();
 
-    // Pre-generate the run_id using the same timestamp format as run.rs.
-    // We pass it explicitly so the background process uses the same ID we return.
-    let run_id = format!("mcp-{}", Local::now().format("%Y%m%d-%H%M%S"));
+    // Pre-generate the run_id. Includes a short random suffix to prevent
+    // collisions when two workflows are submitted within the same second.
+    let run_id = format!(
+        "mcp-{}-{}",
+        Local::now().format("%Y%m%d-%H%M%S"),
+        &uuid::Uuid::new_v4().to_string()[..6]
+    );
 
     // Log file for background output — useful for debugging.
     let log_path = crate::core::paths::modl_root()

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -922,13 +922,15 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         .and_then(|v| v.as_str())
         .ok_or((-32602, "Missing required parameter: spec_yaml".to_string()))?;
 
-    // Write the YAML to a tempfile.
-    let tmp_path = std::env::temp_dir().join(format!(
-        "modl-workflow-{}.yaml",
-        Local::now().format("%Y%m%d-%H%M%S-%f")
-    ));
-    std::fs::write(&tmp_path, spec_yaml)
+    // Write the YAML to a tempfile. NamedTempFile auto-deletes on drop,
+    // so we keep `tmp` alive past the 500ms early-exit check then let it drop.
+    let mut tmp = tempfile::Builder::new()
+        .suffix(".yaml")
+        .tempfile()
+        .map_err(|e| (-32603, format!("Failed to create tempfile: {e}")))?;
+    std::io::Write::write_all(&mut tmp, spec_yaml.as_bytes())
         .map_err(|e| (-32603, format!("Failed to write workflow tempfile: {e}")))?;
+    let tmp_path = tmp.path().to_path_buf();
 
     // Pre-generate the run_id using the same timestamp format as run.rs.
     // We pass it explicitly so the background process uses the same ID we return.
@@ -973,6 +975,10 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
             ));
         }
     }
+
+    // Child has started and survived the early-exit window; the tempfile is no
+    // longer needed (modl run has already opened it).
+    drop(tmp);
 
     // Forward remaining stderr to the log file (best-effort).
     if let Some(mut stderr_pipe) = child.stderr.take() {

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -922,16 +922,6 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         .and_then(|v| v.as_str())
         .ok_or((-32602, "Missing required parameter: spec_yaml".to_string()))?;
 
-    // Write the YAML to a tempfile. NamedTempFile auto-deletes on drop,
-    // so we keep `tmp` alive past the 500ms early-exit check then let it drop.
-    let mut tmp = tempfile::Builder::new()
-        .suffix(".yaml")
-        .tempfile()
-        .map_err(|e| (-32603, format!("Failed to create tempfile: {e}")))?;
-    std::io::Write::write_all(&mut tmp, spec_yaml.as_bytes())
-        .map_err(|e| (-32603, format!("Failed to write workflow tempfile: {e}")))?;
-    let tmp_path = tmp.path().to_path_buf();
-
     // Pre-generate the run_id. Includes a short random suffix to prevent
     // collisions when two workflows are submitted within the same second.
     let run_id = format!(
@@ -940,18 +930,21 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         &uuid::Uuid::new_v4().to_string()[..6]
     );
 
-    // Log file for background output — useful for debugging.
-    let log_path = crate::core::paths::modl_root()
-        .join("run-logs")
-        .join(format!("{run_id}.log"));
-    let _ = std::fs::create_dir_all(log_path.parent().unwrap());
+    // Write YAML to a stable path alongside the stderr log — no temp file
+    // race (child must open before parent deletes). Also useful for debugging.
+    let run_log_dir = crate::core::paths::modl_root().join("run-logs");
+    let _ = std::fs::create_dir_all(&run_log_dir);
+    let spec_path = run_log_dir.join(format!("{run_id}.yaml"));
+    let log_path = run_log_dir.join(format!("{run_id}.log"));
+    std::fs::write(&spec_path, spec_yaml)
+        .map_err(|e| (-32603, format!("Failed to write workflow spec: {e}")))?;
 
     let bin = modl_bin().map_err(|e| (-32603, e.to_string()))?;
 
     // Capture stderr via pipe for a short window so we can detect immediate
     // failures (bad YAML, missing model, etc.) before returning run_id.
     let mut child = std::process::Command::new(&bin)
-        .args(["run", tmp_path.to_str().unwrap_or(""), "--run-id", &run_id])
+        .args(["run", spec_path.to_str().unwrap_or(""), "--run-id", &run_id])
         .stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::piped())
@@ -980,10 +973,6 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         }
     }
 
-    // Child has started and survived the early-exit window; the tempfile is no
-    // longer needed (modl run has already opened it).
-    drop(tmp);
-
     // Forward remaining stderr to the log file (best-effort).
     if let Some(mut stderr_pipe) = child.stderr.take() {
         let log_path_clone = log_path.clone();
@@ -1004,6 +993,7 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
             "text": serde_json::to_string_pretty(&json!({
                 "run_id": run_id,
                 "status": "submitted",
+                "spec": spec_path.to_string_lossy(),
                 "log": log_path.to_string_lossy(),
             })).unwrap_or_default()
         }]

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -940,25 +940,53 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         .join(format!("{run_id}.log"));
     let _ = std::fs::create_dir_all(log_path.parent().unwrap());
 
-    let log_file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .map_err(|e| (-32603, format!("Failed to create log file: {e}")))?;
-
     let bin = modl_bin().map_err(|e| (-32603, e.to_string()))?;
 
-    std::process::Command::new(bin)
+    // Capture stderr via pipe for a short window so we can detect immediate
+    // failures (bad YAML, missing model, etc.) before returning run_id.
+    let mut child = std::process::Command::new(&bin)
         .args(["run", tmp_path.to_str().unwrap_or(""), "--run-id", &run_id])
         .stdin(std::process::Stdio::null())
-        .stdout(
-            std::fs::File::open(&log_path)
-                .map(std::process::Stdio::from)
-                .unwrap_or(std::process::Stdio::null()),
-        )
-        .stderr(std::process::Stdio::from(log_file))
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| (-32603, format!("Failed to spawn modl run: {e}")))?;
+
+    // Wait up to 500 ms — enough to catch YAML parse errors and missing files
+    // without blocking for the actual GPU work.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    if let Ok(Some(status)) = child.try_wait() {
+        // Process already exited — read stderr to report what went wrong.
+        let stderr_text = child
+            .stderr
+            .take()
+            .and_then(|mut r| {
+                let mut buf = String::new();
+                std::io::Read::read_to_string(&mut r, &mut buf).ok()?;
+                Some(buf)
+            })
+            .unwrap_or_default();
+        if !status.success() {
+            return Err((
+                -32603,
+                format!("modl run failed immediately: {}", stderr_text.trim()),
+            ));
+        }
+    }
+
+    // Forward remaining stderr to the log file (best-effort).
+    if let Some(mut stderr_pipe) = child.stderr.take() {
+        let log_path_clone = log_path.clone();
+        std::thread::spawn(move || {
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path_clone)
+            {
+                let _ = std::io::copy(&mut stderr_pipe, &mut f);
+            }
+        });
+    }
 
     Ok(json!({
         "content": [{

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -5,6 +5,7 @@
 //! each tool call spawns the appropriate `modl` subcommand.
 
 use anyhow::{Context, Result};
+use chrono::Local;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use std::io::{self, BufRead, Write};
@@ -379,6 +380,48 @@ fn tool_definitions() -> Value {
                     }
                 },
                 "required": ["prompt"]
+            }
+        },
+        {
+            "name": "run_workflow",
+            "description": "Submit a batch workflow YAML to modl run. Returns immediately with a run_id — the job continues in the background. Use job_status to poll for completion. Useful for fire-and-forget batch runs: submit from laptop, close lid, check back later.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "spec_yaml": {
+                        "type": "string",
+                        "description": "Full YAML content of the workflow spec (the contents of a .yaml file)"
+                    }
+                },
+                "required": ["spec_yaml"]
+            }
+        },
+        {
+            "name": "job_status",
+            "description": "Check the status of a workflow run submitted via run_workflow. Returns aggregate status (pending/running/completed/partial_failure) and artifact URLs. Set MODL_BASE_URL env var on the server for HTTP URLs.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "run_id": {
+                        "type": "string",
+                        "description": "Run ID returned by run_workflow"
+                    }
+                },
+                "required": ["run_id"]
+            }
+        },
+        {
+            "name": "list_run_outputs",
+            "description": "List artifact paths or URLs for a completed workflow run. If MODL_BASE_URL is set on the server, returns HTTP URLs downloadable over Tailscale.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "run_id": {
+                        "type": "string",
+                        "description": "Run ID to list outputs for"
+                    }
+                },
+                "required": ["run_id"]
             }
         }
     ])
@@ -873,6 +916,121 @@ fn tool_remove_bg(args: &Value) -> Result<Value, (i32, String)> {
     }
 }
 
+fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
+    let spec_yaml = args
+        .get("spec_yaml")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing required parameter: spec_yaml".to_string()))?;
+
+    // Write the YAML to a tempfile.
+    let tmp_path = std::env::temp_dir().join(format!(
+        "modl-workflow-{}.yaml",
+        Local::now().format("%Y%m%d-%H%M%S-%f")
+    ));
+    std::fs::write(&tmp_path, spec_yaml)
+        .map_err(|e| (-32603, format!("Failed to write workflow tempfile: {e}")))?;
+
+    // Pre-generate the run_id using the same timestamp format as run.rs.
+    // We pass it explicitly so the background process uses the same ID we return.
+    let run_id = format!("mcp-{}", Local::now().format("%Y%m%d-%H%M%S"));
+
+    // Log file for background output — useful for debugging.
+    let log_path = crate::core::paths::modl_root()
+        .join("run-logs")
+        .join(format!("{run_id}.log"));
+    let _ = std::fs::create_dir_all(log_path.parent().unwrap());
+
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| (-32603, format!("Failed to create log file: {e}")))?;
+
+    let bin = modl_bin().map_err(|e| (-32603, e.to_string()))?;
+
+    std::process::Command::new(bin)
+        .args(["run", tmp_path.to_str().unwrap_or(""), "--run-id", &run_id])
+        .stdin(std::process::Stdio::null())
+        .stdout(
+            std::fs::File::open(&log_path)
+                .map(std::process::Stdio::from)
+                .unwrap_or(std::process::Stdio::null()),
+        )
+        .stderr(std::process::Stdio::from(log_file))
+        .spawn()
+        .map_err(|e| (-32603, format!("Failed to spawn modl run: {e}")))?;
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&json!({
+                "run_id": run_id,
+                "status": "submitted",
+                "log": log_path.to_string_lossy(),
+            })).unwrap_or_default()
+        }]
+    }))
+}
+
+fn tool_job_status(args: &Value) -> Result<Value, (i32, String)> {
+    let run_id = args
+        .get("run_id")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing required parameter: run_id".to_string()))?;
+
+    let (stdout, stderr, success) =
+        run_modl(&["status", "--json", run_id]).map_err(|e| (-32603, e))?;
+
+    if !success {
+        let msg = if stderr.is_empty() { &stdout } else { &stderr };
+        return Err((-32603, format!("Status check failed: {}", msg.trim())));
+    }
+
+    if let Ok(result) = serde_json::from_str::<Value>(&stdout) {
+        Ok(json!({
+            "content": [{"type": "text", "text": serde_json::to_string_pretty(&result).unwrap_or_else(|_| stdout.clone())}]
+        }))
+    } else {
+        Ok(json!({
+            "content": [{"type": "text", "text": stdout.trim()}]
+        }))
+    }
+}
+
+fn tool_list_run_outputs(args: &Value) -> Result<Value, (i32, String)> {
+    let run_id = args
+        .get("run_id")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing required parameter: run_id".to_string()))?;
+
+    let (stdout, stderr, success) =
+        run_modl(&["status", "--json", run_id]).map_err(|e| (-32603, e))?;
+
+    if !success {
+        let msg = if stderr.is_empty() { &stdout } else { &stderr };
+        return Err((-32603, format!("Failed to list outputs: {}", msg.trim())));
+    }
+
+    if let Ok(result) = serde_json::from_str::<Value>(&stdout) {
+        let artifacts = result
+            .get("artifacts")
+            .cloned()
+            .unwrap_or_else(|| json!([]));
+        let count = artifacts.as_array().map(|a| a.len()).unwrap_or(0);
+        let text = format!(
+            "{count} artifact(s) for run {run_id}:\n{}",
+            serde_json::to_string_pretty(&artifacts).unwrap_or_default()
+        );
+        Ok(json!({
+            "content": [{"type": "text", "text": text}]
+        }))
+    } else {
+        Ok(json!({
+            "content": [{"type": "text", "text": stdout.trim()}]
+        }))
+    }
+}
+
 fn tool_enhance(args: &Value) -> Result<Value, (i32, String)> {
     let prompt = args
         .get("prompt")
@@ -956,6 +1114,9 @@ fn handle_request(request: &JsonRpcRequest) -> Option<JsonRpcResponse> {
                 "upscale" => tool_upscale(&arguments),
                 "remove_bg" => tool_remove_bg(&arguments),
                 "enhance" => tool_enhance(&arguments),
+                "run_workflow" => tool_run_workflow(&arguments),
+                "job_status" => tool_job_status(&arguments),
+                "list_run_outputs" => tool_list_run_outputs(&arguments),
                 _ => Err((-32601, format!("Unknown tool: {}", name))),
             }
         }
@@ -1127,7 +1288,10 @@ mod tests {
         assert!(names.contains(&"upscale"));
         assert!(names.contains(&"remove_bg"));
         assert!(names.contains(&"enhance"));
-        assert_eq!(tool_list.len(), 12);
+        assert!(names.contains(&"run_workflow"));
+        assert!(names.contains(&"job_status"));
+        assert!(names.contains(&"list_run_outputs"));
+        assert_eq!(tool_list.len(), 15);
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1690,7 +1690,18 @@ pub async fn run(cli: Cli) -> Result<()> {
             in_order,
             force,
             run_id,
-        } => run::run(&specs, auto_pull, dry_run, json, in_order, !force, run_id.as_deref()).await,
+        } => {
+            run::run(
+                &specs,
+                auto_pull,
+                dry_run,
+                json,
+                in_order,
+                !force,
+                run_id.as_deref(),
+            )
+            .await
+        }
         Commands::Status { run_id, json } => run_status::run(&run_id, json).await,
 
         // ── Hidden ───────────────────────────────────────────────────

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,7 @@ mod preprocess;
 mod push;
 mod remove_bg;
 mod run;
+mod run_status;
 mod runtime;
 mod score;
 mod search;
@@ -1127,6 +1128,27 @@ See `modl/docs/guides/workflows.md` for the full reference.")]
         /// interrupted runs resume cleanly without duplicating work.
         #[arg(long)]
         force: bool,
+        /// Override the run ID (used by MCP/remote callers to track a job
+        /// before it starts). If omitted, a timestamp-based ID is generated.
+        #[arg(long, hide = true)]
+        run_id: Option<String>,
+    },
+
+    /// Show status of a workflow run by run ID
+    ///
+    /// Queries the local database for all step-jobs belonging to the run and
+    /// prints aggregate status plus artifact paths. Set MODL_BASE_URL to get
+    /// HTTP URLs suitable for remote download over Tailscale.
+    ///
+    /// Example:
+    ///   modl status 20240101-120000-my-workflow
+    ///   MODL_BASE_URL=http://server:3939 modl status <run-id> --json
+    Status {
+        /// Workflow run ID (from `modl run` output or MCP run_workflow response)
+        run_id: String,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
 
     // ── Hidden ───────────────────────────────────────────────────────
@@ -1667,7 +1689,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             json,
             in_order,
             force,
-        } => run::run(&specs, auto_pull, dry_run, json, in_order, !force).await,
+            run_id,
+        } => run::run(&specs, auto_pull, dry_run, json, in_order, !force, run_id.as_deref()).await,
+        Commands::Status { run_id, json } => run_status::run(&run_id, json).await,
 
         // ── Hidden ───────────────────────────────────────────────────
         Commands::Init { defaults, root } => init::run(defaults, root.as_deref()).await,

--- a/src/cli/outputs.rs
+++ b/src/cli/outputs.rs
@@ -583,17 +583,22 @@ async fn run_export(
             style(&url).underlined()
         );
 
-        let response = reqwest::blocking::get(&url).context("Failed to connect to server")?;
+        let response = reqwest::get(&url)
+            .await
+            .context("Failed to connect to server")?;
 
         if !response.status().is_success() {
             bail!(
                 "Server returned {}: {}",
                 response.status(),
-                response.text().unwrap_or_default()
+                response.text().await.unwrap_or_default()
             );
         }
 
-        let bytes = response.bytes().context("Failed to read response body")?;
+        let bytes = response
+            .bytes()
+            .await
+            .context("Failed to read response body")?;
         std::fs::create_dir_all(&dest_dir).context("Failed to create destination directory")?;
 
         let cursor = std::io::Cursor::new(bytes);
@@ -602,9 +607,11 @@ async fn run_export(
 
         for i in 0..archive.len() {
             let mut file = archive.by_index(i)?;
-            let out_path = dest_dir.join(file.name());
-            let mut out = std::fs::File::create(&out_path)?;
-            std::io::copy(&mut file, &mut out)?;
+            if let Some(safe_name) = file.enclosed_name() {
+                let out_path = dest_dir.join(safe_name);
+                let mut out = std::fs::File::create(&out_path)?;
+                std::io::copy(&mut file, &mut out)?;
+            }
         }
 
         println!(

--- a/src/cli/outputs.rs
+++ b/src/cli/outputs.rs
@@ -2,6 +2,7 @@ use anyhow::{Context, Result, bail};
 use clap::Subcommand;
 use comfy_table::{Cell, Color, Table, presets::UTF8_FULL_CONDENSED};
 use console::style;
+use std::path::PathBuf;
 
 use crate::core::db::{ArtifactRecord, Database, JobRecord};
 use crate::core::outputs as output_service;
@@ -56,6 +57,25 @@ pub enum OutputCommands {
         #[arg(long, short = 'f')]
         force: bool,
     },
+    /// Download all outputs from a workflow run to a local directory
+    ///
+    /// When --server is set (or MODL_SERVER env var), fetches the ZIP archive
+    /// from a remote modl serve instance over Tailscale. Without --server,
+    /// copies files from the local output directory.
+    ///
+    /// Example:
+    ///   modl outputs export 20240101-120000-my-workflow --dest ./my-run
+    ///   MODL_SERVER=http://server:3939 modl outputs export <run-id> --dest ./local
+    Export {
+        /// Workflow run ID
+        run_id: String,
+        /// Destination directory (created if needed). Defaults to ./<run_id>
+        #[arg(long, short = 'd')]
+        dest: Option<PathBuf>,
+        /// Remote modl server URL (overrides MODL_SERVER env var)
+        #[arg(long)]
+        server: Option<String>,
+    },
 }
 
 pub async fn run(command: OutputCommands) -> Result<()> {
@@ -71,6 +91,11 @@ pub async fn run(command: OutputCommands) -> Result<()> {
         OutputCommands::Fav { id } => run_fav(&id, true).await,
         OutputCommands::Unfav { id } => run_fav(&id, false).await,
         OutputCommands::Rm { id, force } => run_rm(&id, force).await,
+        OutputCommands::Export {
+            run_id,
+            dest,
+            server,
+        } => run_export(&run_id, dest.as_deref(), server.as_deref()).await,
     }
 }
 
@@ -526,6 +551,109 @@ async fn run_rm(id: &str, force: bool) -> Result<()> {
             style("✓").green(),
             style(&filename).bold()
         );
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+async fn run_export(
+    run_id: &str,
+    dest: Option<&std::path::Path>,
+    server: Option<&str>,
+) -> Result<()> {
+    let dest_dir = dest
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| std::path::PathBuf::from(run_id));
+
+    // Determine server URL: explicit arg > env var > local copy
+    let server_url = server
+        .map(|s| s.to_string())
+        .or_else(|| std::env::var("MODL_SERVER").ok());
+
+    if let Some(base) = server_url {
+        // Remote: fetch the ZIP from the server and unpack it.
+        let url = format!("{base}/api/workflow-runs/{run_id}/export.zip");
+        println!(
+            "{} Fetching {} ...",
+            style("→").cyan(),
+            style(&url).underlined()
+        );
+
+        let response = reqwest::blocking::get(&url).context("Failed to connect to server")?;
+
+        if !response.status().is_success() {
+            bail!(
+                "Server returned {}: {}",
+                response.status(),
+                response.text().unwrap_or_default()
+            );
+        }
+
+        let bytes = response.bytes().context("Failed to read response body")?;
+        std::fs::create_dir_all(&dest_dir).context("Failed to create destination directory")?;
+
+        let cursor = std::io::Cursor::new(bytes);
+        let mut archive = zip::ZipArchive::new(cursor).context("Invalid ZIP archive")?;
+        let n = archive.len();
+
+        for i in 0..archive.len() {
+            let mut file = archive.by_index(i)?;
+            let out_path = dest_dir.join(file.name());
+            let mut out = std::fs::File::create(&out_path)?;
+            std::io::copy(&mut file, &mut out)?;
+        }
+
+        println!(
+            "{} Downloaded {} file{} to {}",
+            style("✓").green().bold(),
+            n,
+            if n == 1 { "" } else { "s" },
+            style(dest_dir.display().to_string()).bold()
+        );
+    } else {
+        // Local: copy artifact files directly from DB records.
+        let db = Database::open()?;
+        let jobs = db.list_jobs_by_run_id(run_id)?;
+
+        if jobs.is_empty() {
+            bail!("No workflow run found with ID '{run_id}'");
+        }
+
+        std::fs::create_dir_all(&dest_dir).context("Failed to create destination directory")?;
+
+        let mut copied = 0usize;
+        for job in &jobs {
+            let arts = db.list_artifacts(Some(&job.job_id)).unwrap_or_default();
+            for a in arts {
+                let src = std::path::Path::new(&a.path);
+                if !src.is_file() {
+                    continue;
+                }
+                let name = src
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| a.artifact_id.clone());
+                std::fs::copy(src, dest_dir.join(&name))
+                    .with_context(|| format!("Failed to copy {}", a.path))?;
+                copied += 1;
+            }
+        }
+
+        if copied == 0 {
+            println!("No artifacts found for run '{run_id}'.");
+        } else {
+            println!(
+                "{} Copied {} file{} to {}",
+                style("✓").green().bold(),
+                copied,
+                if copied == 1 { "" } else { "s" },
+                style(dest_dir.display().to_string()).bold()
+            );
+        }
     }
 
     Ok(())

--- a/src/cli/outputs.rs
+++ b/src/cli/outputs.rs
@@ -106,11 +106,8 @@ pub async fn run(command: OutputCommands) -> Result<()> {
 async fn run_list(limit: usize, kind_filter: Option<&str>, favorites_only: bool) -> Result<()> {
     let db = Database::open()?;
     let artifacts = db.list_artifacts(None)?;
-    let favorite_paths = if favorites_only {
-        db.get_favorite_paths()?
-    } else {
-        std::collections::HashSet::new()
-    };
+    // Single query used both for the ⭐ column and the --favorites filter.
+    let all_favorites = db.get_favorite_paths()?;
 
     if artifacts.is_empty() {
         println!("No outputs yet.");
@@ -121,9 +118,6 @@ async fn run_list(limit: usize, kind_filter: Option<&str>, favorites_only: bool)
         return Ok(());
     }
 
-    // Collect all favorite paths for the ⭐ column
-    let all_favorites = db.get_favorite_paths()?;
-
     // Filter by kind if requested
     let filtered: Vec<&ArtifactRecord> = artifacts
         .iter()
@@ -133,7 +127,7 @@ async fn run_list(limit: usize, kind_filter: Option<&str>, favorites_only: bool)
             {
                 return false;
             }
-            if favorites_only && !favorite_paths.contains(&a.path) {
+            if favorites_only && !all_favorites.contains(&a.path) {
                 return false;
             }
             true
@@ -634,7 +628,7 @@ async fn run_export(
 
         let mut copied = 0usize;
         for job in &jobs {
-            let arts = db.list_artifacts(Some(&job.job_id)).unwrap_or_default();
+            let arts = db.list_artifacts(Some(&job.job_id))?;
             for a in arts {
                 let src = std::path::Path::new(&a.path);
                 if !src.is_file() {

--- a/src/cli/outputs.rs
+++ b/src/cli/outputs.rs
@@ -394,32 +394,27 @@ async fn run_open(id: &str) -> Result<()> {
 
 async fn run_search(query: &str, limit: usize) -> Result<()> {
     let db = Database::open()?;
-    let jobs = db.list_jobs(None)?;
-    let query_lower = query.to_lowercase();
-
-    let mut matching_artifacts: Vec<(ArtifactRecord, String)> = Vec::new();
-
-    for job in &jobs {
-        // Search inside spec_json
-        let spec_lower = job.spec_json.to_lowercase();
-        if !spec_lower.contains(&query_lower) {
-            continue;
-        }
-
-        // This job matches — pull its artifacts
-        let artifacts = db.list_artifacts(Some(&job.job_id))?;
-        let summary = job_summary(job);
-
-        for artifact in artifacts {
-            matching_artifacts.push((artifact, summary.prompt_or_name.clone()));
-            if matching_artifacts.len() >= limit {
-                break;
-            }
-        }
-        if matching_artifacts.len() >= limit {
-            break;
-        }
-    }
+    // Single JOIN query — no N+1.
+    let rows = db.search_artifacts(query, limit)?;
+    let matching_artifacts: Vec<(ArtifactRecord, String)> = rows
+        .into_iter()
+        .map(|(artifact, spec_json)| {
+            let prompt = serde_json::from_str::<serde_json::Value>(&spec_json)
+                .ok()
+                .and_then(|v| {
+                    v.get("prompt")
+                        .and_then(|p| p.as_str())
+                        .or_else(|| {
+                            v.get("output")
+                                .and_then(|o| o.get("lora_name"))
+                                .and_then(|n| n.as_str())
+                        })
+                        .map(|s| s.to_string())
+                })
+                .unwrap_or_else(|| "—".into());
+            (artifact, prompt)
+        })
+        .collect();
 
     if matching_artifacts.is_empty() {
         println!("No outputs matching '{}'.", style(query).italic());

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -195,6 +195,7 @@ pub async fn run(
     json: bool,
     in_order: bool,
     skip_existing: bool,
+    run_id_override: Option<&str>,
 ) -> Result<()> {
     let db = Database::open()?;
     let multi = spec_paths.len() > 1;
@@ -207,7 +208,7 @@ pub async fn run(
             println!("── {}/{}: {} ──", i + 1, spec_paths.len(), spec_path);
         }
 
-        let plan_result = build_plan(spec_path, &db);
+        let plan_result = build_plan(spec_path, &db, run_id_override);
 
         if dry_run {
             run_dry_run(plan_result, json, in_order)?;
@@ -276,7 +277,11 @@ fn run_dry_run(plan_result: Result<Plan, PlanError>, json: bool, in_order: bool)
 /// Auto-disabling LoRA on model override is a safe default, not a
 /// restriction: if the user wants to force a LoRA through anyway, they
 /// can set `lora:` explicitly on the step.
-pub fn build_plan(spec_path: &str, db: &Database) -> Result<Plan, PlanError> {
+pub fn build_plan(
+    spec_path: &str,
+    db: &Database,
+    run_id_override: Option<&str>,
+) -> Result<Plan, PlanError> {
     // 1. Parse + validate YAML
     let wf = parse_file(Path::new(spec_path)).map_err(|e| PlanError::Parse(format!("{e:#}")))?;
 
@@ -292,11 +297,13 @@ pub fn build_plan(spec_path: &str, db: &Database) -> Result<Plan, PlanError> {
     // 4. Compute run id + output dir (dry-run uses these only for display)
     let date = chrono::Local::now().format("%Y-%m-%d").to_string();
     let output_dir = paths::modl_root().join("outputs").join(&date);
-    let run_id = format!(
-        "{}-{}",
-        chrono::Local::now().format("%Y%m%d-%H%M%S"),
-        sanitize_for_path(&wf.name)
-    );
+    let run_id = run_id_override.map(|s| s.to_string()).unwrap_or_else(|| {
+        format!(
+            "{}-{}",
+            chrono::Local::now().format("%Y%m%d-%H%M%S"),
+            sanitize_for_path(&wf.name)
+        )
+    });
 
     // 5. Per-step resolution: model override, lora override, seed expansion.
     // We cache resolved models by ID so a workflow that uses the same model

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -747,7 +747,7 @@ pub async fn execute_plan(
                         step_labels.clone(),
                     );
                     let (job_id, artifacts) =
-                        execute_generate_step(&mut executor, &spec, &step.id, db)?;
+                        execute_generate_step(&mut executor, &spec, &step.id, &plan.run_id, db)?;
                     for (i, artifact) in artifacts.iter().enumerate() {
                         let artifact_id = format!("{}-img-{}", job_id, i);
                         let image_seed = spec.params.seed.map(|s| s + i as u64);
@@ -823,7 +823,7 @@ pub async fn execute_plan(
                         step_labels.clone(),
                     );
                     let (job_id, artifacts) =
-                        execute_edit_step(&mut executor, &spec, &step.id, db)?;
+                        execute_edit_step(&mut executor, &spec, &step.id, &plan.run_id, db)?;
                     for (i, artifact) in artifacts.iter().enumerate() {
                         let artifact_id = format!("{}-img-{}", job_id, i);
                         let image_seed = spec.params.seed.map(|s| s + i as u64);
@@ -1505,11 +1505,12 @@ fn execute_generate_step(
     executor: &mut LocalExecutor,
     spec: &GenerateJobSpec,
     step_id: &str,
+    run_id: &str,
     db: &Database,
 ) -> Result<(String, Vec<PathBuf>)> {
     let handle = executor.submit_generate(spec)?;
     let job_id = handle.job_id.clone();
-    register_job(db, &job_id, "generate", spec)?;
+    register_job(db, &job_id, "generate", spec, run_id)?;
     let rx = executor.events(&job_id)?;
     let result = consume_events(rx, step_id, db, &job_id);
     match &result {
@@ -1527,11 +1528,12 @@ fn execute_edit_step(
     executor: &mut LocalExecutor,
     spec: &EditJobSpec,
     step_id: &str,
+    run_id: &str,
     db: &Database,
 ) -> Result<(String, Vec<PathBuf>)> {
     let handle = executor.submit_edit(spec)?;
     let job_id = handle.job_id.clone();
-    register_job(db, &job_id, "edit", spec)?;
+    register_job(db, &job_id, "edit", spec, run_id)?;
     let rx = executor.events(&job_id)?;
     let result = consume_events(rx, step_id, db, &job_id);
     match &result {
@@ -1545,17 +1547,23 @@ fn execute_edit_step(
     result.map(|paths| (job_id, paths))
 }
 
-/// Insert a job row so the UI can discover workflow outputs alongside
-/// regular `modl generate` / `modl edit` results. Mirrors what those CLI
-/// handlers do directly.
 fn register_job<S: serde::Serialize>(
     db: &Database,
     job_id: &str,
     kind: &str,
     spec: &S,
+    run_id: &str,
 ) -> Result<()> {
     let spec_json = serde_json::to_string(spec).unwrap_or_else(|_| "{}".to_string());
-    db.insert_job(job_id, kind, "running", &spec_json, "local", None)?;
+    db.insert_job(
+        job_id,
+        kind,
+        "running",
+        &spec_json,
+        "local",
+        None,
+        Some(run_id),
+    )?;
     Ok(())
 }
 

--- a/src/cli/run_status.rs
+++ b/src/cli/run_status.rs
@@ -18,6 +18,8 @@ pub async fn run(run_id: &str, json: bool) -> Result<()> {
     let failed = jobs.iter().filter(|j| j.status == "error").count();
     let running = jobs.iter().filter(|j| j.status == "running").count();
 
+    // partial_failure: all steps have terminated, at least one errored.
+    // A run with pending steps and failures stays "pending" until all settle.
     let aggregate = if failed > 0 && running == 0 && completed + failed == total {
         "partial_failure"
     } else if running > 0 {

--- a/src/cli/run_status.rs
+++ b/src/cli/run_status.rs
@@ -18,14 +18,18 @@ pub async fn run(run_id: &str, json: bool) -> Result<()> {
     let failed = jobs.iter().filter(|j| j.status == "error").count();
     let running = jobs.iter().filter(|j| j.status == "running").count();
 
-    // partial_failure: all steps have terminated, at least one errored.
-    // A run with pending steps and failures stays "pending" until all settle.
-    let aggregate = if failed > 0 && running == 0 && completed + failed == total {
+    let cancelled = jobs.iter().filter(|j| j.status == "cancelled").count();
+    // partial_failure / cancelled: all steps terminated, none still running.
+    // Runs with pending steps and failures stay "pending" until all settle.
+    let is_terminal = running == 0 && completed + failed + cancelled == total;
+    let aggregate = if failed > 0 && is_terminal {
         "partial_failure"
     } else if running > 0 {
         "running"
     } else if completed == total {
         "completed"
+    } else if cancelled > 0 && is_terminal {
+        "cancelled"
     } else {
         "pending"
     };
@@ -62,6 +66,7 @@ pub async fn run(run_id: &str, json: bool) -> Result<()> {
                 "completed": completed,
                 "failed": failed,
                 "running": running,
+                "cancelled": cancelled,
             },
             "artifacts": artifacts.iter().map(|(path, url)| serde_json::json!({
                 "path": path,
@@ -83,6 +88,7 @@ pub async fn run(run_id: &str, json: bool) -> Result<()> {
             "completed" => style(aggregate).green().to_string(),
             "running" => style(aggregate).yellow().to_string(),
             "partial_failure" => style(aggregate).red().to_string(),
+            "cancelled" => style(aggregate).yellow().to_string(),
             _ => style(aggregate).dim().to_string(),
         }
     );
@@ -115,7 +121,7 @@ pub async fn run(run_id: &str, json: bool) -> Result<()> {
         }
     }
 
-    if aggregate != "completed" && aggregate != "partial_failure" {
+    if aggregate != "completed" && aggregate != "partial_failure" && aggregate != "cancelled" {
         println!();
         println!(
             "  {} Re-run {} to refresh.",

--- a/src/cli/run_status.rs
+++ b/src/cli/run_status.rs
@@ -1,0 +1,133 @@
+use anyhow::{Result, bail};
+use console::style;
+
+use crate::core::db::Database;
+
+pub async fn run(run_id: &str, json: bool) -> Result<()> {
+    let db = Database::open()?;
+
+    let jobs = db.list_jobs_by_run_id(run_id)?;
+
+    if jobs.is_empty() {
+        bail!("No workflow run found with ID '{run_id}'");
+    }
+
+    // Aggregate status across step-jobs.
+    let total = jobs.len();
+    let completed = jobs.iter().filter(|j| j.status == "completed").count();
+    let failed = jobs.iter().filter(|j| j.status == "error").count();
+    let running = jobs.iter().filter(|j| j.status == "running").count();
+
+    let aggregate = if failed > 0 && running == 0 && completed + failed == total {
+        "partial_failure"
+    } else if running > 0 {
+        "running"
+    } else if completed == total {
+        "completed"
+    } else {
+        "pending"
+    };
+
+    // Collect artifacts for all step-jobs.
+    let mut artifacts: Vec<(String, String)> = Vec::new(); // (path, url)
+    let base_url = std::env::var("MODL_BASE_URL").ok();
+
+    for job in &jobs {
+        let arts = db.list_artifacts(Some(&job.job_id)).unwrap_or_default();
+        for a in arts {
+            let url = match &base_url {
+                Some(base) => {
+                    // Strip the local root prefix and build a URL.
+                    let local_root = crate::core::paths::modl_root();
+                    let rel = std::path::Path::new(&a.path)
+                        .strip_prefix(&local_root)
+                        .map(|p| p.to_string_lossy().to_string())
+                        .unwrap_or_else(|_| a.path.clone());
+                    format!("{base}/files/{rel}")
+                }
+                None => a.path.clone(),
+            };
+            artifacts.push((a.path.clone(), url));
+        }
+    }
+
+    if json {
+        let out = serde_json::json!({
+            "run_id": run_id,
+            "status": aggregate,
+            "steps": {
+                "total": total,
+                "completed": completed,
+                "failed": failed,
+                "running": running,
+            },
+            "artifacts": artifacts.iter().map(|(path, url)| serde_json::json!({
+                "path": path,
+                "url": url,
+            })).collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    // Human output
+    println!("{}", style("Workflow run status").bold().cyan());
+    println!();
+    println!("  {}  {}", style("Run ID:").dim(), run_id);
+    println!(
+        "  {}  {}",
+        style("Status:").dim(),
+        match aggregate {
+            "completed" => style(aggregate).green().to_string(),
+            "running" => style(aggregate).yellow().to_string(),
+            "partial_failure" => style(aggregate).red().to_string(),
+            _ => style(aggregate).dim().to_string(),
+        }
+    );
+    println!(
+        "  {}  {}/{} steps complete{}",
+        style("Steps:").dim(),
+        completed,
+        total,
+        if failed > 0 {
+            format!(", {} failed", failed)
+        } else {
+            String::new()
+        }
+    );
+
+    if !artifacts.is_empty() {
+        println!();
+        println!(
+            "  {} {} artifact{}",
+            style("Outputs:").dim(),
+            artifacts.len(),
+            if artifacts.len() == 1 { "" } else { "s" }
+        );
+        for (path, url) in &artifacts {
+            if base_url.is_some() {
+                println!("    {}", style(url).underlined().cyan());
+            } else {
+                println!("    {}", style(path).dim());
+            }
+        }
+    }
+
+    if aggregate != "completed" && aggregate != "partial_failure" {
+        println!();
+        println!(
+            "  {} Re-run {} to refresh.",
+            style("ℹ").dim(),
+            style(format!("modl status {run_id}")).cyan()
+        );
+    } else if base_url.is_none() && !artifacts.is_empty() {
+        println!();
+        println!(
+            "  {} Set {} to get HTTP URLs for remote download.",
+            style("ℹ").dim(),
+            style("MODL_BASE_URL=http://server:PORT").cyan()
+        );
+    }
+
+    Ok(())
+}

--- a/src/cli/train.rs
+++ b/src/cli/train.rs
@@ -453,6 +453,7 @@ async fn execute_training(
         &spec_json,
         target_str.trim_matches('"'),
         None,
+        None,
     )?;
 
     println!(

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -153,7 +153,14 @@ fn remove_trained_artifact(
     db.delete_artifact(&artifact.artifact_id)?;
 
     // Remove associated job records from DB
-    db.delete_jobs_by_lora_name(lora_name)?;
+    let deleted_jobs = db.delete_jobs_by_lora_name(lora_name)?;
+    if deleted_jobs > 0 {
+        println!(
+            "  {} Removed {} job record(s)",
+            style("×").red(),
+            deleted_jobs
+        );
+    }
 
     println!();
     println!(

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -378,8 +378,16 @@ mod tests {
         let store_root = tempfile::TempDir::new().unwrap();
 
         // Insert a job record so the FK on artifacts is satisfied
-        db.insert_job("job-test-123", "train", "running", "{}", "local", None)
-            .unwrap();
+        db.insert_job(
+            "job-test-123",
+            "train",
+            "running",
+            "{}",
+            "local",
+            None,
+            None,
+        )
+        .unwrap();
 
         let result = collect_lora(
             &output_file,

--- a/src/core/db/artifacts.rs
+++ b/src/core/db/artifacts.rs
@@ -144,6 +144,47 @@ impl Database {
         Ok(())
     }
 
+    /// Search artifacts whose job spec_json contains `query` (case-insensitive).
+    ///
+    /// Returns `(ArtifactRecord, spec_json)` pairs ordered by job creation time,
+    /// newest first. Single JOIN query — no N+1.
+    pub fn search_artifacts(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<(ArtifactRecord, String)>> {
+        let pattern = format!("%{}%", query.to_lowercase());
+        let mut stmt = self.conn.prepare(
+            "SELECT a.artifact_id, a.job_id, a.kind, a.path, a.sha256, a.size_bytes, a.metadata, a.created_at,
+                    j.spec_json
+             FROM artifacts a
+             JOIN jobs j ON j.job_id = a.job_id
+             WHERE lower(j.spec_json) LIKE ?1
+             ORDER BY j.created_at DESC
+             LIMIT ?2",
+        ).context("Failed to prepare search query")?;
+
+        let rows = stmt
+            .query_map(params![pattern, limit as i64], |row| {
+                let artifact = ArtifactRecord {
+                    artifact_id: row.get(0)?,
+                    job_id: row.get(1)?,
+                    kind: row.get(2)?,
+                    path: row.get(3)?,
+                    sha256: row.get(4)?,
+                    size_bytes: row.get::<_, i64>(5)? as u64,
+                    metadata: row.get(6)?,
+                    created_at: row.get(7)?,
+                };
+                let spec_json: String = row.get(8)?;
+                Ok((artifact, spec_json))
+            })
+            .context("Failed to search artifacts")?;
+
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .context("Failed to collect search results")
+    }
+
     /// Delete artifact records by file path. Returns number of deleted rows.
     pub fn delete_artifacts_by_path(&self, path: &str) -> Result<usize> {
         let deleted = self

--- a/src/core/db/jobs.rs
+++ b/src/core/db/jobs.rs
@@ -4,7 +4,9 @@ use rusqlite::params;
 use super::Database;
 
 impl Database {
-    /// Insert a new training job
+    /// Insert a new job. Pass `workflow_run_id` for workflow steps so the
+    /// indexed column is populated and `list_jobs_by_run_id` avoids a LIKE scan.
+    #[allow(clippy::too_many_arguments)]
     pub fn insert_job(
         &self,
         job_id: &str,
@@ -13,12 +15,13 @@ impl Database {
         spec_json: &str,
         target: &str,
         provider: Option<&str>,
+        workflow_run_id: Option<&str>,
     ) -> Result<()> {
         self.conn
             .execute(
-                "INSERT INTO jobs (job_id, kind, status, spec_json, target, provider)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                params![job_id, kind, status, spec_json, target, provider],
+                "INSERT INTO jobs (job_id, kind, status, spec_json, target, provider, workflow_run_id)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                params![job_id, kind, status, spec_json, target, provider, workflow_run_id],
             )
             .context("Failed to insert job")?;
         Ok(())
@@ -155,18 +158,35 @@ impl Database {
         Ok(())
     }
 
-    /// Find all step-jobs belonging to a workflow run (matched via spec_json label).
+    /// Find all step-jobs belonging to a workflow run.
+    /// Uses the indexed `workflow_run_id` column; falls back to a spec_json LIKE
+    /// scan for older rows created before the column was added.
     pub fn list_jobs_by_run_id(&self, run_id: &str) -> Result<Vec<JobRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT job_id, kind, status, spec_json, target, provider, created_at, started_at, completed_at \
+             FROM jobs WHERE workflow_run_id = ?1 ORDER BY created_at ASC"
+        ).context("Failed to prepare indexed query")?;
+
+        let rows = stmt
+            .query_map(params![run_id], JobRecord::from_row)
+            .context("Failed to query jobs by run_id")?;
+        let results: Vec<JobRecord> = rows
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .context("Failed to collect job results")?;
+
+        if !results.is_empty() {
+            return Ok(results);
+        }
+
+        // Fallback: LIKE scan for rows pre-dating the workflow_run_id column.
         let pattern = format!("%{run_id}%");
         let mut stmt = self.conn.prepare(
             "SELECT job_id, kind, status, spec_json, target, provider, created_at, started_at, completed_at \
-             FROM jobs WHERE spec_json LIKE ?1 ORDER BY created_at ASC"
-        ).context("Failed to prepare query")?;
-
+             FROM jobs WHERE workflow_run_id IS NULL AND spec_json LIKE ?1 ORDER BY created_at ASC"
+        ).context("Failed to prepare fallback query")?;
         let rows = stmt
             .query_map(params![pattern], JobRecord::from_row)
-            .context("Failed to query jobs by run_id")?;
-
+            .context("Failed to query jobs by run_id (fallback)")?;
         rows.collect::<std::result::Result<Vec<_>, _>>()
             .context("Failed to collect job results")
     }

--- a/src/core/db/jobs.rs
+++ b/src/core/db/jobs.rs
@@ -179,6 +179,7 @@ impl Database {
         }
 
         // Fallback: LIKE scan for rows pre-dating the workflow_run_id column.
+        // TODO: remove this once all users have migrated past DB version 1.
         let pattern = format!("%{run_id}%");
         let mut stmt = self.conn.prepare(
             "SELECT job_id, kind, status, spec_json, target, provider, created_at, started_at, completed_at \

--- a/src/core/db/jobs.rs
+++ b/src/core/db/jobs.rs
@@ -133,29 +133,21 @@ impl Database {
         Ok(updated)
     }
 
-    /// Delete all jobs and their events for a given LoRA name
-    pub fn delete_jobs_by_lora_name(&self, lora_name: &str) -> Result<()> {
+    /// Delete all jobs and their events for a given LoRA name.
+    /// Returns the number of deleted job rows so the caller can display feedback.
+    pub fn delete_jobs_by_lora_name(&self, lora_name: &str) -> Result<usize> {
         let pattern = format!("job-{lora_name}-%");
-        // Delete events first (child records)
         self.conn
             .execute(
                 "DELETE FROM job_events WHERE job_id LIKE ?1",
                 params![pattern],
             )
             .context("Failed to delete job events")?;
-        // Delete the jobs themselves
         let deleted = self
             .conn
             .execute("DELETE FROM jobs WHERE job_id LIKE ?1", params![pattern])
             .context("Failed to delete jobs")?;
-        if deleted > 0 {
-            println!(
-                "  {} Removed {} job record(s)",
-                console::style("×").red(),
-                deleted
-            );
-        }
-        Ok(())
+        Ok(deleted)
     }
 
     /// Find all step-jobs belonging to a workflow run.
@@ -180,10 +172,14 @@ impl Database {
 
         // Fallback: LIKE scan for rows pre-dating the workflow_run_id column.
         // TODO: remove this once all users have migrated past DB version 1.
-        let pattern = format!("%{run_id}%");
+        let escaped = run_id
+            .replace('\\', "\\\\")
+            .replace('%', "\\%")
+            .replace('_', "\\_");
+        let pattern = format!("%{escaped}%");
         let mut stmt = self.conn.prepare(
             "SELECT job_id, kind, status, spec_json, target, provider, created_at, started_at, completed_at \
-             FROM jobs WHERE workflow_run_id IS NULL AND spec_json LIKE ?1 ORDER BY created_at ASC"
+             FROM jobs WHERE workflow_run_id IS NULL AND spec_json LIKE ?1 ESCAPE '\\' ORDER BY created_at ASC"
         ).context("Failed to prepare fallback query")?;
         let rows = stmt
             .query_map(params![pattern], JobRecord::from_row)

--- a/src/core/db/jobs.rs
+++ b/src/core/db/jobs.rs
@@ -77,6 +77,7 @@ impl Database {
     }
 
     /// List all jobs, optionally filtered by status
+    #[allow(dead_code)]
     pub fn list_jobs(&self, status_filter: Option<&str>) -> Result<Vec<JobRecord>> {
         let sql = if status_filter.is_some() {
             "SELECT job_id, kind, status, spec_json, target, provider, created_at, started_at, completed_at FROM jobs WHERE status = ?1 ORDER BY created_at DESC"

--- a/src/core/db/jobs.rs
+++ b/src/core/db/jobs.rs
@@ -155,6 +155,22 @@ impl Database {
         Ok(())
     }
 
+    /// Find all step-jobs belonging to a workflow run (matched via spec_json label).
+    pub fn list_jobs_by_run_id(&self, run_id: &str) -> Result<Vec<JobRecord>> {
+        let pattern = format!("%{run_id}%");
+        let mut stmt = self.conn.prepare(
+            "SELECT job_id, kind, status, spec_json, target, provider, created_at, started_at, completed_at \
+             FROM jobs WHERE spec_json LIKE ?1 ORDER BY created_at ASC"
+        ).context("Failed to prepare query")?;
+
+        let rows = stmt
+            .query_map(params![pattern], JobRecord::from_row)
+            .context("Failed to query jobs by run_id")?;
+
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .context("Failed to collect job results")
+    }
+
     /// Count total jobs in the database.
     pub fn count_jobs(&self) -> Result<usize> {
         let count: i64 = self

--- a/src/core/db/mod.rs
+++ b/src/core/db/mod.rs
@@ -181,6 +181,34 @@ impl Database {
             ",
             )
             .context("Failed to run database migrations")?;
+
+        // Version-gated migrations — guarded by PRAGMA user_version so they
+        // only run once even if migrate() is called on every startup.
+        let version: i64 = self
+            .conn
+            .query_row("PRAGMA user_version", [], |r| r.get(0))
+            .unwrap_or(0);
+
+        if version < 1 {
+            // Add indexed workflow_run_id column so modl status doesn't need a
+            // full spec_json LIKE scan.
+            let _ = self
+                .conn
+                .execute_batch("ALTER TABLE jobs ADD COLUMN workflow_run_id TEXT;");
+            let _ = self.conn.execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_jobs_workflow_run_id
+                 ON jobs (workflow_run_id) WHERE workflow_run_id IS NOT NULL;",
+            );
+            // Back-fill existing rows using SQLite's json_extract.
+            let _ = self.conn.execute_batch(
+                "UPDATE jobs SET workflow_run_id =
+                     json_extract(spec_json, '$.labels.workflow_run')
+                 WHERE workflow_run_id IS NULL
+                   AND json_type(spec_json, '$.labels.workflow_run') = 'text';",
+            );
+            let _ = self.conn.execute_batch("PRAGMA user_version = 1;");
+        }
+
         Ok(())
     }
 }

--- a/src/core/db/mod.rs
+++ b/src/core/db/mod.rs
@@ -209,6 +209,14 @@ impl Database {
             let _ = self.conn.execute_batch("PRAGMA user_version = 1;");
         }
 
+        if version < 2 {
+            let _ = self.conn.execute_batch(
+                "CREATE INDEX IF NOT EXISTS idx_artifacts_job_id
+                 ON artifacts (job_id) WHERE job_id IS NOT NULL;",
+            );
+            let _ = self.conn.execute_batch("PRAGMA user_version = 2;");
+        }
+
         Ok(())
     }
 }

--- a/src/core/db/models.rs
+++ b/src/core/db/models.rs
@@ -22,6 +22,8 @@ impl Database {
                 ],
             )
             .context("Failed to insert installed model")?;
+        // Keep the shared store index in sync (best-effort — errors ignored).
+        crate::core::store_index::upsert(record);
         Ok(())
     }
 
@@ -43,6 +45,7 @@ impl Database {
         self.conn
             .execute("DELETE FROM installed WHERE id = ?1", params![id])
             .context("Failed to remove installed model")?;
+        crate::core::store_index::remove_by_id(id);
         Ok(())
     }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -32,6 +32,7 @@ pub mod resolver;
 pub mod run_manifest;
 pub mod runtime;
 pub mod store;
+pub mod store_index;
 pub mod symlink;
 pub mod training;
 pub mod training_status;

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -25,6 +25,7 @@ pub mod outputs;
 pub mod paths;
 pub mod preflight;
 pub mod presets;
+pub mod reconcile;
 pub mod registry;
 pub mod remote_executor;
 pub mod resolver;

--- a/src/core/reconcile.rs
+++ b/src/core/reconcile.rs
@@ -1,0 +1,154 @@
+use anyhow::Result;
+use std::collections::{HashMap, HashSet};
+
+use crate::core::config::Config;
+use crate::core::db::Database;
+use crate::core::registry::RegistryIndex;
+
+/// Scan store directories and register any files not already tracked in the DB.
+///
+/// Uses `canonicalize()` on each file path so symlinked stores (e.g. a new OS
+/// user whose `~/modl/store` points to another user's store) produce canonical
+/// paths that survive across users.
+///
+/// Returns the number of newly-registered models.
+pub fn reconcile_store(db: &Database) -> Result<usize> {
+    let config = Config::load()?;
+
+    let tracked: HashSet<String> = db
+        .list_installed(None)?
+        .into_iter()
+        .map(|m| m.store_path)
+        .collect();
+
+    let mut candidates: Vec<(String, String, String, String, u64)> = Vec::new();
+
+    let store_dir = config.store_root().join("store");
+    scan_dir(&store_dir, &tracked, &mut candidates);
+
+    // Also cover the config-dir store (~/.modl/store) for locally-trained LoRAs.
+    let config_dir_store = Config::default_path()
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .join("store");
+    if config_dir_store != store_dir {
+        scan_dir(&config_dir_store, &tracked, &mut candidates);
+    }
+
+    if candidates.is_empty() {
+        return Ok(0);
+    }
+
+    let registry_lookup = build_registry_lookup();
+    let mut registered = 0;
+
+    for (store_path, asset_type, hash_prefix, file_name, size) in &candidates {
+        let (id, name, variant) = registry_lookup
+            .get(hash_prefix.as_str())
+            .cloned()
+            .unwrap_or_else(|| {
+                let stem = file_name
+                    .strip_suffix(".safetensors")
+                    .or_else(|| file_name.strip_suffix(".ckpt"))
+                    .or_else(|| file_name.strip_suffix(".bin"))
+                    .or_else(|| file_name.strip_suffix(".pt"))
+                    .unwrap_or(file_name);
+                (format!("local/{asset_type}/{stem}"), stem.to_string(), None)
+            });
+
+        if db
+            .insert_installed(&crate::core::db::InstalledModelRecord {
+                id: &id,
+                name: &name,
+                asset_type,
+                variant: variant.as_deref(),
+                sha256: hash_prefix,
+                size: *size,
+                file_name,
+                store_path,
+            })
+            .is_ok()
+        {
+            registered += 1;
+        }
+    }
+
+    Ok(registered)
+}
+
+fn scan_dir(
+    store_dir: &std::path::Path,
+    tracked: &HashSet<String>,
+    out: &mut Vec<(String, String, String, String, u64)>,
+) {
+    if !store_dir.is_dir() {
+        return;
+    }
+    let Ok(type_dirs) = std::fs::read_dir(store_dir) else {
+        return;
+    };
+    for type_entry in type_dirs.flatten() {
+        if !type_entry.path().is_dir() {
+            continue;
+        }
+        let Ok(hash_dirs) = std::fs::read_dir(type_entry.path()) else {
+            continue;
+        };
+        for hash_entry in hash_dirs.flatten() {
+            if !hash_entry.path().is_dir() {
+                continue;
+            }
+            let Ok(files) = std::fs::read_dir(hash_entry.path()) else {
+                continue;
+            };
+            for file_entry in files.flatten() {
+                let file_path = file_entry.path();
+                if !file_path.is_file() {
+                    continue;
+                }
+                // Use the canonical path so symlinked stores produce stable DB entries.
+                let canonical =
+                    std::fs::canonicalize(&file_path).unwrap_or_else(|_| file_path.clone());
+                let path_str = canonical.to_string_lossy().to_string();
+                if tracked.contains(&path_str) {
+                    continue;
+                }
+                let size = std::fs::metadata(&canonical).map(|m| m.len()).unwrap_or(0);
+                let asset_type = type_entry.file_name().to_string_lossy().to_string();
+                let hash_prefix = hash_entry.file_name().to_string_lossy().to_string();
+                let file_name = file_entry.file_name().to_string_lossy().to_string();
+                out.push((path_str, asset_type, hash_prefix, file_name, size));
+            }
+        }
+    }
+}
+
+fn build_registry_lookup() -> HashMap<String, (String, String, Option<String>)> {
+    let mut map = HashMap::new();
+    let Ok(index) = RegistryIndex::load() else {
+        return map;
+    };
+    for manifest in &index.items {
+        if let Some(ref file) = manifest.file
+            && file.sha256.len() >= 16
+        {
+            map.insert(
+                file.sha256[..16].to_string(),
+                (manifest.id.clone(), manifest.name.clone(), None),
+            );
+        }
+        for variant in &manifest.variants {
+            if variant.sha256.len() >= 16 {
+                map.insert(
+                    variant.sha256[..16].to_string(),
+                    (
+                        manifest.id.clone(),
+                        manifest.name.clone(),
+                        Some(variant.id.clone()),
+                    ),
+                );
+            }
+        }
+    }
+    map
+}

--- a/src/core/reconcile.rs
+++ b/src/core/reconcile.rs
@@ -1,6 +1,10 @@
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 
+use crate::core::config::Config;
+use crate::core::db::Database;
+use crate::core::registry::RegistryIndex;
+
 /// Fast reconciliation from the shared store index.yaml instead of a directory scan.
 ///
 /// For new users with a symlinked store, this populates the local SQLite from
@@ -38,10 +42,6 @@ pub fn reconcile_from_index(db: &Database) -> Result<usize> {
     }
     Ok(registered)
 }
-
-use crate::core::config::Config;
-use crate::core::db::Database;
-use crate::core::registry::RegistryIndex;
 
 /// Scan store directories and register any files not already tracked in the DB.
 ///

--- a/src/core/reconcile.rs
+++ b/src/core/reconcile.rs
@@ -1,6 +1,44 @@
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 
+/// Fast reconciliation from the shared store index.yaml instead of a directory scan.
+///
+/// For new users with a symlinked store, this populates the local SQLite from
+/// the YAML that install operations maintain. O(index entries), not O(files).
+/// Returns the number of newly-registered entries.
+pub fn reconcile_from_index(db: &Database) -> Result<usize> {
+    let entries = crate::core::store_index::load();
+    if entries.is_empty() {
+        return Ok(0);
+    }
+    let tracked: HashSet<String> = db
+        .list_installed(None)?
+        .into_iter()
+        .map(|m| m.store_path)
+        .collect();
+
+    let mut registered = 0;
+    for entry in &entries {
+        if !tracked.contains(&entry.store_path)
+            && db
+                .insert_installed(&crate::core::db::InstalledModelRecord {
+                    id: &entry.id,
+                    name: &entry.name,
+                    asset_type: &entry.asset_type,
+                    variant: entry.variant.as_deref(),
+                    sha256: &entry.sha256,
+                    size: entry.size,
+                    file_name: &entry.file_name,
+                    store_path: &entry.store_path,
+                })
+                .is_ok()
+        {
+            registered += 1;
+        }
+    }
+    Ok(registered)
+}
+
 use crate::core::config::Config;
 use crate::core::db::Database;
 use crate::core::registry::RegistryIndex;

--- a/src/core/store_index.rs
+++ b/src/core/store_index.rs
@@ -1,0 +1,85 @@
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+use crate::core::db::InstalledModelRecord;
+
+/// Shared store index — a YAML manifest at `<store_root>/store/index.yaml`.
+///
+/// Written by every install/uninstall operation so the index is always current.
+/// On `modl ls`, a new user whose `~/modl/store` is a symlink to a shared store
+/// reads this file and populates their local SQLite in milliseconds instead of
+/// walking the entire directory tree.
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct IndexEntry {
+    pub id: String,
+    pub name: String,
+    pub asset_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
+    pub sha256: String,
+    pub size: u64,
+    pub file_name: String,
+    pub store_path: String,
+}
+
+fn index_path() -> PathBuf {
+    // Prefer config-declared store root; fall back to ~/.modl/store.
+    crate::core::config::Config::load()
+        .ok()
+        .map(|c| c.store_root().join("store").join("index.yaml"))
+        .unwrap_or_else(|| {
+            crate::core::paths::modl_root()
+                .join("store")
+                .join("index.yaml")
+        })
+}
+
+pub fn load() -> Vec<IndexEntry> {
+    let path = index_path();
+    if !path.exists() {
+        return vec![];
+    }
+    std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| serde_yaml::from_str(&s).ok())
+        .unwrap_or_default()
+}
+
+fn save(entries: &[IndexEntry]) {
+    let path = index_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Ok(yaml) = serde_yaml::to_string(entries) {
+        let _ = std::fs::write(&path, yaml);
+    }
+}
+
+/// Add or update an entry (keyed by `id`). Errors are intentionally swallowed
+/// — the index is a best-effort cache; SQLite is the source of truth.
+pub fn upsert(record: &InstalledModelRecord) {
+    let mut entries = load();
+    entries.retain(|e| e.id != record.id);
+    entries.push(IndexEntry {
+        id: record.id.to_string(),
+        name: record.name.to_string(),
+        asset_type: record.asset_type.to_string(),
+        variant: record.variant.map(|v| v.to_string()),
+        sha256: record.sha256.to_string(),
+        size: record.size,
+        file_name: record.file_name.to_string(),
+        store_path: record.store_path.to_string(),
+    });
+    entries.sort_by(|a, b| a.id.cmp(&b.id));
+    save(&entries);
+}
+
+/// Remove the entry for `id`. No-op if not found.
+pub fn remove_by_id(id: &str) {
+    let mut entries = load();
+    let before = entries.len();
+    entries.retain(|e| e.id != id);
+    if entries.len() != before {
+        save(&entries);
+    }
+}

--- a/src/core/store_index.rs
+++ b/src/core/store_index.rs
@@ -47,11 +47,20 @@ pub fn load() -> Vec<IndexEntry> {
 
 fn save(entries: &[IndexEntry]) {
     let path = index_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    if let Ok(yaml) = serde_yaml::to_string(entries) {
-        let _ = std::fs::write(&path, yaml);
+    let Some(parent) = path.parent() else { return };
+    let _ = std::fs::create_dir_all(parent);
+    let Ok(yaml) = serde_yaml::to_string(entries) else {
+        return;
+    };
+    // Write to a sibling tempfile then rename atomically so concurrent writers
+    // on different OS users never produce a partial or interleaved index.
+    if let Ok(mut tmp) = tempfile::Builder::new()
+        .prefix(".index-")
+        .suffix(".yaml.tmp")
+        .tempfile_in(parent)
+        && std::io::Write::write_all(&mut tmp, yaml.as_bytes()).is_ok()
+    {
+        let _ = tmp.persist(&path);
     }
 }
 

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -267,7 +267,12 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
                 count: raw_step.count.or(raw.defaults.count),
             })
         } else {
-            let source_str = raw_step.edit.as_ref().unwrap();
+            let source_str = raw_step.edit.as_ref().ok_or_else(|| {
+                anyhow!(
+                    "step `{}`: expected `generate:` or `edit:` field",
+                    raw_step.id
+                )
+            })?;
             let edit_prompt = raw_step.prompt.as_ref().ok_or_else(|| {
                 anyhow!(
                     "step `{}`: edit steps require a `prompt:` field",

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -9,7 +9,7 @@
 use anyhow::{Context, Result, anyhow, bail};
 use base64::Engine as _;
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
 // ---------------------------------------------------------------------------
@@ -105,6 +105,10 @@ struct RawWorkflow {
     lora: Option<String>,
     #[serde(default)]
     defaults: StepDefaults,
+    /// Named image variables — defined once, referenced in any edit step as `$name`.
+    /// Values are either `data:image/...;base64,...` URIs or server-side file paths.
+    #[serde(default)]
+    images: HashMap<String, String>,
     steps: Vec<RawStep>,
 }
 
@@ -179,6 +183,10 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
     if raw.steps.is_empty() {
         bail!("workflow must have at least one step");
     }
+
+    // Resolve named image variables before processing steps. Each value is either
+    // a base64 data URI or a server-side path; both materialise to a PathBuf.
+    let image_vars = resolve_image_vars(&raw.images, base_dir)?;
 
     let mut seen_ids: HashSet<String> = HashSet::new();
     let mut materialized: Vec<Step> = Vec::with_capacity(raw.steps.len());
@@ -280,7 +288,8 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
                     raw_step.id
                 )
             })?;
-            let source = parse_image_ref(source_str, base_dir, &seen_ids, &raw_step.id)?;
+            let source =
+                parse_image_ref(source_str, base_dir, &seen_ids, &image_vars, &raw_step.id)?;
             StepKind::Edit(EditStep {
                 source,
                 prompt: edit_prompt.clone(),
@@ -355,18 +364,76 @@ fn validate_seeds(
     Ok(())
 }
 
+/// Pre-process the top-level `images:` map: decode/resolve each value and write
+/// it to `base_dir/{name}-ref.{ext}` so every step can reference it by name.
+fn resolve_image_vars(
+    images: &HashMap<String, String>,
+    base_dir: &Path,
+) -> Result<HashMap<String, PathBuf>> {
+    let mut vars = HashMap::with_capacity(images.len());
+    for (name, value) in images {
+        if !is_valid_id(name) {
+            bail!("images: variable name `{name}` must contain only letters, digits, `-`, `_`");
+        }
+        let path = if value.starts_with("data:image/") {
+            let (header, data) = value
+                .split_once(',')
+                .ok_or_else(|| anyhow!("images.{name}: data URI is missing the comma separator"))?;
+            let ext = header
+                .trim_start_matches("data:image/")
+                .split_once(';')
+                .map(|(t, _)| t)
+                .unwrap_or("png");
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(data)
+                .with_context(|| format!("images.{name}: failed to decode base64 data"))?;
+            let out_path = base_dir.join(format!("{name}-ref.{ext}"));
+            std::fs::write(&out_path, &bytes).with_context(|| {
+                format!("images.{name}: failed to write to `{}`", out_path.display())
+            })?;
+            out_path
+        } else {
+            let p = if Path::new(value).is_absolute() {
+                PathBuf::from(value)
+            } else {
+                base_dir.join(value)
+            };
+            if !p.exists() {
+                bail!("images.{name}: file `{}` does not exist", p.display());
+            }
+            p
+        };
+        vars.insert(name.clone(), path);
+    }
+    Ok(vars)
+}
+
 /// Parse an `edit:` source image reference.
 ///
-/// Two forms:
+/// Three forms:
+/// - `$name` (no `.outputs[`) → named image variable from the top-level `images:` map
 /// - `$step-id.outputs[N]` → resolved at runtime to the Nth output of an earlier step
 /// - Anything else → filesystem path relative to `base_dir`, must exist
 fn parse_image_ref(
     s: &str,
     base_dir: &Path,
     earlier_step_ids: &HashSet<String>,
+    image_vars: &HashMap<String, PathBuf>,
     current_step_id: &str,
 ) -> Result<ImageRef> {
     if let Some(rest) = s.strip_prefix('$') {
+        // `$name` with no dot → image variable ref.
+        // `$step-id.outputs[N]` → step-output ref.
+        // Anything else (e.g. `$a.outputs` missing `[N]`) → malformed, caught below.
+        if !rest.contains('.') {
+            let path = image_vars.get(rest).ok_or_else(|| {
+                anyhow!(
+                    "step `{current_step_id}`: image variable `{s}` is not defined — add `{rest}:` to the top-level `images:` map"
+                )
+            })?;
+            return Ok(ImageRef::Local(path.clone()));
+        }
+
         let (step_id, bracket_part) = rest.split_once(".outputs[").ok_or_else(|| {
             anyhow!(
                 "step `{current_step_id}`: invalid step-output ref `{s}` — expected `$step-id.outputs[N]`"
@@ -995,5 +1062,60 @@ steps:
             },
             _ => panic!("expected edit step"),
         }
+    }
+
+    // 1×1 red pixel PNG used across image-var tests.
+    const RED_PNG_B64: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+
+    #[test]
+    fn image_var_base64_resolved_by_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "name: test\nmodel: flux-dev\nimages:\n  alice: \"data:image/png;base64,{RED_PNG_B64}\"\nsteps:\n  - id: s1\n    edit: \"$alice\"\n    prompt: \"fix it\"\n"
+        );
+        let wf = parse_str(&yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Edit(e) => match &e.source {
+                ImageRef::Local(p) => {
+                    assert!(p.exists());
+                    assert!(p.to_string_lossy().ends_with("alice-ref.png"));
+                }
+                _ => panic!("expected Local"),
+            },
+            _ => panic!("expected edit"),
+        }
+    }
+
+    #[test]
+    fn image_var_reused_across_steps_same_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "name: test\nmodel: flux-dev\nimages:\n  hero: \"data:image/png;base64,{RED_PNG_B64}\"\nsteps:\n  - id: s1\n    edit: \"$hero\"\n    prompt: \"scene 1\"\n  - id: s2\n    edit: \"$hero\"\n    prompt: \"scene 2\"\n"
+        );
+        let wf = parse_str(&yaml, tmp.path()).unwrap();
+        let path0 = match &wf.steps[0].kind {
+            StepKind::Edit(e) => match &e.source {
+                ImageRef::Local(p) => p.clone(),
+                _ => panic!(),
+            },
+            _ => panic!(),
+        };
+        let path1 = match &wf.steps[1].kind {
+            StepKind::Edit(e) => match &e.source {
+                ImageRef::Local(p) => p.clone(),
+                _ => panic!(),
+            },
+            _ => panic!(),
+        };
+        assert_eq!(path0, path1, "both steps should point to the same file");
+    }
+
+    #[test]
+    fn image_var_undefined_gives_clear_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = "name: test\nmodel: flux-dev\nsteps:\n  - id: s1\n    edit: \"$nobody\"\n    prompt: \"hi\"\n";
+        let err = parse_str(yaml, tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("nobody"), "got: {err}");
+        assert!(err.contains("images:"), "got: {err}");
     }
 }

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -7,6 +7,7 @@
 //! `GenerateJobSpec` / `EditJobSpec` happens at execution time (Phase B).
 
 use anyhow::{Context, Result, anyhow, bail};
+use base64::Engine as _;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -394,6 +395,32 @@ fn parse_image_ref(
             step_id: step_id.to_string(),
             index,
         })
+    } else if s.starts_with("data:image/") {
+        // Base64 inline image — decode and materialise to disk next to the spec file.
+        // Enables passing images from a remote client through the MCP run_workflow tool.
+        let (header, data) = s.split_once(',').ok_or_else(|| {
+            anyhow!(
+                "step `{current_step_id}`: inline image `data:...` is missing the comma separator"
+            )
+        })?;
+        let ext = header
+            .trim_start_matches("data:image/")
+            .split_once(';')
+            .map(|(t, _)| t)
+            .unwrap_or("png");
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(data)
+            .with_context(|| {
+                format!("step `{current_step_id}`: failed to decode base64 inline image")
+            })?;
+        let out_path = base_dir.join(format!("{current_step_id}-source.{ext}"));
+        std::fs::write(&out_path, &bytes).with_context(|| {
+            format!(
+                "step `{current_step_id}`: failed to write inline image to `{}`",
+                out_path.display()
+            )
+        })?;
+        Ok(ImageRef::Local(out_path))
     } else {
         let path = if Path::new(s).is_absolute() {
             PathBuf::from(s)
@@ -940,5 +967,33 @@ steps:
 "#;
         let err = parse(yaml).unwrap_err().to_string();
         assert!(err.contains("step-output ref"), "got: {err}");
+    }
+
+    #[test]
+    fn inline_base64_image_materialised() {
+        use std::io::Read;
+        // 1×1 red pixel PNG, base64-encoded.
+        let b64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI6QAAAABJRU5ErkJggg==";
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "name: test\nmodel: flux-dev\nsteps:\n  - id: retouch\n    edit: \"data:image/png;base64,{b64}\"\n    prompt: \"fix it\"\n"
+        );
+        let wf = parse_str(&yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Edit(e) => match &e.source {
+                ImageRef::Local(p) => {
+                    assert!(p.exists(), "inline image should be written to disk");
+                    assert!(p.to_string_lossy().ends_with("retouch-source.png"));
+                    let mut bytes = Vec::new();
+                    std::fs::File::open(p)
+                        .unwrap()
+                        .read_to_end(&mut bytes)
+                        .unwrap();
+                    assert!(!bytes.is_empty());
+                }
+                _ => panic!("expected Local after inline decode"),
+            },
+            _ => panic!("expected edit step"),
+        }
     }
 }

--- a/src/ui/routes/mod.rs
+++ b/src/ui/routes/mod.rs
@@ -7,3 +7,4 @@ pub mod models;
 pub mod outputs;
 pub mod studio;
 pub mod training;
+pub mod workflow_runs;

--- a/src/ui/routes/workflow_runs.rs
+++ b/src/ui/routes/workflow_runs.rs
@@ -27,21 +27,35 @@ pub async fn api_export_run_zip(Path(run_id): Path<String>) -> Response {
             ];
             (headers, Body::from(bytes)).into_response()
         }
-        Ok(Err(e)) => (
+        Ok(Err(ZipError::NotFound(id))) => (
             StatusCode::NOT_FOUND,
-            format!("No artifacts found for run '{e}'"),
+            format!("No workflow run found: '{id}'"),
         )
             .into_response(),
+        Ok(Err(ZipError::NoArtifacts(id))) => (
+            StatusCode::ACCEPTED,
+            format!("Run '{id}' exists but has no artifacts yet — try again later"),
+        )
+            .into_response(),
+        Ok(Err(ZipError::Other(e))) => (StatusCode::INTERNAL_SERVER_ERROR, e).into_response(),
         Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "ZIP generation failed").into_response(),
     }
 }
 
-fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), String> {
-    let db = Database::open().map_err(|e| e.to_string())?;
-    let jobs = db.list_jobs_by_run_id(run_id).map_err(|e| e.to_string())?;
+enum ZipError {
+    NotFound(String),
+    NoArtifacts(String),
+    Other(String),
+}
+
+fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), ZipError> {
+    let db = Database::open().map_err(|e| ZipError::Other(e.to_string()))?;
+    let jobs = db
+        .list_jobs_by_run_id(run_id)
+        .map_err(|e| ZipError::Other(e.to_string()))?;
 
     if jobs.is_empty() {
-        return Err(run_id.to_string());
+        return Err(ZipError::NotFound(run_id.to_string()));
     }
 
     let mut artifact_paths: Vec<String> = Vec::new();
@@ -55,12 +69,12 @@ fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), String> {
     }
 
     if artifact_paths.is_empty() {
-        return Err(run_id.to_string());
+        return Err(ZipError::NoArtifacts(run_id.to_string()));
     }
 
     // Build ZIP in a tempfile; the finished archive is read into memory before
     // sending. Acceptable for typical run sizes; revisit if >1 GB runs appear.
-    let tmp = tempfile::NamedTempFile::new().map_err(|e| e.to_string())?;
+    let tmp = tempfile::NamedTempFile::new().map_err(|e| ZipError::Other(e.to_string()))?;
     let mut zip = zip::ZipWriter::new(tmp);
     let options = zip::write::FileOptions::<()>::default()
         .compression_method(zip::CompressionMethod::Deflated);
@@ -81,8 +95,8 @@ fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), String> {
         }
     }
 
-    let tmp_done = zip.finish().map_err(|e| e.to_string())?;
-    let bytes = std::fs::read(tmp_done.path()).map_err(|e| e.to_string())?;
+    let tmp_done = zip.finish().map_err(|e| ZipError::Other(e.to_string()))?;
+    let bytes = std::fs::read(tmp_done.path()).map_err(|e| ZipError::Other(e.to_string()))?;
     let filename = format!("{run_id}.zip");
     Ok((bytes, filename))
 }

--- a/src/ui/routes/workflow_runs.rs
+++ b/src/ui/routes/workflow_runs.rs
@@ -58,21 +58,25 @@ fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), String> {
         return Err(run_id.to_string());
     }
 
-    // Stream into a tempfile to avoid holding all images in RAM.
+    // Build ZIP in a tempfile; the finished archive is read into memory before
+    // sending. Acceptable for typical run sizes; revisit if >1 GB runs appear.
     let tmp = tempfile::NamedTempFile::new().map_err(|e| e.to_string())?;
     let mut zip = zip::ZipWriter::new(tmp);
     let options = zip::write::FileOptions::<()>::default()
         .compression_method(zip::CompressionMethod::Deflated);
 
-    for path in &artifact_paths {
+    for (idx, path) in artifact_paths.iter().enumerate() {
         let p = std::path::Path::new(path);
-        let name = p
+        let base_name = p
             .file_name()
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "file".to_string());
+        // Prefix with index to avoid collisions when multiple steps produce
+        // identically-named files.
+        let entry_name = format!("{idx:03}_{base_name}");
 
         if let Ok(data) = std::fs::read(p) {
-            let _ = zip.start_file(&name, options);
+            let _ = zip.start_file(&entry_name, options);
             let _ = zip.write_all(&data);
         }
     }

--- a/src/ui/routes/workflow_runs.rs
+++ b/src/ui/routes/workflow_runs.rs
@@ -1,0 +1,83 @@
+use axum::{
+    body::Body,
+    extract::Path,
+    http::{StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use std::io::Write;
+use tokio::task;
+
+use crate::core::db::Database;
+
+/// GET /api/workflow-runs/:run_id/export.zip
+///
+/// Collects all artifacts for a workflow run and streams them as a ZIP archive.
+/// Works with any HTTP client: curl, browser, `modl outputs export --server`.
+pub async fn api_export_run_zip(Path(run_id): Path<String>) -> Response {
+    let result = task::spawn_blocking(move || build_zip(&run_id)).await;
+
+    match result {
+        Ok(Ok((bytes, filename))) => {
+            let headers = [
+                (header::CONTENT_TYPE, "application/zip".to_string()),
+                (
+                    header::CONTENT_DISPOSITION,
+                    format!("attachment; filename=\"{filename}\""),
+                ),
+            ];
+            (headers, Body::from(bytes)).into_response()
+        }
+        Ok(Err(e)) => (
+            StatusCode::NOT_FOUND,
+            format!("No artifacts found for run '{e}'"),
+        )
+            .into_response(),
+        Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "ZIP generation failed").into_response(),
+    }
+}
+
+fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), String> {
+    let db = Database::open().map_err(|e| e.to_string())?;
+    let jobs = db.list_jobs_by_run_id(run_id).map_err(|e| e.to_string())?;
+
+    if jobs.is_empty() {
+        return Err(run_id.to_string());
+    }
+
+    let mut artifact_paths: Vec<String> = Vec::new();
+    for job in &jobs {
+        let arts = db.list_artifacts(Some(&job.job_id)).unwrap_or_default();
+        for a in arts {
+            if std::path::Path::new(&a.path).is_file() {
+                artifact_paths.push(a.path);
+            }
+        }
+    }
+
+    if artifact_paths.is_empty() {
+        return Err(run_id.to_string());
+    }
+
+    let buf = Vec::new();
+    let mut zip = zip::ZipWriter::new(std::io::Cursor::new(buf));
+    let options = zip::write::FileOptions::<()>::default()
+        .compression_method(zip::CompressionMethod::Deflated);
+
+    for path in &artifact_paths {
+        let p = std::path::Path::new(path);
+        let name = p
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "file".to_string());
+
+        if let Ok(data) = std::fs::read(p) {
+            let _ = zip.start_file(&name, options);
+            let _ = zip.write_all(&data);
+        }
+    }
+
+    let cursor = zip.finish().map_err(|e| e.to_string())?;
+    let bytes = cursor.into_inner();
+    let filename = format!("{run_id}.zip");
+    Ok((bytes, filename))
+}

--- a/src/ui/routes/workflow_runs.rs
+++ b/src/ui/routes/workflow_runs.rs
@@ -58,8 +58,9 @@ fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), String> {
         return Err(run_id.to_string());
     }
 
-    let buf = Vec::new();
-    let mut zip = zip::ZipWriter::new(std::io::Cursor::new(buf));
+    // Stream into a tempfile to avoid holding all images in RAM.
+    let tmp = tempfile::NamedTempFile::new().map_err(|e| e.to_string())?;
+    let mut zip = zip::ZipWriter::new(tmp);
     let options = zip::write::FileOptions::<()>::default()
         .compression_method(zip::CompressionMethod::Deflated);
 
@@ -76,8 +77,8 @@ fn build_zip(run_id: &str) -> Result<(Vec<u8>, String), String> {
         }
     }
 
-    let cursor = zip.finish().map_err(|e| e.to_string())?;
-    let bytes = cursor.into_inner();
+    let tmp_done = zip.finish().map_err(|e| e.to_string())?;
+    let bytes = std::fs::read(tmp_done.path()).map_err(|e| e.to_string())?;
     let filename = format!("{run_id}.zip");
     Ok((bytes, filename))
 }

--- a/src/ui/server.rs
+++ b/src/ui/server.rs
@@ -152,7 +152,7 @@ pub async fn start(port: u16, open_browser: bool) -> Result<()> {
         .route("/api/datasets/{name}", get(datasets::api_get_dataset))
         // Workflow run export
         .route(
-            "/api/workflow-runs/:run_id/export.zip",
+            "/api/workflow-runs/{run_id}/export.zip",
             get(workflow_runs::api_export_run_zip),
         )
         // Outputs

--- a/src/ui/server.rs
+++ b/src/ui/server.rs
@@ -9,7 +9,7 @@ use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 
 use super::routes::{
-    analysis, civitai, datasets, files, generate, models, outputs, studio, training,
+    analysis, civitai, datasets, files, generate, models, outputs, studio, training, workflow_runs,
 };
 
 // ---------------------------------------------------------------------------
@@ -150,6 +150,11 @@ pub async fn start(port: u16, open_browser: bool) -> Result<()> {
         // Datasets
         .route("/api/datasets", get(datasets::api_list_datasets))
         .route("/api/datasets/{name}", get(datasets::api_get_dataset))
+        // Workflow run export
+        .route(
+            "/api/workflow-runs/:run_id/export.zip",
+            get(workflow_runs::api_export_run_zip),
+        )
         // Outputs
         .route(
             "/api/outputs",


### PR DESCRIPTION
## Summary

Four features that work together to enable: shared model storage across Linux users, remote job submission via MCP over Tailscale, and batch output download.

### Phase 1 — `modl ls` filesystem fallback
- New `src/core/reconcile.rs` with `reconcile_store()` — scans store dirs and auto-registers any files not yet tracked in SQLite
- `modl ls` calls it silently on every run, prints a note only if new models were found
- Uses `canonicalize()` so symlinked stores work (e.g. a new user whose `~/modl/store` → `/shared/modl/store` sees all models immediately)
- `doctor --repair` now delegates to the same function instead of duplicating the logic

### Phase 2 — `modl status <run-id>`
- New command: `modl status <run-id> [--json]`
- Queries all step-jobs by `workflow_run` label in `spec_json`, aggregates into `pending / running / completed / partial_failure`
- Set `MODL_BASE_URL=http://server:PORT` to get HTTP URLs instead of local paths — useful for remote access over Tailscale

### Phase 3 — MCP workflow tools (15 tools total, up from 12)
Three new tools added to the existing stdio MCP server:
- **`run_workflow(spec_yaml)`** — writes YAML to tempfile, spawns `modl run` detached, returns `{ run_id, status: "submitted" }` immediately. Fire-and-forget: submit from laptop, close lid, come back later.
- **`job_status(run_id)`** — polls `modl status --json` for a run
- **`list_run_outputs(run_id)`** — returns artifact URLs for a completed run

Claude Code SSH config (no port forwarding, no tokens):
```json
{ "command": "ssh", "args": ["server", "modl", "mcp"] }
```

### Phase 4 — `modl outputs export` + ZIP endpoint
- `GET /api/workflow-runs/:run_id/export.zip` — new Axum route, streams all artifacts for a run as a ZIP
- `modl outputs export <run-id> [--dest ./local] [--server http://server:PORT]`
  - Without `--server`: copies files locally from DB records
  - With `--server` (or `MODL_SERVER` env): fetches the ZIP from a remote `modl serve` instance and unpacks it
- Also works with `curl http://server:PORT/api/workflow-runs/<run-id>/export.zip -o run.zip`

## Use case this enables

```
# On server (home Pop OS box, shared by family):
modl serve &

# On laptop (Claude Code with SSH MCP config):
# Submit 200-image batch, get run_id immediately
run_workflow(spec_yaml="...")  # → { "run_id": "mcp-20240101-120000" }

# Close laptop, come back later
job_status("mcp-20240101-120000")  # → { "status": "completed", "artifacts": [...] }

# Download everything
modl outputs export mcp-20240101-120000 --server http://server:3939 --dest ./my-run
```

## Multi-user setup (family server)
```bash
# Each user symlinks their store to the shared location
ln -s /shared/modl/store ~/modl/store

# modl ls now auto-discovers all shared models on first run
modl ls  # ℹ Auto-registered 15 models found on disk
```

## Test plan
- [ ] `modl ls` with a symlinked store auto-registers models from the symlink target
- [ ] `modl ls` on a fresh user with shared store shows all models without `modl pull`
- [ ] `modl doctor --repair` still works (now delegates to reconcile_store)
- [ ] `modl status <run-id>` returns correct aggregate after a `modl run` completes
- [ ] `modl status <run-id> --json` returns parseable JSON with artifact paths
- [ ] `MODL_BASE_URL=http://server:PORT modl status <run-id> --json` returns HTTP URLs
- [ ] MCP `run_workflow` returns run_id without blocking
- [ ] MCP `job_status` returns correct status
- [ ] `curl http://server:PORT/api/workflow-runs/<run-id>/export.zip` downloads a valid ZIP
- [ ] `modl outputs export <run-id> --dest ./out` copies files locally
- [ ] `modl outputs export <run-id> --server http://server:PORT --dest ./out` fetches remotely

🤖 Generated with [Claude Code](https://claude.com/claude-code)