### PR TITLE
feat: LoRAs + --fast on pods — auto push/pull, first-class workflow fast:

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,12 +123,17 @@ modl generate "a red apple on a rustic wooden table" --base flux-schnell --pod
 modl edit --image photo.png "make it golden" --pod
 modl run workflow.yaml --pod                 # multi-step workflows, chained on the pod
 
+modl generate "OHWX on a beach" --base flux-dev --lora product-v1 --pod   # your LoRA, their GPU
+modl generate "a red apple" --base qwen-image --fast 4 --pod              # Lightning fast mode
+
 modl pod rm <id>                             # destroy when done — pods bill until destroyed
 ```
 
 Runs are fire-and-forget on the pod: close the laptop mid-generation and the job finishes anyway — fetch the results later with `modl pod pull <run-id>`. Everything moves directly between your machine and the pod over SSH; no cloud storage, no third-party relay. `modl run workflow.yaml --pod --dry-run` validates a workflow's pod-compatibility without renting anything.
 
-Not yet supported on pods: LoRAs, controlnet/style-ref, inpainting masks.
+LoRAs work on pods like they do locally: registry LoRAs are pulled on the pod, and your own trained LoRAs are pushed into the pod's store automatically the first time a workflow references them. This closes the loop with pod training — train on a pod, then `--lora <name>` on a pod, no manual file juggling.
+
+Not yet supported on pods: controlnet/style-ref, inpainting masks.
 
 ---
 

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -50,8 +50,6 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
     }
     for (flag, set) in [
         ("--mask", args.mask.is_some()),
-        ("--lora", args.lora.is_some()),
-        ("--fast", args.fast.is_some()),
         ("--blend", args.blend != BlendMode::Pixel),
         ("--cloud", args.cloud),
         ("--attach-gpu", args.attach_gpu),
@@ -59,6 +57,17 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
         if set {
             anyhow::bail!("{flag} isn't supported with --pod yet — run locally or drop the flag.");
         }
+    }
+    if args.fast.is_some() && args.lora.is_some() {
+        anyhow::bail!(
+            "Cannot use --lora and --fast together. --fast applies a Lightning LoRA which conflicts with a user LoRA."
+        );
+    }
+    // Workflow `lora:` refs carry no weight — the pod applies full strength.
+    if args.lora.is_some() && args.lora_strength != 1.0 {
+        anyhow::bail!(
+            "--lora-strength isn't supported with --pod yet — LoRAs run at full strength there."
+        );
     }
     let model = args.base.unwrap_or("qwen-image-edit-2511");
     let local_image = resolve_image_input(&args.images[0]).await?;
@@ -88,6 +97,8 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
         model,
         args.prompt,
         std::path::Path::new(&local_image),
+        args.lora,
+        args.fast,
         width,
         height,
         args.steps,
@@ -266,20 +277,7 @@ pub async fn run(args: EditArgs<'_>) -> Result<()> {
             )
         })?;
 
-        let sched_overrides: std::collections::HashMap<String, serde_json::Value> = lightning
-            .scheduler_overrides
-            .iter()
-            .map(|(k, v)| {
-                let val = if *v == "null" {
-                    serde_json::Value::Null
-                } else if let Ok(f) = v.parse::<f64>() {
-                    serde_json::json!(f)
-                } else {
-                    serde_json::Value::String(v.to_string())
-                };
-                (k.to_string(), val)
-            })
-            .collect();
+        let sched_overrides = lightning.scheduler_overrides_json();
 
         (
             lora_ref,

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -134,18 +134,28 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         "--pod needs an explicit --base <model-id> (e.g. flux-schnell) — it's pulled into the pod's store.",
     )?;
     for (flag, set) in [
-        ("--lora", args.lora.is_some()),
         ("--init-image", args.init_image.is_some()),
         ("--mask", args.mask.is_some()),
         ("--controlnet", !args.controlnet.is_empty()),
         ("--style-ref", !args.style_ref.is_empty()),
-        ("--fast", args.fast.is_some()),
         ("--cloud", args.cloud),
         ("--attach-gpu", args.attach_gpu),
     ] {
         if set {
             anyhow::bail!("{flag} isn't supported with --pod yet — run locally or drop the flag.");
         }
+    }
+    if args.fast.is_some() && args.lora.is_some() {
+        anyhow::bail!(
+            "--fast and --lora cannot be used together. \
+             The --fast flag auto-applies a Lightning distillation LoRA."
+        );
+    }
+    // Workflow `lora:` refs carry no weight — the pod applies full strength.
+    if args.lora.is_some() && args.lora_strength != 1.0 {
+        anyhow::bail!(
+            "--lora-strength isn't supported with --pod yet — LoRAs run at full strength there."
+        );
     }
 
     let (width, height) = match args.size {
@@ -172,6 +182,8 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
     let spec = crate::core::pod_run::single_generate_spec(
         model,
         args.prompt,
+        args.lora,
+        args.fast,
         width,
         height,
         args.steps,
@@ -312,20 +324,7 @@ async fn run_local(args: GenerateArgs<'_>, db: Database) -> Result<()> {
             )
         })?;
 
-        let sched_overrides: std::collections::HashMap<String, serde_json::Value> = lightning
-            .scheduler_overrides
-            .iter()
-            .map(|(k, v)| {
-                let val = if *v == "null" {
-                    serde_json::Value::Null
-                } else if let Ok(f) = v.parse::<f64>() {
-                    serde_json::json!(f)
-                } else {
-                    serde_json::Value::String(v.to_string())
-                };
-                (k.to_string(), val)
-            })
-            .collect();
+        let sched_overrides = lightning.scheduler_overrides_json();
 
         (
             lora_ref,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,6 +31,7 @@ mod pod;
 mod popular;
 mod preprocess;
 mod push;
+mod register;
 mod remove_bg;
 mod run;
 mod run_status;
@@ -983,6 +984,29 @@ pub enum Commands {
         owner: Option<String>,
     },
 
+    /// Register a local model file into the store (content-addressed copy + DB + shared index)
+    ///
+    /// Makes a file that arrived outside `modl pull` referenceable by name:
+    /// `modl register my-lora.safetensors --name my-lora`, then use
+    /// `--lora my-lora` or `lora: my-lora` in workflows. Also used
+    /// internally when pushing LoRAs to pods.
+    Register {
+        /// Path to the model file (e.g. a LoRA .safetensors)
+        path: String,
+        /// Name to register under (what --lora / workflow `lora:` will reference)
+        #[arg(long)]
+        name: String,
+        /// Stable id (defaults to local/<type>/<name>)
+        #[arg(long)]
+        id: Option<String>,
+        /// Asset type
+        #[arg(long = "type", value_enum, default_value = "lora")]
+        asset_type: AssetType,
+        /// Expected SHA256 — registration fails if the file doesn't match
+        #[arg(long)]
+        sha256: Option<String>,
+    },
+
     /// List installed models
     Ls {
         /// Filter by asset type (checkpoint, lora, vae, text_encoder, etc.)
@@ -1549,6 +1573,13 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
+        Commands::Register {
+            path,
+            name,
+            id,
+            asset_type,
+            sha256,
+        } => register::run(&path, &name, id.as_deref(), &asset_type, sha256.as_deref()),
         Commands::Ls {
             r#type,
             summary,

--- a/src/cli/register.rs
+++ b/src/cli/register.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use console::style;
+
+use crate::core::install;
+use crate::core::manifest::AssetType;
+
+pub fn run(
+    path: &str,
+    name: &str,
+    id: Option<&str>,
+    asset_type: &AssetType,
+    sha256: Option<&str>,
+) -> Result<()> {
+    let config = crate::core::config::Config::load()?;
+    let db = crate::core::db::Database::open()?;
+    let result = install::register_file(
+        std::path::Path::new(path),
+        name,
+        id,
+        asset_type,
+        sha256,
+        &db,
+        &config.store_root(),
+    )?;
+
+    if result.already_registered {
+        println!(
+            "{} {} already registered as {} ({})",
+            style("i").dim(),
+            name,
+            style(&result.id).bold(),
+            style(&result.sha256[..16]).dim(),
+        );
+    } else {
+        println!(
+            "{} Registered {} as {} ({})",
+            style("✓").green().bold(),
+            style(name).bold(),
+            result.id,
+            style(&result.sha256[..16]).dim(),
+        );
+        println!("  {}", result.store_path.display());
+    }
+    Ok(())
+}

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -115,11 +115,34 @@ pub struct PlannedStep {
     /// Used for display ("show the override in the plan print") and for
     /// warm-worker accounting (model switches cost a reload).
     pub model_overridden: bool,
+    /// Lightning fast-mode resolution for steps with `fast:`. The Lightning
+    /// LoRA itself lands in `resolved_lora`; this carries the rest.
+    pub lightning: Option<ResolvedLightning>,
+}
+
+/// Plan-time resolution of a step's `fast:` field against the model's
+/// Lightning config from models.toml.
+#[derive(Debug, Clone)]
+pub struct ResolvedLightning {
+    pub steps: u32,
+    pub guidance: f32,
+    pub scheduler_overrides: HashMap<String, serde_json::Value>,
 }
 
 impl PlannedStep {
     pub fn expected_artifacts(&self) -> usize {
         self.sub_jobs.iter().map(|(_, c)| *c as usize).sum()
+    }
+
+    /// Default (steps, guidance) for this step: the Lightning resolution when
+    /// `fast:` is set, the effective model's defaults otherwise. Explicit
+    /// per-step `steps:`/`guidance:` still override these.
+    fn effective_defaults(&self) -> (u32, f32) {
+        let (steps, guidance) = model_family::model_defaults(&self.resolved_model.id);
+        match &self.lightning {
+            Some(l) => (l.steps, l.guidance),
+            None => (steps, guidance),
+        }
     }
 }
 
@@ -139,6 +162,13 @@ pub enum PlanError {
 
     #[error("LoRA `{lora}` not found in local store")]
     LoraNotFound { lora: String },
+
+    #[error("step `{step_id}`: Lightning LoRA `{lora}` (variant {variant}) is not installed")]
+    LightningLoraNotInstalled {
+        step_id: String,
+        lora: String,
+        variant: String,
+    },
 
     #[error(
         "step `{step_id}`: model `{model}` does not support `{kind}` (missing capability `{required}`)"
@@ -161,6 +191,7 @@ impl PlanError {
             PlanError::Parse(_) => "parse_error",
             PlanError::ModelNotInstalled { .. } => "model_not_installed",
             PlanError::LoraNotFound { .. } => "lora_not_found",
+            PlanError::LightningLoraNotInstalled { .. } => "lightning_lora_not_installed",
             PlanError::IncompatibleCapability { .. } => "incompatible_capability",
             PlanError::Other(_) => "other",
         }
@@ -172,6 +203,9 @@ impl PlanError {
             PlanError::ModelNotInstalled { model } => Some(format!("modl pull {model}")),
             PlanError::LoraNotFound { lora } => {
                 Some(format!("modl pull {lora} or train it with `modl train`"))
+            }
+            PlanError::LightningLoraNotInstalled { lora, variant, .. } => {
+                Some(format!("modl pull {lora} --variant {variant}"))
             }
             PlanError::IncompatibleCapability { kind, .. } => Some(format!(
                 "pick a model that supports `{kind}` (see `modl info <model>`)"
@@ -263,15 +297,22 @@ async fn run_on_pod(
     }
 
     if dry_run {
+        let db = Database::open()?;
         for path in spec_paths {
             let checked = std::fs::read_to_string(path)
                 .with_context(|| format!("Failed to read {path}"))
                 .and_then(|yaml| {
                     crate::core::pod_run::check_pod_supported(&yaml)?;
-                    crate::core::pod_run::workflow_models(&yaml)
+                    let models = crate::core::pod_run::workflow_models(&yaml)?;
+                    let loras = crate::core::pod_run::classify_workflow_loras(&yaml, &db)?;
+                    Ok((models, loras))
                 });
             match checked {
-                Ok(models) => {
+                Ok((models, loras)) => {
+                    let lora_pulls: Vec<&str> =
+                        loras.pulls.iter().map(|(id, _)| id.as_str()).collect();
+                    let lora_pushes: Vec<&str> =
+                        loras.pushes.iter().map(|p| p.name.as_str()).collect();
                     if json {
                         println!(
                             "{}",
@@ -280,6 +321,8 @@ async fn run_on_pod(
                                 "target": "pod",
                                 "spec": path,
                                 "models": models,
+                                "lora_pulls": lora_pulls,
+                                "lora_pushes": lora_pushes,
                             })
                         );
                     } else {
@@ -288,6 +331,12 @@ async fn run_on_pod(
                             style("✓").green(),
                             models.join(", ")
                         );
+                        if !lora_pulls.is_empty() {
+                            println!("  LoRAs pulled on pod: {}", lora_pulls.join(", "));
+                        }
+                        if !lora_pushes.is_empty() {
+                            println!("  LoRAs pushed to pod: {}", lora_pushes.join(", "));
+                        }
                     }
                 }
                 Err(e) => {
@@ -450,15 +499,17 @@ pub fn build_plan(
     let mut total_artifacts = 0usize;
 
     for step in &wf.steps {
-        let (step_model_override, step_lora_override, sub_jobs) = match &step.kind {
+        let (step_model_override, step_lora_override, step_fast, sub_jobs) = match &step.kind {
             StepKind::Generate(g) => (
                 g.model.clone(),
                 g.lora.clone(),
+                g.fast,
                 expand_seeds(g.seed, g.count, &g.seeds),
             ),
             StepKind::Edit(e) => (
                 e.model.clone(),
                 e.lora.clone(),
+                e.fast,
                 expand_seeds(e.seed, e.count, &e.seeds),
             ),
         };
@@ -485,15 +536,30 @@ pub fn build_plan(
         // capabilities) — same policy as `arch_key`.
         check_capability(&step.id, &resolved_model.id, &step.kind)?;
 
+        // Resolve `fast:` against the model's Lightning config. The parser
+        // already rejects `fast` + `lora` on the same step; an inherited
+        // workflow-level `lora` is overridden by the Lightning LoRA.
+        let (lightning, lightning_lora) = match step_fast {
+            Some(fast_steps) => {
+                let (l, lora) = resolve_fast(&step.id, &resolved_model.id, fast_steps, db)?;
+                (Some(l), Some(lora))
+            }
+            None => (None, None),
+        };
+
         // Resolve effective LoRA for this step
-        let resolved_lora = match step_lora_override {
-            Some(ref name) => Some(resolve_lora(name, db)?),
-            None => {
-                if model_overridden {
-                    // Auto-disable inherited LoRA on model override
-                    None
-                } else {
-                    default_lora.clone()
+        let resolved_lora = if let Some(lora) = lightning_lora {
+            Some(lora)
+        } else {
+            match step_lora_override {
+                Some(ref name) => Some(resolve_lora(name, db)?),
+                None => {
+                    if model_overridden {
+                        // Auto-disable inherited LoRA on model override
+                        None
+                    } else {
+                        default_lora.clone()
+                    }
                 }
             }
         };
@@ -506,6 +572,7 @@ pub fn build_plan(
             resolved_model,
             resolved_lora,
             model_overridden,
+            lightning,
         });
     }
 
@@ -702,6 +769,42 @@ fn resolve_lora(name: &str, db: &Database) -> Result<LoraRef, PlanError> {
         })
 }
 
+/// Resolve a step's `fast:` field: look up the model's Lightning config,
+/// pick the 4/8-step variant, and resolve the Lightning LoRA from the store.
+fn resolve_fast(
+    step_id: &str,
+    model_id: &str,
+    fast_steps: u32,
+    db: &Database,
+) -> Result<(ResolvedLightning, LoraRef), PlanError> {
+    let Some(cfg) = model_family::lightning_config(model_id) else {
+        let supported: Vec<&str> = model_family::lightning_configs()
+            .iter()
+            .map(|c| c.base_model_id.as_str())
+            .collect();
+        return Err(PlanError::Other(format!(
+            "step `{step_id}`: `fast` is not supported for `{model_id}`. Supported: {}",
+            supported.join(", ")
+        )));
+    };
+    let (variant, steps) = cfg.resolve(fast_steps);
+    let lora = model_resolve::resolve_lora(&cfg.lora_registry_id, 1.0, db)
+        .map_err(|e| PlanError::Other(format!("LoRA resolution error: {e}")))?
+        .ok_or_else(|| PlanError::LightningLoraNotInstalled {
+            step_id: step_id.to_string(),
+            lora: cfg.lora_registry_id.clone(),
+            variant: variant.to_string(),
+        })?;
+    Ok((
+        ResolvedLightning {
+            steps,
+            guidance: cfg.guidance,
+            scheduler_overrides: cfg.scheduler_overrides_json(),
+        },
+        lora,
+    ))
+}
+
 // ---------------------------------------------------------------------------
 // execute_plan — the GPU work. Runs every step, streams events, registers
 // each step as a DB job row with workflow labels for UI filtering.
@@ -874,6 +977,7 @@ pub async fn execute_plan(
                         Some(resolved_model.base_path.clone()),
                         resolved_model.arch_key.clone(),
                         resolved_lora.clone(),
+                        planned.lightning.as_ref(),
                         g,
                         *seed,
                         *count,
@@ -949,6 +1053,7 @@ pub async fn execute_plan(
                         Some(resolved_model.base_path.clone()),
                         resolved_model.arch_key.clone(),
                         resolved_lora.clone(),
+                        planned.lightning.as_ref(),
                         e,
                         &source_path,
                         *seed,
@@ -1178,10 +1283,10 @@ fn print_plan_human(plan: &Plan, in_order: bool) {
         let expected = planned.expected_artifacts();
         let i = exec_idx; // used for the leading index column
         let reordered = !in_order && exec_idx != declared_idx;
-        // Use the step's *effective* model for the defaults lookup, so per-step
-        // model overrides fall back to the overridden model's defaults.
-        let (default_steps, default_guidance) =
-            model_family::model_defaults(&planned.resolved_model.id);
+        // Use the step's *effective* model for the defaults lookup (so
+        // per-step model overrides fall back to the overridden model's
+        // defaults), with `fast:` Lightning resolution applied on top.
+        let (default_steps, default_guidance) = planned.effective_defaults();
 
         let model_annotation = if planned.model_overridden {
             format!(" [model={}]", planned.resolved_model.id)
@@ -1189,7 +1294,9 @@ fn print_plan_human(plan: &Plan, in_order: bool) {
             String::new()
         };
         let lora_annotation = match &planned.resolved_lora {
-            Some(l) if planned.model_overridden => format!(" [lora={}]", l.name),
+            Some(l) if planned.model_overridden || planned.lightning.is_some() => {
+                format!(" [lora={}]", l.name)
+            }
             _ => String::new(),
         };
         let reorder_annotation = if reordered {
@@ -1279,8 +1386,7 @@ fn print_plan_json(plan: &Plan, in_order: bool) -> Result<()> {
         .iter()
         .zip(plan.planned_steps.iter())
         .map(|(step, planned)| {
-            let (default_steps, default_guidance) =
-                model_family::model_defaults(&planned.resolved_model.id);
+            let (default_steps, default_guidance) = planned.effective_defaults();
             let model_json = if planned.model_overridden {
                 Some(planned.resolved_model.id.clone())
             } else {
@@ -1534,6 +1640,7 @@ fn build_generate_spec(
     base_model_path: Option<String>,
     arch_key: Option<String>,
     lora: Option<LoraRef>,
+    lightning: Option<&ResolvedLightning>,
     step: &GenerateStep,
     seed: Option<u64>,
     count: u32,
@@ -1541,8 +1648,16 @@ fn build_generate_spec(
     labels: HashMap<String, String>,
 ) -> GenerateJobSpec {
     let (default_steps, default_guidance) = model_family::model_defaults(wf_model);
-    let steps = step.steps.unwrap_or(default_steps);
-    let guidance = step.guidance.unwrap_or(default_guidance);
+    // Explicit step fields win over `fast:` resolution, which wins over
+    // model defaults — same precedence as `modl generate --fast --steps`.
+    let steps = step
+        .steps
+        .or(lightning.map(|l| l.steps))
+        .unwrap_or(default_steps);
+    let guidance = step
+        .guidance
+        .or(lightning.map(|l| l.guidance))
+        .unwrap_or(default_guidance);
     let width = step.width.unwrap_or(1024);
     let height = step.height.unwrap_or(1024);
 
@@ -1567,7 +1682,9 @@ fn build_generate_spec(
             init_image: None,
             mask: None,
             strength: None,
-            scheduler_overrides: HashMap::new(),
+            scheduler_overrides: lightning
+                .map(|l| l.scheduler_overrides.clone())
+                .unwrap_or_default(),
             controlnet: Vec::new(),
             style_ref: Vec::new(),
             inpaint_method: None,
@@ -1588,6 +1705,7 @@ fn build_edit_spec(
     base_model_path: Option<String>,
     arch_key: Option<String>,
     lora: Option<LoraRef>,
+    lightning: Option<&ResolvedLightning>,
     step: &EditStep,
     source_path: &Path,
     seed: Option<u64>,
@@ -1596,8 +1714,15 @@ fn build_edit_spec(
     labels: HashMap<String, String>,
 ) -> EditJobSpec {
     let (default_steps, default_guidance) = model_family::model_defaults(wf_model);
-    let steps = step.steps.unwrap_or(default_steps);
-    let guidance = step.guidance.unwrap_or(default_guidance);
+    // Same precedence as build_generate_spec: explicit > fast > defaults.
+    let steps = step
+        .steps
+        .or(lightning.map(|l| l.steps))
+        .unwrap_or(default_steps);
+    let guidance = step
+        .guidance
+        .or(lightning.map(|l| l.guidance))
+        .unwrap_or(default_guidance);
 
     EditJobSpec {
         prompt: step.prompt.clone(),
@@ -1620,7 +1745,9 @@ fn build_edit_spec(
             height: step.height,
             mask_path: None,
             blend_mode: crate::core::job::BlendMode::Pixel,
-            scheduler_overrides: HashMap::new(),
+            scheduler_overrides: lightning
+                .map(|l| l.scheduler_overrides.clone())
+                .unwrap_or_default(),
         },
         runtime: RuntimeRef {
             profile: runtime::resolved_generation_profile().to_string(),
@@ -1890,6 +2017,7 @@ mod tests {
             prompt: "x".into(),
             model: None,
             lora: None,
+            fast: None,
             seed: None,
             seeds: None,
             width: None,
@@ -1906,6 +2034,7 @@ mod tests {
             prompt: "x".into(),
             model: None,
             lora: None,
+            fast: None,
             seed: None,
             seeds: None,
             width: None,
@@ -1979,6 +2108,7 @@ mod tests {
                 resolved_model: fake_resolved(m),
                 resolved_lora: None,
                 model_overridden: false,
+                lightning: None,
             })
             .collect()
     }

--- a/src/core/artifacts.rs
+++ b/src/core/artifacts.rs
@@ -112,7 +112,7 @@ pub fn collect_lora(
 
 /// Create symlinks for a LoRA file in common tool directories.
 /// Currently symlinks into any configured ComfyUI lora dirs.
-fn create_lora_symlinks(
+pub(crate) fn create_lora_symlinks(
     store_path: &Path,
     lora_name: &str,
     file_name: &str,

--- a/src/core/install.rs
+++ b/src/core/install.rs
@@ -409,3 +409,188 @@ pub async fn hf_pull(
         final_path,
     ))
 }
+
+/// Result of `register_file`.
+#[derive(Debug)]
+pub struct RegisterFileResult {
+    pub id: String,
+    pub sha256: String,
+    pub store_path: PathBuf,
+    /// True when the id was already registered with this content — the call
+    /// was a no-op.
+    pub already_registered: bool,
+}
+
+/// Register a local model file into the content-addressed store: hash,
+/// verify, copy into `store/<type>/<sha16>/<file>` (no-op when the file
+/// already lives there), record in SQLite and the shared store index.
+///
+/// This is how a file that arrived outside `modl pull` becomes referenceable
+/// by name (`--lora <name>`, workflow `lora:`). It is also the pod-side half
+/// of LoRA push: the file is rsynced straight into the store path, then this
+/// registers it. Idempotent — re-registering the same content is a no-op.
+pub fn register_file(
+    path: &std::path::Path,
+    name: &str,
+    id: Option<&str>,
+    asset_type: &AssetType,
+    expected_sha256: Option<&str>,
+    db: &Database,
+    store_root: &std::path::Path,
+) -> Result<RegisterFileResult> {
+    if !path.is_file() {
+        anyhow::bail!("File not found: {}", path.display());
+    }
+    let file_name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .context("File has no valid file name")?
+        .to_string();
+
+    let sha256 =
+        Store::hash_file(path).with_context(|| format!("Failed to hash {}", path.display()))?;
+    if let Some(expected) = expected_sha256
+        && !sha256.eq_ignore_ascii_case(expected)
+    {
+        anyhow::bail!(
+            "SHA256 mismatch for {}: expected {expected}, got {sha256} — transfer corrupted?",
+            path.display()
+        );
+    }
+
+    let store = Store::new(store_root.to_path_buf());
+    let store_path = store.path_for(asset_type, &sha256, &file_name);
+    // Copy into the store unless the source already IS the store path
+    // (LoRA push rsyncs directly there before registering).
+    let already_in_place = path
+        .canonicalize()
+        .ok()
+        .is_some_and(|p| p == store_path || store_path.exists());
+    if !already_in_place {
+        store.ensure_dir(&store_path)?;
+        std::fs::copy(path, &store_path).with_context(|| {
+            format!(
+                "Failed to copy {} → {}",
+                path.display(),
+                store_path.display()
+            )
+        })?;
+    }
+
+    let id = id
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| format!("local/{asset_type}/{name}"));
+    let already_registered = db
+        .list_installed(None)?
+        .iter()
+        .any(|m| m.id == id && m.sha256 == sha256);
+    if !already_registered {
+        let size = std::fs::metadata(&store_path).map(|m| m.len()).unwrap_or(0);
+        db.insert_installed(&InstalledModelRecord {
+            id: &id,
+            name,
+            asset_type: &asset_type.to_string(),
+            variant: None,
+            sha256: &sha256,
+            size,
+            file_name: &file_name,
+            store_path: &store_path.to_string_lossy(),
+        })?;
+    }
+
+    if matches!(asset_type, AssetType::Lora) {
+        let _ = super::artifacts::create_lora_symlinks(&store_path, name, &file_name);
+    }
+
+    Ok(RegisterFileResult {
+        id,
+        sha256,
+        store_path,
+        already_registered,
+    })
+}
+
+#[cfg(test)]
+mod register_tests {
+    use super::*;
+    use std::path::Path;
+
+    fn setup() -> (tempfile::TempDir, Database, std::path::PathBuf) {
+        let dir = tempfile::TempDir::new().unwrap();
+        let db = Database::open_at(&dir.path().join("db.sqlite")).unwrap();
+        let file = dir.path().join("alice.safetensors");
+        std::fs::write(&file, b"fake lora bytes").unwrap();
+        (dir, db, file)
+    }
+
+    #[test]
+    fn registers_copies_and_is_idempotent() {
+        let (dir, db, file) = setup();
+
+        let r =
+            register_file(&file, "alice", None, &AssetType::Vae, None, &db, dir.path()).unwrap();
+        assert!(!r.already_registered);
+        assert_eq!(r.id, "local/vae/alice");
+        assert!(r.store_path.exists());
+        assert!(r.store_path.starts_with(dir.path()));
+        let installed = db.list_installed(Some("vae")).unwrap();
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].name, "alice");
+        assert_eq!(installed[0].sha256, r.sha256);
+
+        // Second call: same content, same id — no-op.
+        let r2 =
+            register_file(&file, "alice", None, &AssetType::Vae, None, &db, dir.path()).unwrap();
+        assert!(r2.already_registered);
+        assert_eq!(db.list_installed(Some("vae")).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn explicit_id_and_sha_verification() {
+        let (dir, db, file) = setup();
+
+        let err = register_file(
+            &file,
+            "alice",
+            Some("train:alice:1234"),
+            &AssetType::Vae,
+            Some(&"0".repeat(64)),
+            &db,
+            dir.path(),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("SHA256 mismatch"), "{err}");
+        assert!(db.list_installed(None).unwrap().is_empty());
+
+        let sha = Store::hash_file(&file).unwrap();
+        let r = register_file(
+            &file,
+            "alice",
+            Some("train:alice:1234"),
+            &AssetType::Vae,
+            Some(&sha),
+            &db,
+            dir.path(),
+        )
+        .unwrap();
+        assert_eq!(r.id, "train:alice:1234");
+    }
+
+    #[test]
+    fn missing_file_errors() {
+        let (dir, db, _) = setup();
+        assert!(
+            register_file(
+                Path::new("/nonexistent/x.safetensors"),
+                "x",
+                None,
+                &AssetType::Vae,
+                None,
+                &db,
+                dir.path(),
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -165,6 +165,24 @@ impl LightningConfig {
             (&self.variant_8step, 8)
         }
     }
+
+    /// Scheduler overrides as JSON values for job specs: "null" → Null,
+    /// numeric strings → numbers, anything else stays a string.
+    pub fn scheduler_overrides_json(&self) -> std::collections::HashMap<String, serde_json::Value> {
+        self.scheduler_overrides
+            .iter()
+            .map(|(k, v)| {
+                let val = if *v == "null" {
+                    serde_json::Value::Null
+                } else if let Ok(f) = v.parse::<f64>() {
+                    serde_json::json!(f)
+                } else {
+                    serde_json::Value::String(v.to_string())
+                };
+                (k.to_string(), val)
+            })
+            .collect()
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/pod_run.rs
+++ b/src/core/pod_run.rs
@@ -206,15 +206,25 @@ pub fn prepare(pod: &Pod, models: &[String]) -> Result<()> {
 /// variant selection (fp8/GGUF by VRAM) happens pod-side.
 pub fn pull_models(pod: &Pod, models: &[String]) -> Result<()> {
     for m in models {
-        eprintln!(
-            "{} Ensuring {} on pod...",
-            style("→").cyan(),
-            style(m).bold()
-        );
-        run_ssh_streaming(&pod.ssh, &format!("{REMOTE_MODL} pull {}", shell_quote(m)))
-            .with_context(|| format!("`modl pull {m}` failed on the pod"))?;
+        pull_model(pod, m, None)?;
     }
     Ok(())
+}
+
+/// `modl pull` a single registry item on the pod, optionally pinning a
+/// variant (Lightning LoRAs resolve their variant from the `fast:` step
+/// count instead of pod VRAM).
+pub fn pull_model(pod: &Pod, id: &str, variant: Option<&str>) -> Result<()> {
+    eprintln!(
+        "{} Ensuring {} on pod...",
+        style("→").cyan(),
+        style(id).bold()
+    );
+    let mut cmd = format!("{REMOTE_MODL} pull {}", shell_quote(id));
+    if let Some(v) = variant {
+        cmd.push_str(&format!(" --variant {}", shell_quote(v)));
+    }
+    run_ssh_streaming(&pod.ssh, &cmd).with_context(|| format!("`modl pull {id}` failed on the pod"))
 }
 
 /// Model IDs referenced by a workflow YAML (workflow-level + per-step
@@ -242,19 +252,191 @@ pub fn workflow_models(yaml: &str) -> Result<Vec<String>> {
     Ok(models)
 }
 
+/// All `lora:` references in a workflow YAML (workflow-level + per-step),
+/// deduplicated, in declaration order.
+fn workflow_lora_refs(v: &serde_yaml::Value) -> Vec<String> {
+    let mut loras: Vec<String> = Vec::new();
+    let mut push = |l: Option<&serde_yaml::Value>| {
+        if let Some(s) = l.and_then(|v| v.as_str())
+            && !loras.iter().any(|x| x == s)
+        {
+            loras.push(s.to_string());
+        }
+    };
+    push(v.get("lora"));
+    if let Some(steps) = v.get("steps").and_then(|s| s.as_sequence()) {
+        for step in steps {
+            push(step.get("lora"));
+        }
+    }
+    loras
+}
+
+/// A locally-stored LoRA (trained or registered) that must be shipped into
+/// the pod's store before the workflow can reference it by name.
+#[derive(Debug)]
+pub struct LoraPush {
+    /// Stable id to register under on the pod (kept identical to the local
+    /// id so the same reference resolves on both machines).
+    pub id: String,
+    pub name: String,
+    pub sha256: String,
+    pub size: u64,
+    pub file_name: String,
+    pub local_path: PathBuf,
+}
+
+/// How each LoRA referenced by a workflow reaches the pod.
+#[derive(Debug, Default)]
+pub struct WorkflowLoras {
+    /// Registry items — pulled pod-side like models: (id, optional variant).
+    /// Includes the Lightning LoRAs required by `fast:` steps.
+    pub pulls: Vec<(String, Option<String>)>,
+    /// Local LoRAs — rsynced into the pod store and registered.
+    pub pushes: Vec<LoraPush>,
+}
+
+/// Classify every LoRA a workflow needs (explicit `lora:` refs + the
+/// Lightning LoRAs implied by `fast:` steps) into pod-side pulls vs local
+/// pushes. Registry items are pulled on the pod (its own bandwidth, correct
+/// variant selection); anything only known locally is pushed. Unresolvable
+/// references fail here — before any pod time is spent.
+pub fn classify_workflow_loras(
+    yaml: &str,
+    db: &crate::core::db::Database,
+) -> Result<WorkflowLoras> {
+    let v: serde_yaml::Value = serde_yaml::from_str(yaml).context("Invalid workflow YAML")?;
+    let registry_ids: std::collections::HashSet<String> =
+        crate::core::registry::RegistryIndex::load()
+            .map(|idx| idx.items.iter().map(|m| m.id.clone()).collect())
+            .unwrap_or_default();
+    let installed_loras = db.list_installed(Some("lora"))?;
+
+    let mut result = WorkflowLoras::default();
+
+    for lora in workflow_lora_refs(&v) {
+        if registry_ids.contains(&lora) {
+            result.pulls.push((lora, None));
+        } else if let Some(m) = installed_loras
+            .iter()
+            .find(|m| m.name == lora || m.id == lora)
+        {
+            result.pushes.push(LoraPush {
+                id: m.id.clone(),
+                name: m.name.clone(),
+                sha256: m.sha256.clone(),
+                size: m.size,
+                file_name: m.file_name.clone(),
+                local_path: PathBuf::from(&m.store_path),
+            });
+        } else {
+            bail!(
+                "LoRA `{lora}` not found — not installed locally and not a registry item.\n  \
+                 Train it (`modl train`), pull it (`modl pull {lora}`), or register a file \
+                 (`modl register <file> --name {lora}`)."
+            );
+        }
+    }
+
+    // `fast:` steps need the model's Lightning LoRA on the pod. It's always
+    // a registry item — resolve the variant from the requested step count.
+    let wf_model = v.get("model").and_then(|m| m.as_str());
+    for step in v
+        .get("steps")
+        .and_then(|s| s.as_sequence())
+        .into_iter()
+        .flatten()
+    {
+        let Some(fast) = step.get("fast").and_then(|f| f.as_u64()) else {
+            continue;
+        };
+        let model = step
+            .get("model")
+            .and_then(|m| m.as_str())
+            .or(wf_model)
+            .context("`fast` step has no model (neither per-step nor workflow-level)")?;
+        let Some(cfg) = crate::core::model_family::lightning_config(model) else {
+            let id = step.get("id").and_then(|i| i.as_str()).unwrap_or("?");
+            bail!("step `{id}`: `fast` is not supported for `{model}` (no Lightning config).");
+        };
+        let (variant, _) = cfg.resolve(fast as u32);
+        let pull = (cfg.lora_registry_id.clone(), Some(variant.to_string()));
+        if !result.pulls.contains(&pull) {
+            result.pulls.push(pull);
+        }
+    }
+
+    Ok(result)
+}
+
+/// Ship a local LoRA into the pod's store: rsync the file to its
+/// content-addressed path (skipped when already there — content-addressed
+/// means existence implies identity), then `modl register` pod-side, which
+/// re-hashes (verifying the transfer) and records it in the pod's SQLite +
+/// store index. After this, the workflow's `lora: <name>` resolves on the
+/// pod exactly like it does locally.
+pub fn push_lora(pod: &Pod, lora: &LoraPush) -> Result<()> {
+    // Mirror Store::path_for: <store_root>/store/<type>/<sha16>/<file>. Pods
+    // run modl as root with stock config, whose store root is ~/modl. If a
+    // pod ever diverges, `modl register` below copies the file into the
+    // right place — this path is just the zero-copy fast path.
+    let prefix = &lora.sha256[..lora.sha256.len().min(16)];
+    let remote_dir = format!("/root/modl/store/lora/{prefix}");
+    let remote_path = format!("{remote_dir}/{}", lora.file_name);
+
+    let exists = run_ssh_capture(
+        &pod.ssh,
+        &format!(
+            "test -f {} && echo yes || echo no",
+            shell_quote(&remote_path)
+        ),
+    )
+    .unwrap_or_default();
+    if !exists.contains("yes") {
+        eprintln!(
+            "{} Pushing LoRA {} to pod ({:.1} MB)...",
+            style("→").cyan(),
+            style(&lora.name).bold(),
+            lora.size as f64 / 1_048_576.0
+        );
+        run_ssh_quiet(&pod.ssh, &format!("mkdir -p {}", shell_quote(&remote_dir)))?;
+        rsync_to(&pod.ssh, &lora.local_path, &remote_path)
+            .with_context(|| format!("Failed to push LoRA {} to the pod", lora.name))?;
+    }
+
+    let mut cmd = format!(
+        "{REMOTE_MODL} register {} --name {} --id {} --type lora",
+        shell_quote(&remote_path),
+        shell_quote(&lora.name),
+        shell_quote(&lora.id),
+    );
+    // Only a full hash can be verified — reconciled entries may carry a
+    // 16-char prefix, which `register` would reject as a mismatch.
+    if lora.sha256.len() == 64 {
+        cmd.push_str(&format!(" --sha256 {}", shell_quote(&lora.sha256)));
+    }
+    run_ssh_streaming(&pod.ssh, &cmd)
+        .with_context(|| format!("`modl register` failed on the pod for LoRA {}", lora.name))?;
+    Ok(())
+}
+
 /// Reject specs the pod can't satisfy yet, with a useful message.
 pub fn check_pod_supported(yaml: &str) -> Result<()> {
     let v: serde_yaml::Value = serde_yaml::from_str(yaml).context("Invalid workflow YAML")?;
     let steps = v.get("steps").and_then(|s| s.as_sequence());
-    let has_lora = v.get("lora").is_some()
-        || steps
-            .map(|steps| steps.iter().any(|s| s.get("lora").is_some()))
-            .unwrap_or(false);
-    if has_lora {
-        bail!(
-            "LoRA references aren't supported on pods yet — the pod's store has no local LoRAs.\n  \
-             Run this workflow locally, or drop the `lora:` field."
-        );
+
+    // LoRA refs by name resolve pod-side after push/pull. A file path names
+    // a file on THIS machine that won't exist there — catch it at submit
+    // time with the fix.
+    for lora in workflow_lora_refs(&v) {
+        if lora.contains('/') || lora.ends_with(".safetensors") {
+            bail!(
+                "`lora: {lora}` is a file path — it won't exist on the pod.\n  \
+                 Register it locally first:\n    \
+                 modl register {lora} --name <name>\n  \
+                 then reference it as `lora: <name>`."
+            );
+        }
     }
 
     // Image refs must resolve on the pod: `$step.outputs[N]` and `$name`
@@ -300,7 +482,19 @@ pub async fn run_workflow_on_pod(
 ) -> Result<RemoteRunOutcome> {
     check_pod_supported(spec_yaml)?;
     let models = workflow_models(spec_yaml)?;
+    // Resolve LoRA references against the local DB *before* touching the pod
+    // so unresolvable refs fail without spending pod time.
+    let loras = {
+        let db = crate::core::db::Database::open()?;
+        classify_workflow_loras(spec_yaml, &db)?
+    };
     prepare(pod, &models)?;
+    for (id, variant) in &loras.pulls {
+        pull_model(pod, id, variant.as_deref())?;
+    }
+    for lora in &loras.pushes {
+        push_lora(pod, lora)?;
+    }
 
     let run_id = opts.run_id.unwrap_or_else(|| {
         format!(
@@ -560,9 +754,12 @@ fn walk_files(dir: &Path) -> Vec<PathBuf> {
 
 /// Build a one-step generate workflow so `modl generate --pod` funnels
 /// through the same remote surface as `modl run --pod`.
+#[allow(clippy::too_many_arguments)]
 pub fn single_generate_spec(
     model: &str,
     prompt: &str,
+    lora: Option<&str>,
+    fast: Option<u32>,
     width: Option<u32>,
     height: Option<u32>,
     steps: Option<u32>,
@@ -572,6 +769,8 @@ pub fn single_generate_spec(
     let mut step = serde_yaml::Mapping::new();
     step.insert("id".into(), "gen".into());
     step.insert("generate".into(), prompt.into());
+    insert_opt(&mut step, "lora", lora.map(|v| v.into()));
+    insert_opt(&mut step, "fast", fast.map(|v| v.into()));
     insert_opt(&mut step, "width", width.map(|v| v.into()));
     insert_opt(&mut step, "height", height.map(|v| v.into()));
     insert_opt(&mut step, "steps", steps.map(|v| v.into()));
@@ -606,6 +805,8 @@ pub fn single_edit_spec(
     model: &str,
     prompt: &str,
     image_path: &Path,
+    lora: Option<&str>,
+    fast: Option<u32>,
     width: Option<u32>,
     height: Option<u32>,
     steps: Option<u32>,
@@ -637,6 +838,8 @@ pub fn single_edit_spec(
     step.insert("id".into(), "edit".into());
     step.insert("edit".into(), "$input".into());
     step.insert("prompt".into(), prompt.into());
+    insert_opt(&mut step, "lora", lora.map(|v| v.into()));
+    insert_opt(&mut step, "fast", fast.map(|v| v.into()));
     insert_opt(&mut step, "width", width.map(|v| v.into()));
     insert_opt(&mut step, "height", height.map(|v| v.into()));
     insert_opt(&mut step, "steps", steps.map(|v| v.into()));
@@ -695,13 +898,92 @@ steps:
     }
 
     #[test]
-    fn rejects_lora_specs() {
-        let yaml = "name: t\nmodel: m\nlora: my-lora\nsteps:\n  - id: a\n    generate: x\n";
-        assert!(check_pod_supported(yaml).is_err());
-        let yaml2 = "name: t\nmodel: m\nsteps:\n  - id: a\n    generate: x\n    lora: l\n";
-        assert!(check_pod_supported(yaml2).is_err());
-        let ok = "name: t\nmodel: m\nsteps:\n  - id: a\n    generate: x\n";
-        assert!(check_pod_supported(ok).is_ok());
+    fn lora_names_supported_but_path_refs_rejected() {
+        // Name-form LoRA refs are fine — they're pushed/pulled before the run.
+        let by_name = "name: t\nmodel: m\nlora: my-lora\nsteps:\n  - id: a\n    generate: x\n";
+        assert!(check_pod_supported(by_name).is_ok());
+        let per_step = "name: t\nmodel: m\nsteps:\n  - id: a\n    generate: x\n    lora: l\n";
+        assert!(check_pod_supported(per_step).is_ok());
+
+        // Path-form refs name files on this machine — rejected with the fix.
+        let by_path =
+            "name: t\nmodel: m\nlora: /home/me/x.safetensors\nsteps:\n  - id: a\n    generate: x\n";
+        let err = check_pod_supported(by_path).unwrap_err().to_string();
+        assert!(err.contains("modl register"), "{err}");
+        let step_path =
+            "name: t\nmodel: m\nsteps:\n  - id: a\n    generate: x\n    lora: x.safetensors\n";
+        assert!(check_pod_supported(step_path).is_err());
+    }
+
+    #[test]
+    fn extracts_lora_refs_dedup() {
+        let yaml = r#"
+name: t
+model: m
+lora: alice
+steps:
+  - id: a
+    generate: x
+  - id: b
+    generate: y
+    lora: bob
+  - id: c
+    generate: z
+    lora: alice
+"#;
+        let v: serde_yaml::Value = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(
+            workflow_lora_refs(&v),
+            vec!["alice".to_string(), "bob".into()]
+        );
+    }
+
+    #[test]
+    fn classifies_local_lora_as_push_and_unknown_as_error() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let db = crate::core::db::Database::open_at(tmp.path()).unwrap();
+        db.insert_installed(&crate::core::db::InstalledModelRecord {
+            id: "train:alice:abcd",
+            name: "alice",
+            asset_type: "lora",
+            variant: None,
+            sha256: &"a".repeat(64),
+            size: 42,
+            file_name: "alice.safetensors",
+            store_path: "/store/lora/aaaa/alice.safetensors",
+        })
+        .unwrap();
+
+        let yaml = "name: t\nmodel: m\nlora: alice\nsteps:\n  - id: a\n    generate: x\n";
+        let loras = classify_workflow_loras(yaml, &db).unwrap();
+        assert!(loras.pulls.is_empty());
+        assert_eq!(loras.pushes.len(), 1);
+        assert_eq!(loras.pushes[0].id, "train:alice:abcd");
+        assert_eq!(loras.pushes[0].file_name, "alice.safetensors");
+
+        let unknown = "name: t\nmodel: m\nlora: nope\nsteps:\n  - id: a\n    generate: x\n";
+        let err = classify_workflow_loras(unknown, &db)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("not found"), "{err}");
+    }
+
+    #[test]
+    fn fast_step_adds_lightning_pull() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let db = crate::core::db::Database::open_at(tmp.path()).unwrap();
+
+        // qwen-image has a Lightning config in models.toml.
+        let yaml = "name: t\nmodel: qwen-image\nsteps:\n  - id: a\n    generate: x\n    fast: 4\n";
+        let loras = classify_workflow_loras(yaml, &db).unwrap();
+        assert_eq!(loras.pulls.len(), 1);
+        assert_eq!(loras.pulls[0].0, "qwen-image-2512-lightning");
+        assert_eq!(loras.pulls[0].1.as_deref(), Some("4step-bf16"));
+
+        // A model without a Lightning config fails at classification time.
+        let bad = "name: t\nmodel: sdxl\nsteps:\n  - id: a\n    generate: x\n    fast: 4\n";
+        let err = classify_workflow_loras(bad, &db).unwrap_err().to_string();
+        assert!(err.contains("not supported"), "{err}");
     }
 
     #[test]
@@ -709,6 +991,8 @@ steps:
         let spec = single_generate_spec(
             "flux-schnell",
             "a red apple",
+            None,
+            None,
             Some(1024),
             None,
             Some(4),
@@ -722,6 +1006,39 @@ steps:
         assert!(spec.contains("width: 1024"));
         assert!(spec.contains("seed: 7"));
         assert!(!spec.contains("height"));
+        assert!(!spec.contains("lora"));
+        assert!(!spec.contains("fast"));
+    }
+
+    #[test]
+    fn generate_spec_carries_lora_and_fast() {
+        let spec = single_generate_spec(
+            "qwen-image",
+            "p",
+            Some("alice"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+        )
+        .unwrap();
+        assert!(spec.contains("lora: alice"));
+
+        let spec = single_generate_spec(
+            "qwen-image",
+            "p",
+            None,
+            Some(4),
+            None,
+            None,
+            None,
+            None,
+            &[],
+        )
+        .unwrap();
+        assert!(spec.contains("fast: 4"));
     }
 
     #[test]
@@ -732,6 +1049,8 @@ steps:
             "klein-9b",
             "make it golden",
             &tmp,
+            None,
+            None,
             None,
             None,
             None,
@@ -759,6 +1078,8 @@ steps:
             "klein-9b",
             "p",
             &tmp,
+            None,
+            None,
             Some(1820),
             Some(1024),
             Some(28),

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -49,6 +49,11 @@ pub struct GenerateStep {
     /// - model overridden → no LoRA (auto-disabled; the workflow-level LoRA
     ///   probably belongs to a different model family)
     pub lora: Option<String>,
+    /// Lightning fast mode: target step count (4 or 8). Resolves to the
+    /// model's Lightning distillation LoRA + scheduler overrides at plan
+    /// time. Mutually exclusive with `lora` on the same step; overrides an
+    /// inherited workflow-level `lora`.
+    pub fast: Option<u32>,
     pub seed: Option<u64>,
     /// Explicit seed list for variation exploration — one output per seed.
     /// Mutually exclusive with `seed` + `count`. Empty list is rejected at parse time.
@@ -68,6 +73,8 @@ pub struct EditStep {
     pub model: Option<String>,
     /// Per-step LoRA override. See `GenerateStep::lora`.
     pub lora: Option<String>,
+    /// Lightning fast mode. See `GenerateStep::fast`.
+    pub fast: Option<u32>,
     pub seed: Option<u64>,
     /// Explicit seed list for variation exploration — one output per seed.
     /// Mutually exclusive with `seed` + `count`. Empty list is rejected at parse time.
@@ -141,6 +148,8 @@ struct RawStep {
     model: Option<String>,
     #[serde(default)]
     lora: Option<String>,
+    #[serde(default)]
+    fast: Option<u32>,
     #[serde(default)]
     seed: Option<u64>,
     #[serde(default)]
@@ -244,6 +253,12 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
                 raw_step.id
             );
         }
+        if raw_step.fast.is_some() && raw_step.lora.is_some() {
+            bail!(
+                "step `{}`: cannot set both `fast` and `lora` — `fast` auto-applies the model's Lightning LoRA",
+                raw_step.id
+            );
+        }
 
         // When a step overrides the model, don't inherit workflow-level
         // defaults for steps/guidance — those are model-dependent and the
@@ -267,6 +282,7 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
                 prompt: prompt.clone(),
                 model: raw_step.model.clone(),
                 lora: raw_step.lora.clone(),
+                fast: raw_step.fast,
                 seed: raw_step.seed.or(raw.defaults.seed),
                 seeds: raw_step.seeds.clone(),
                 width: raw_step.width.or(raw.defaults.width),
@@ -295,6 +311,7 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
                 prompt: edit_prompt.clone(),
                 model: raw_step.model.clone(),
                 lora: raw_step.lora.clone(),
+                fast: raw_step.fast,
                 seed: raw_step.seed.or(raw.defaults.seed),
                 seeds: raw_step.seeds.clone(),
                 width: raw_step.width.or(raw.defaults.width),
@@ -966,6 +983,47 @@ steps:
             StepKind::Generate(g) => assert_eq!(g.lora.as_deref(), Some("override-lora")),
             _ => panic!(),
         }
+    }
+
+    #[test]
+    fn per_step_fast_parsed() {
+        let yaml = r#"
+name: test
+model: qwen-image
+steps:
+  - id: a
+    generate: "cat"
+    fast: 4
+  - id: b
+    generate: "dog"
+"#;
+        let wf = parse(yaml).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => assert_eq!(g.fast, Some(4)),
+            _ => panic!(),
+        }
+        match &wf.steps[1].kind {
+            StepKind::Generate(g) => assert_eq!(g.fast, None),
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn fast_and_lora_on_same_step_rejected() {
+        let yaml = r#"
+name: test
+model: qwen-image
+steps:
+  - id: a
+    generate: "cat"
+    fast: 4
+    lora: my-lora
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(
+            err.contains("cannot set both `fast` and `lora`"),
+            "got: {err}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Supersedes #116 (auto-closed when its base branch was deleted on the #115 merge). Rebased onto main. Roadmap item 2 from the pod gaps doc: LoRA push to pods.

## What

A workflow referencing a LoRA now runs on a pod with zero manual file juggling — closing the train-remotely → use-remotely loop:

- **LoRA classification before pod time** (`classify_workflow_loras`): every `lora:` ref + every `fast:` step is resolved locally first. Registry items (incl. Lightning LoRAs, with the 4/8-step variant pinned) are `modl pull`ed pod-side; locally-trained/registered LoRAs are rsynced straight into the pod store's content-addressed path and registered there. Unknown refs fail before anything is rented or warmed.
- **`modl register <file> --name <n>`** (new command): adopt any model file into the store — hash (verify against `--sha256`), content-addressed copy, SQLite + shared `index.yaml`, lora symlink. Idempotent. This is the pod-side half of LoRA push, and independently useful for manually-downloaded files.
- **`fast:` as a first-class workflow step field**: `build_plan` resolves the model's Lightning LoRA, step count, guidance, and scheduler overrides. Previously workflow runs always shipped empty `scheduler_overrides` — so this also fixes Lightning sigma-schedule fidelity for any future workflow use, local included. Mutually exclusive with `lora` on the same step (parse-time error).
- **`generate`/`edit` `--pod`**: the `--lora` and `--fast` bails from #115 become working flags. Clear bails remain for `--lora-strength ≠ 1` and `--fast` + `--lora`.
- **`run --pod --dry-run`** preflights LoRA classification and reports pulls vs pushes (also in `--json`).

## Verified

- 178 unit tests pass (new: classification, register idempotency + sha verify, workflow `fast` parsing, spec builders), clippy clean — re-run after the rebase onto main.
- End-to-end under an isolated `$HOME` with the real binary: `modl register` (fresh + idempotent re-register + `ls`), pod dry-run showing push/pull classification, path-form and unknown LoRA errors with actionable fixes.
- Local dry-run against the real store: `fast: 4` on qwen-image resolves to 4 steps, g=1, Lightning LoRA — shown in plan output and JSON.

**Not yet live-tested on a rented pod** — the pod smoke should cover: push a trained LoRA + generate with it, and `--fast 4` generate (Lightning pull with pinned variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)