### PR TITLE
fix: no silent flag drops on pods — bail or pass through every flag

### DIFF
--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -51,6 +51,8 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
     for (flag, set) in [
         ("--mask", args.mask.is_some()),
         ("--lora", args.lora.is_some()),
+        ("--fast", args.fast.is_some()),
+        ("--blend", args.blend != BlendMode::Pixel),
         ("--cloud", args.cloud),
         ("--attach-gpu", args.attach_gpu),
     ] {
@@ -61,16 +63,42 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
     let model = args.base.unwrap_or("qwen-image-edit-2511");
     let local_image = resolve_image_input(&args.images[0]).await?;
 
+    let (width, height) = match args.size {
+        Some(s) => {
+            let (w, h) = resolve_edit_size(s)?;
+            (Some(w), Some(h))
+        }
+        None => (None, None),
+    };
+    // count>1 maps to explicit seeds (one output per seed on the pod).
+    let seeds: Vec<u64> = match (args.seed, args.count) {
+        (Some(s), c) if c > 1 => (0..c as u64).map(|i| s + i).collect(),
+        (Some(s), _) => vec![s],
+        (None, c) if c > 1 => {
+            let base = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.subsec_nanos() as u64)
+                .unwrap_or(0);
+            (0..c as u64).map(|i| base + i).collect()
+        }
+        (None, _) => vec![],
+    };
+
     let spec = crate::core::pod_run::single_edit_spec(
         model,
         args.prompt,
         std::path::Path::new(&local_image),
+        width,
+        height,
+        args.steps,
+        args.guidance.map(|g| g as f64),
+        &seeds,
     )?;
 
     let rec = crate::core::pod_state::active_pod()
         .await?
         .context("No pod up — run `modl pod up <gpu>` first, or use --attach-gpu / --cloud.")?;
-    println!(
+    eprintln!(
         "{} Editing on pod {} ({}, ${:.3}/hr)…",
         style("→").cyan(),
         rec.instance_id,
@@ -78,8 +106,15 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
         rec.dph_total
     );
     let pod = crate::core::pod::Pod::from(rec.clone());
-    crate::core::pod_run::run_workflow_on_pod(&pod, &spec, None).await?;
-    println!(
+    let outcome =
+        crate::core::pod_run::run_workflow_on_pod(&pod, &spec, None, Default::default()).await?;
+    if args.json {
+        println!(
+            "{}",
+            serde_json::to_string(&super::generate::pod_result_json(&outcome))?
+        );
+    }
+    eprintln!(
         "{} Pod {} still running (${:.3}/hr) — {} when done.",
         style("⚠").yellow(),
         rec.instance_id,

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -139,6 +139,7 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         ("--mask", args.mask.is_some()),
         ("--controlnet", !args.controlnet.is_empty()),
         ("--style-ref", !args.style_ref.is_empty()),
+        ("--fast", args.fast.is_some()),
         ("--cloud", args.cloud),
         ("--attach-gpu", args.attach_gpu),
     ] {
@@ -181,7 +182,7 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
     let rec = crate::core::pod_state::active_pod()
         .await?
         .context("No pod up — run `modl pod up <gpu>` first, or use --attach-gpu / --cloud.")?;
-    println!(
+    eprintln!(
         "{} Generating on pod {} ({}, ${:.3}/hr)…",
         style("→").cyan(),
         rec.instance_id,
@@ -189,8 +190,12 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         rec.dph_total
     );
     let pod = crate::core::pod::Pod::from(rec.clone());
-    crate::core::pod_run::run_workflow_on_pod(&pod, &spec, None).await?;
-    println!(
+    let outcome =
+        crate::core::pod_run::run_workflow_on_pod(&pod, &spec, None, Default::default()).await?;
+    if args.json {
+        println!("{}", serde_json::to_string(&pod_result_json(&outcome))?);
+    }
+    eprintln!(
         "{} Pod {} still running (${:.3}/hr) — {} when done.",
         style("⚠").yellow(),
         rec.instance_id,
@@ -198,6 +203,19 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         style(format!("modl pod rm {}", rec.instance_id)).bold()
     );
     Ok(())
+}
+
+/// JSON result for a pod run — same shape for generate/edit/run so agents
+/// can parse one schema.
+pub(crate) fn pod_result_json(
+    outcome: &crate::core::pod_run::RemoteRunOutcome,
+) -> serde_json::Value {
+    serde_json::json!({
+        "status": outcome.status,
+        "run_id": outcome.run_id,
+        "output_dir": outcome.local_dir,
+        "images": outcome.artifacts,
+    })
 }
 
 async fn run_local(args: GenerateArgs<'_>, db: Database) -> Result<()> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1212,7 +1212,9 @@ See `modl/docs/guides/workflows.md` for the full reference.")]
         #[arg(long)]
         dry_run: bool,
         /// Emit machine-readable JSON instead of human-formatted output.
-        /// Only meaningful with --dry-run today; ignored otherwise.
+        /// Meaningful with --dry-run (execution plan) and with --pod (one
+        /// result object per spec: run_id, status, artifact paths); ignored
+        /// for plain local execution today.
         #[arg(long)]
         json: bool,
         /// Run on the active BYO-key pod (`modl pod up`) — the workflow,

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -202,7 +202,15 @@ pub async fn run(
     if pod {
         // Pod execution ships the YAML to the pod's own modl install — plan
         // building, model resolution, and step chaining all happen there.
-        return run_on_pod(spec_paths, dry_run).await;
+        return run_on_pod(
+            spec_paths,
+            dry_run,
+            json,
+            in_order,
+            skip_existing,
+            run_id_override,
+        )
+        .await;
     }
 
     let db = Database::open()?;
@@ -235,21 +243,71 @@ pub async fn run(
 /// Run each workflow file on the active pod, sequentially, via the remote
 /// modl install (`core::pod_run`). With --dry-run, validate pod
 /// compatibility and list referenced models without renting anything.
-async fn run_on_pod(spec_paths: &[String], dry_run: bool) -> Result<()> {
+///
+/// `--run-id`, `--force` and `--in-order` are forwarded to the pod-side
+/// `modl run` so local and pod flags behave identically. With `--json`, one
+/// result object per spec is emitted on stdout (progress goes to stderr).
+async fn run_on_pod(
+    spec_paths: &[String],
+    dry_run: bool,
+    json: bool,
+    in_order: bool,
+    skip_existing: bool,
+    run_id_override: Option<&str>,
+) -> Result<()> {
     use anyhow::Context as _;
     use console::style;
 
+    if run_id_override.is_some() && spec_paths.len() > 1 {
+        bail!("--run-id with multiple workflow files is ambiguous — pass a single file.");
+    }
+
     if dry_run {
         for path in spec_paths {
-            let yaml =
-                std::fs::read_to_string(path).with_context(|| format!("Failed to read {path}"))?;
-            crate::core::pod_run::check_pod_supported(&yaml)?;
-            let models = crate::core::pod_run::workflow_models(&yaml)?;
-            println!(
-                "{} {path}: pod-compatible — models: {}",
-                style("✓").green(),
-                models.join(", ")
-            );
+            let checked = std::fs::read_to_string(path)
+                .with_context(|| format!("Failed to read {path}"))
+                .and_then(|yaml| {
+                    crate::core::pod_run::check_pod_supported(&yaml)?;
+                    crate::core::pod_run::workflow_models(&yaml)
+                });
+            match checked {
+                Ok(models) => {
+                    if json {
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "valid": true,
+                                "target": "pod",
+                                "spec": path,
+                                "models": models,
+                            })
+                        );
+                    } else {
+                        println!(
+                            "{} {path}: pod-compatible — models: {}",
+                            style("✓").green(),
+                            models.join(", ")
+                        );
+                    }
+                }
+                Err(e) => {
+                    if json {
+                        // Same contract as the local dry-run: exit 0, signal
+                        // validity in the payload so agents can parse it.
+                        println!(
+                            "{}",
+                            serde_json::json!({
+                                "valid": false,
+                                "target": "pod",
+                                "spec": path,
+                                "error": { "message": format!("{e:#}") },
+                            })
+                        );
+                    } else {
+                        return Err(e);
+                    }
+                }
+            }
         }
         return Ok(());
     }
@@ -262,13 +320,13 @@ async fn run_on_pod(spec_paths: &[String], dry_run: bool) -> Result<()> {
     for (i, path) in spec_paths.iter().enumerate() {
         if spec_paths.len() > 1 {
             if i > 0 {
-                println!();
+                eprintln!();
             }
-            println!("── {}/{}: {} ──", i + 1, spec_paths.len(), path);
+            eprintln!("── {}/{}: {} ──", i + 1, spec_paths.len(), path);
         }
         let yaml =
             std::fs::read_to_string(path).with_context(|| format!("Failed to read {path}"))?;
-        println!(
+        eprintln!(
             "{} Running {} on pod {} ({}, ${:.3}/hr)…",
             style("→").cyan(),
             path,
@@ -276,10 +334,21 @@ async fn run_on_pod(spec_paths: &[String], dry_run: bool) -> Result<()> {
             rec.gpu_name,
             rec.dph_total
         );
-        crate::core::pod_run::run_workflow_on_pod(&pod, &yaml, None).await?;
+        let opts = crate::core::pod_run::RemoteRunOptions {
+            run_id: run_id_override.map(String::from),
+            force: !skip_existing,
+            in_order,
+        };
+        let outcome = crate::core::pod_run::run_workflow_on_pod(&pod, &yaml, None, opts).await?;
+        if json {
+            println!(
+                "{}",
+                serde_json::to_string(&super::generate::pod_result_json(&outcome))?
+            );
+        }
     }
 
-    println!(
+    eprintln!(
         "{} Pod {} still running (${:.3}/hr) — {} when done.",
         style("⚠").yellow(),
         rec.instance_id,

--- a/src/cli/train.rs
+++ b/src/cli/train.rs
@@ -64,6 +64,13 @@ impl PodArgs {
 async fn run_pod(spec: TrainJobSpec, args: PodArgs) -> Result<()> {
     use crate::core::{pod, pod_state};
 
+    if spec.params.resume_from.is_some() {
+        anyhow::bail!(
+            "--resume isn't supported with --pod yet — the checkpoint path is local to this \
+             machine and won't exist on the pod. Run locally, or drop --resume."
+        );
+    }
+
     if !args.fresh
         && let Some(rec) = pod_state::active_pod().await?
     {

--- a/src/core/pod.rs
+++ b/src/core/pod.rs
@@ -1046,17 +1046,33 @@ pub(crate) fn run_ssh_stdin(ssh: &SshTarget, cmd: &str, input: &str) -> Result<(
     Ok(())
 }
 
-/// Run a remote script with live output (bootstrap etc.).
+/// Run a remote script with live output (bootstrap etc.). The remote output
+/// is progress narration, so it goes to OUR stderr — stdout stays reserved
+/// for results (`--json` consumers pipe stdout).
 pub(crate) fn run_ssh_streaming(ssh: &SshTarget, script: &str) -> Result<()> {
     let status = Command::new("ssh")
         .args(ssh.base_args())
         .arg(format!("bash -c {}", shell_quote(script)))
+        .stdout(stderr_stdio())
         .status()
         .context("ssh command failed to spawn")?;
     if !status.success() {
         bail!("Remote bootstrap failed (exit {status}).");
     }
     Ok(())
+}
+
+/// A `Stdio` handle pointing at this process's stderr (falls back to
+/// inherited stdout if the fd can't be cloned).
+fn stderr_stdio() -> Stdio {
+    #[cfg(unix)]
+    {
+        use std::os::fd::AsFd;
+        if let Ok(fd) = std::io::stderr().as_fd().try_clone_to_owned() {
+            return Stdio::from(fd);
+        }
+    }
+    Stdio::inherit()
 }
 
 pub(crate) fn rsync_to(ssh: &SshTarget, local: &Path, remote: &str) -> Result<()> {

--- a/src/core/pod_run.rs
+++ b/src/core/pod_run.rs
@@ -42,7 +42,6 @@ const STATUS_POLL_SECS: u64 = 15;
 /// are expected; the run itself is unaffected).
 const MAX_POLL_FAILURES: u32 = 20;
 
-#[allow(dead_code)] // CLI callers print inline today; MCP/UI consumers will read these
 pub struct RemoteRunOutcome {
     pub run_id: String,
     /// Aggregate status: completed | partial_failure | cancelled
@@ -50,6 +49,20 @@ pub struct RemoteRunOutcome {
     /// Local directory the run's artifacts were exported into.
     pub local_dir: PathBuf,
     pub artifacts: Vec<PathBuf>,
+}
+
+/// Caller-controlled knobs for a remote workflow run. Everything here maps
+/// 1:1 onto the pod-side `modl run` invocation so local and pod flags behave
+/// identically.
+#[derive(Default)]
+pub struct RemoteRunOptions {
+    /// Use this run id instead of generating a `pod-…` one (`run --run-id`).
+    pub run_id: Option<String>,
+    /// Pod-side `modl run --force` — regenerate even when matching sidecars
+    /// exist in the pod's outputs.
+    pub force: bool,
+    /// Pod-side `modl run --in-order` — YAML declaration order, no scheduler.
+    pub in_order: bool,
 }
 
 /// Ensure the pod runs the same modl version as this CLI.
@@ -86,7 +99,7 @@ pub fn ensure_modl(pod: &Pod) -> Result<()> {
     let url = format!(
         "https://github.com/modl-org/modl/releases/download/v{version}/modl-v{version}-x86_64-unknown-linux-musl.tar.gz"
     );
-    println!("{} Installing modl v{version} on pod...", style("→").cyan());
+    eprintln!("{} Installing modl v{version} on pod...", style("→").cyan());
     let install = format!(
         "set -e; mkdir -p {REMOTE_MODL_DIR}; curl -fsSL {} | tar xz -C {REMOTE_MODL_DIR}",
         shell_quote(&url)
@@ -94,7 +107,7 @@ pub fn ensure_modl(pod: &Pod) -> Result<()> {
     if run_ssh_streaming(&pod.ssh, &install).is_err() {
         // Dev build with no published asset — upload a locally-built binary.
         let local = local_pod_binary()?;
-        println!(
+        eprintln!(
             "{} No release asset for v{version} — uploading local build ({})...",
             style("!").yellow(),
             local.display()
@@ -161,7 +174,7 @@ fn sha256_file(path: &Path) -> Result<String> {
 /// the pod's auth store so `modl pull` can fetch gated models.
 fn configure_auth(pod: &Pod) -> Result<()> {
     let Some(token) = crate::core::pod::huggingface_token() else {
-        println!(
+        eprintln!(
             "{} No HuggingFace token found — gated models (Flux, Klein) will fail to pull on the pod.",
             style("⚠").yellow()
         );
@@ -193,7 +206,7 @@ pub fn prepare(pod: &Pod, models: &[String]) -> Result<()> {
 /// variant selection (fp8/GGUF by VRAM) happens pod-side.
 pub fn pull_models(pod: &Pod, models: &[String]) -> Result<()> {
     for m in models {
-        println!(
+        eprintln!(
             "{} Ensuring {} on pod...",
             style("→").cyan(),
             style(m).bold()
@@ -232,9 +245,9 @@ pub fn workflow_models(yaml: &str) -> Result<Vec<String>> {
 /// Reject specs the pod can't satisfy yet, with a useful message.
 pub fn check_pod_supported(yaml: &str) -> Result<()> {
     let v: serde_yaml::Value = serde_yaml::from_str(yaml).context("Invalid workflow YAML")?;
+    let steps = v.get("steps").and_then(|s| s.as_sequence());
     let has_lora = v.get("lora").is_some()
-        || v.get("steps")
-            .and_then(|s| s.as_sequence())
+        || steps
             .map(|steps| steps.iter().any(|s| s.get("lora").is_some()))
             .unwrap_or(false);
     if has_lora {
@@ -242,6 +255,37 @@ pub fn check_pod_supported(yaml: &str) -> Result<()> {
             "LoRA references aren't supported on pods yet — the pod's store has no local LoRAs.\n  \
              Run this workflow locally, or drop the `lora:` field."
         );
+    }
+
+    // Image refs must resolve on the pod: `$step.outputs[N]` and `$name`
+    // variables do, data URIs are decoded pod-side, but a bare path names a
+    // file on THIS machine that won't exist there — the run would only fail
+    // minutes later, pod-side, with a confusing message.
+    if let Some(images) = v.get("images").and_then(|m| m.as_mapping()) {
+        for (name, value) in images {
+            let (Some(name), Some(value)) = (name.as_str(), value.as_str()) else {
+                continue;
+            };
+            if !value.starts_with("data:image/") {
+                bail!(
+                    "images.{name} is a file path — it won't exist on the pod.\n  \
+                     Inline it as a base64 data URI:\n    \
+                     {name}: \"data:image/png;base64,...\"  (base64 -w0 <file>, or `base64 -i <file>` on macOS)"
+                );
+            }
+        }
+    }
+    for step in steps.into_iter().flatten() {
+        let Some(src) = step.get("edit").and_then(|e| e.as_str()) else {
+            continue;
+        };
+        if !src.starts_with('$') && !src.starts_with("data:image/") {
+            let id = step.get("id").and_then(|i| i.as_str()).unwrap_or("?");
+            bail!(
+                "step `{id}`: edit source `{src}` is a local file path — it won't exist on the pod.\n  \
+                 Add it to the `images:` map as a base64 data URI and reference it as `$name`."
+            );
+        }
     }
     Ok(())
 }
@@ -252,16 +296,19 @@ pub async fn run_workflow_on_pod(
     pod: &Pod,
     spec_yaml: &str,
     local_dest: Option<&Path>,
+    opts: RemoteRunOptions,
 ) -> Result<RemoteRunOutcome> {
     check_pod_supported(spec_yaml)?;
     let models = workflow_models(spec_yaml)?;
     prepare(pod, &models)?;
 
-    let run_id = format!(
-        "pod-{}-{:04x}",
-        chrono::Local::now().format("%Y%m%d-%H%M%S"),
-        std::process::id() & 0xffff
-    );
+    let run_id = opts.run_id.unwrap_or_else(|| {
+        format!(
+            "pod-{}-{:04x}",
+            chrono::Local::now().format("%Y%m%d-%H%M%S"),
+            std::process::id() & 0xffff
+        )
+    });
 
     // Ship the spec.
     let remote_spec = format!("{REMOTE_ROOT}/runs/{run_id}.yaml");
@@ -275,15 +322,22 @@ pub async fn run_workflow_on_pod(
     // Fire and forget — the run survives a dropped link or a closed laptop.
     let log = format!("{REMOTE_ROOT}/runs/{run_id}.log");
     let pidfile = format!("{REMOTE_ROOT}/runs/{run_id}.pid");
+    let mut run_flags = String::new();
+    if opts.force {
+        run_flags.push_str(" --force");
+    }
+    if opts.in_order {
+        run_flags.push_str(" --in-order");
+    }
     let launch = format!(
-        "nohup {REMOTE_MODL} run {} --run-id {} > {} 2>&1 & echo $! > {}; echo ok",
+        "nohup {REMOTE_MODL} run {} --run-id {}{run_flags} > {} 2>&1 & echo $! > {}; echo ok",
         shell_quote(&remote_spec),
         shell_quote(&run_id),
         shell_quote(&log),
         shell_quote(&pidfile),
     );
     run_ssh_quiet(&pod.ssh, &launch)?;
-    println!(
+    eprintln!(
         "{} Workflow running on pod {} — {}",
         style("→").cyan(),
         pod.instance_id,
@@ -296,7 +350,7 @@ pub async fn run_workflow_on_pod(
         bail!("Pod run {run_id} ended with status: {status}");
     }
     if status == "partial_failure" {
-        println!(
+        eprintln!(
             "{} Some steps failed — exporting the artifacts that did complete.",
             style("⚠").yellow()
         );
@@ -349,14 +403,14 @@ pub fn export_run(
         );
     }
 
-    println!(
+    eprintln!(
         "{} {} artifact(s) → {}",
         style("✓").green().bold(),
         artifacts.len(),
         local_dir.display()
     );
     for a in &artifacts {
-        println!("  {}", a.display());
+        eprintln!("  {}", a.display());
     }
     Ok((local_dir, artifacts))
 }
@@ -372,7 +426,7 @@ fn wait_for_run(pod: &Pod, run_id: &str, log: &str, pidfile: &str) -> Result<Str
         // Drain whatever the tail has produced since the last poll.
         if let Some((_, rx)) = &tail {
             while let Ok(line) = rx.try_recv() {
-                println!("  {}", style(line.trim_end()).dim());
+                eprintln!("  {}", style(line.trim_end()).dim());
             }
             // Tail children die with flaky links — respawn lazily.
             if let Some((child, _)) = &mut tail
@@ -389,7 +443,7 @@ fn wait_for_run(pod: &Pod, run_id: &str, log: &str, pidfile: &str) -> Result<Str
                     if let Some((mut child, rx)) = tail.take() {
                         // Print any final log lines before killing the tail.
                         while let Ok(line) = rx.try_recv() {
-                            println!("  {}", style(line.trim_end()).dim());
+                            eprintln!("  {}", style(line.trim_end()).dim());
                         }
                         let _ = child.kill();
                         let _ = child.wait();
@@ -430,7 +484,7 @@ fn wait_for_run(pod: &Pod, run_id: &str, log: &str, pidfile: &str) -> Result<Str
                     );
                 }
                 if poll_failures == 1 {
-                    println!(
+                    eprintln!(
                         "{} Status poll failed — retrying (run continues on the pod)...",
                         style("!").yellow()
                     );
@@ -547,7 +601,17 @@ pub fn single_generate_spec(
 
 /// Build a one-step edit workflow with the input image inlined as a base64
 /// data URI (the MCP-safe image-ref form — client paths don't exist on pods).
-pub fn single_edit_spec(model: &str, prompt: &str, image_path: &Path) -> Result<String> {
+#[allow(clippy::too_many_arguments)]
+pub fn single_edit_spec(
+    model: &str,
+    prompt: &str,
+    image_path: &Path,
+    width: Option<u32>,
+    height: Option<u32>,
+    steps: Option<u32>,
+    guidance: Option<f64>,
+    seeds: &[u64],
+) -> Result<String> {
     let bytes = std::fs::read(image_path)
         .with_context(|| format!("Failed to read {}", image_path.display()))?;
     let mime = match image_path
@@ -573,6 +637,22 @@ pub fn single_edit_spec(model: &str, prompt: &str, image_path: &Path) -> Result<
     step.insert("id".into(), "edit".into());
     step.insert("edit".into(), "$input".into());
     step.insert("prompt".into(), prompt.into());
+    insert_opt(&mut step, "width", width.map(|v| v.into()));
+    insert_opt(&mut step, "height", height.map(|v| v.into()));
+    insert_opt(&mut step, "steps", steps.map(|v| v.into()));
+    insert_opt(&mut step, "guidance", guidance.map(|v| v.into()));
+    match seeds {
+        [] => {}
+        [one] => {
+            step.insert("seed".into(), (*one).into());
+        }
+        many => {
+            step.insert(
+                "seeds".into(),
+                serde_yaml::Value::Sequence(many.iter().map(|s| (*s).into()).collect()),
+            );
+        }
+    }
 
     let mut root = serde_yaml::Mapping::new();
     root.insert("name".into(), "pod-edit".into());
@@ -648,10 +728,69 @@ steps:
     fn edit_spec_inlines_image_as_data_uri() {
         let tmp = std::env::temp_dir().join(format!("modl-podrun-test-{}.png", std::process::id()));
         std::fs::write(&tmp, b"fakepng").unwrap();
-        let spec = single_edit_spec("klein-9b", "make it golden", &tmp).unwrap();
+        let spec = single_edit_spec(
+            "klein-9b",
+            "make it golden",
+            &tmp,
+            None,
+            None,
+            None,
+            None,
+            &[],
+        )
+        .unwrap();
         std::fs::remove_file(&tmp).unwrap();
         assert!(spec.contains("data:image/png;base64,"));
         assert!(spec.contains("$input"));
         assert!(spec.contains("make it golden"));
+        // No optional params passed — none serialized (`steps:` here is the
+        // workflow's step list, not an inference-steps field).
+        assert!(!spec.contains("guidance"));
+        assert!(!spec.contains("seed"));
+        assert!(!spec.contains("width"));
+    }
+
+    #[test]
+    fn edit_spec_carries_params_and_seeds() {
+        let tmp =
+            std::env::temp_dir().join(format!("modl-podrun-test2-{}.png", std::process::id()));
+        std::fs::write(&tmp, b"fakepng").unwrap();
+        let spec = single_edit_spec(
+            "klein-9b",
+            "p",
+            &tmp,
+            Some(1820),
+            Some(1024),
+            Some(28),
+            Some(4.5),
+            &[7, 8],
+        )
+        .unwrap();
+        std::fs::remove_file(&tmp).unwrap();
+        assert!(spec.contains("width: 1820"));
+        assert!(spec.contains("height: 1024"));
+        assert!(spec.contains("steps: 28"));
+        assert!(spec.contains("guidance: 4.5"));
+        assert!(spec.contains("seeds:"));
+        assert!(spec.contains("- 7"));
+        assert!(spec.contains("- 8"));
+    }
+
+    #[test]
+    fn rejects_bare_local_image_paths() {
+        // Bare path in an edit step — would resolve pod-side and fail there.
+        let step_path =
+            "name: t\nmodel: m\nsteps:\n  - id: a\n    edit: photo.png\n    prompt: p\n";
+        let err = check_pod_supported(step_path).unwrap_err().to_string();
+        assert!(err.contains("local file path"), "{err}");
+
+        // File path in the images: map — same problem.
+        let images_path = "name: t\nmodel: m\nimages:\n  ref: /home/me/ref.png\nsteps:\n  - id: a\n    generate: x\n";
+        let err = check_pod_supported(images_path).unwrap_err().to_string();
+        assert!(err.contains("file path"), "{err}");
+
+        // Data URIs, $variables and $step refs are all fine.
+        let ok = "name: t\nmodel: m\nimages:\n  ref: \"data:image/png;base64,aWs=\"\nsteps:\n  - id: a\n    generate: x\n  - id: b\n    edit: \"$ref\"\n    prompt: p\n  - id: c\n    edit: \"$a.outputs[0]\"\n    prompt: p\n";
+        assert!(check_pod_supported(ok).is_ok());
     }
 }


### PR DESCRIPTION
Tier 2 of [pod-gaps-and-roadmap]: every flag on `generate`/`edit`/`run`/`train` now either works with `--pod` or errors clearly at submit time. Nothing is silently ignored anymore.

## Newly supported (pass-through)

- **`edit --pod`**: `--steps`, `--guidance`, `--seed`, `--size`, `--count` now ship in the one-step workflow spec (`count>1` expands to explicit seeds, same as generate already did).
- **`run --pod`**: `--run-id`, `--force`, `--in-order` are forwarded to the pod-side `modl run`, so local and pod flags behave identically (resume-by-default semantics included).
- **`--json` on `generate`/`edit`/`run --pod`**: emits a real result object on stdout — `{status, run_id, output_dir, images}` from `RemoteRunOutcome`, one line per spec. `run --pod --dry-run --json` emits `{valid, target: "pod", spec, models}` (or `{valid: false, error}` with exit 0, matching the local dry-run contract).

## Newly bailing (were silently dropped)

- `generate --pod --fast` and `edit --pod --fast` — Lightning LoRA resolution lives in the local store; bails until LoRA push lands.
- `edit --pod --blend` (non-default) — bails.
- `train --pod --resume` — checkpoint path is local to this machine; bails instead of breaking pod-side.
- `run --pod --run-id` with multiple spec files — ambiguous, bails.
- **Bare local image paths in workflow YAMLs** (`edit: photo.png` steps or `images:` map values that aren't data URIs) are rejected at submit time with `images:`-map guidance, instead of failing minutes later on the pod with a confusing message.

## Plumbing

To make `--json` stdout parseable, all pod progress narration moved to stderr (`pod_run.rs` + the CLI pod paths), and `run_ssh_streaming` now redirects remote output to local stderr. Terminal UX is unchanged; `modl … --pod --json | jq` now works.

## Tests

- `check_pod_supported` rejects bare paths in steps and `images:` map; accepts data URIs, `$name` and `$step.outputs[N]` refs
- `single_edit_spec` carries width/height/steps/guidance/seeds; omits them when unset
- Full suite + clippy `-D warnings` green; new bail/JSON paths exercised manually against the debug binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)