### PR TITLE
fix: release workflow dies at parse time (secrets in job-level if)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,11 +126,24 @@ jobs:
             artifacts/modl-*
             artifacts/SHA256SUMS
 
+  # The secrets context is not available in job-level `if` expressions;
+  # referencing it there fails the whole workflow at parse time (the 0-second
+  # startup failures that shipped v0.2.13/v0.2.14 with no assets). Gate via a
+  # job output instead, where secrets are legal.
+  docker-gate:
+    name: Check Docker Hub credentials
+    runs-on: ubuntu-latest
+    outputs:
+      has-creds: ${{ steps.check.outputs.has-creds }}
+    steps:
+      - id: check
+        run: echo "has-creds=${{ secrets.DOCKERHUB_USERNAME != '' }}" >> "$GITHUB_OUTPUT"
+
   docker:
     name: Push GPU Docker Image
-    needs: build
+    needs: [build, docker-gate]
     runs-on: ubuntu-latest
-    if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+    if: needs.docker-gate.outputs.has-creds == 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

`release.yml` has failed instantly (0s, no logs) on every tag since v0.2.13, so **v0.2.13 and v0.2.14 have zero release assets** and `curl modl.run/install.sh | sh` currently 404s (it resolves the latest tag, then downloads a nonexistent asset). Last complete release: v0.2.12.

Root cause: v0.2.13 added

```yaml
if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
```

at the **job** level on the `docker` job. The `secrets` context is not available in job-level `if` expressions, which makes the whole workflow invalid at parse time — hence the startup failures with no logs.

## Fix

Standard gate-job pattern: a `docker-gate` job exposes `has-creds` as a job output (secrets are legal in steps), and `docker` conditions on `needs.docker-gate.outputs.has-creds`. Behavior is what v0.2.13 intended: docker push is skipped when Docker Hub credentials aren't configured.

## Notes

- **No release is triggered by merging this** — the workflow only runs on `v*` tags.
- Once merged, the next tag (v0.2.15, when we choose to cut it) will publish assets again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
