### PR TITLE
feat: MCP pod tools — drive rented GPU pods from an agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 node_modules/
 target-ubuntu/
 pod-outputs/
+/target-musl

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1242,6 +1242,20 @@ fn pod_job_status(run_id: &str) -> Result<Value, (i32, String)> {
             );
         }
         v
+    } else if crate::core::paths::modl_root()
+        .join("run-logs")
+        .join(format!("{run_id}.yaml"))
+        .is_file()
+    {
+        // We submitted this run but the pod's DB doesn't know it yet — the
+        // pod-side modl is still preparing (binary install, model pull,
+        // runtime setup), which dominates a cold pod's first minutes.
+        // "pending" is the truthful answer, not an error.
+        json!({
+            "run_id": run_id,
+            "status": "pending",
+            "note": "Pod is still preparing the run (model pull / runtime install) — pod_logs shows live progress.",
+        })
     } else {
         let msg = if stderr.is_empty() { &stdout } else { &stderr };
         return Err((-32603, format!("Pod status check failed: {}", msg.trim())));

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1109,13 +1109,19 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         std::process::Stdio::null()
     };
 
-    // Capture stderr via pipe for a short window so we can detect immediate
-    // failures (bad YAML, missing model, etc.) before returning run_id.
+    // The child's stderr goes STRAIGHT to the log file — never through a
+    // pipe. A pipe's read end dies with this MCP server process, and the
+    // child's next eprintln! would panic on EPIPE, silently killing a
+    // fire-and-forget run the instant the agent's session ends (the exact
+    // "close the laptop lid" case these tools exist for).
+    let stderr_log: std::process::Stdio = std::fs::File::create(&log_path)
+        .map(Into::into)
+        .unwrap_or_else(|_| std::process::Stdio::null());
     let mut child = std::process::Command::new(&bin)
         .args(&cmd_args)
         .stdin(std::process::Stdio::null())
         .stdout(stdout)
-        .stderr(std::process::Stdio::piped())
+        .stderr(stderr_log)
         .spawn()
         .map_err(|e| (-32603, format!("Failed to spawn modl run: {e}")))?;
 
@@ -1135,38 +1141,19 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
-    if let Some(status) = early_exit {
-        // Process already exited — read stderr to report what went wrong.
-        let stderr_text = child
-            .stderr
-            .take()
-            .and_then(|mut r| {
-                let mut buf = String::new();
-                std::io::Read::read_to_string(&mut r, &mut buf).ok()?;
-                Some(buf)
-            })
-            .unwrap_or_default();
-        if !status.success() {
-            let _ = std::fs::remove_file(pod_result_path(&run_id));
-            return Err((
-                -32603,
-                format!("modl run failed immediately: {}", stderr_text.trim()),
-            ));
-        }
-    }
-
-    // Forward remaining stderr to the log file (best-effort).
-    if let Some(mut stderr_pipe) = child.stderr.take() {
-        let log_path_clone = log_path.clone();
-        std::thread::spawn(move || {
-            if let Ok(mut f) = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&log_path_clone)
-            {
-                let _ = std::io::copy(&mut stderr_pipe, &mut f);
-            }
-        });
+    if let Some(status) = early_exit
+        && !status.success()
+    {
+        // Process already exited — the log file holds what went wrong.
+        let stderr_text = std::fs::read_to_string(&log_path).unwrap_or_default();
+        let _ = std::fs::remove_file(pod_result_path(&run_id));
+        return Err((
+            -32603,
+            format!(
+                "modl run failed immediately: {}",
+                strip_ansi(&stderr_text).trim()
+            ),
+        ));
     }
 
     // Reap the child process when it exits so it doesn't linger as a zombie.
@@ -1365,11 +1352,16 @@ fn tool_pod_up(args: &Value) -> Result<Value, (i32, String)> {
     let stdout: std::process::Stdio = std::fs::File::create(&result_path)
         .map(Into::into)
         .unwrap_or_else(|_| std::process::Stdio::null());
+    // stderr straight to the log file — a pipe would die with this MCP
+    // server and panic the detached child on its next eprintln! (EPIPE).
+    let stderr_log: std::process::Stdio = std::fs::File::create(&log_path)
+        .map(Into::into)
+        .unwrap_or_else(|_| std::process::Stdio::null());
     let mut child = std::process::Command::new(&bin)
         .args(&cmd_args)
         .stdin(std::process::Stdio::null())
         .stdout(stdout)
-        .stderr(std::process::Stdio::piped())
+        .stderr(stderr_log)
         .spawn()
         .map_err(|e| (-32603, format!("Failed to spawn modl pod up: {e}")))?;
 
@@ -1377,16 +1369,8 @@ fn tool_pod_up(args: &Value) -> Result<Value, (i32, String)> {
     let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2000);
     loop {
         if let Ok(Some(status)) = child.try_wait() {
-            let stderr_text = child
-                .stderr
-                .take()
-                .and_then(|mut r| {
-                    let mut buf = String::new();
-                    std::io::Read::read_to_string(&mut r, &mut buf).ok()?;
-                    Some(buf)
-                })
-                .unwrap_or_default();
             if !status.success() {
+                let stderr_text = std::fs::read_to_string(&log_path).unwrap_or_default();
                 let _ = std::fs::remove_file(&result_path);
                 return Err((
                     -32603,
@@ -1404,19 +1388,6 @@ fn tool_pod_up(args: &Value) -> Result<Value, (i32, String)> {
         std::thread::sleep(std::time::Duration::from_millis(100));
     }
 
-    // Forward remaining stderr (provisioning narration) to the log file.
-    if let Some(mut stderr_pipe) = child.stderr.take() {
-        let log_path_clone = log_path.clone();
-        std::thread::spawn(move || {
-            if let Ok(mut f) = std::fs::OpenOptions::new()
-                .create(true)
-                .append(true)
-                .open(&log_path_clone)
-            {
-                let _ = std::io::copy(&mut stderr_pipe, &mut f);
-            }
-        });
-    }
     std::thread::spawn(move || {
         let _ = child.wait();
     });

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -384,13 +384,17 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "run_workflow",
-            "description": "Submit a batch workflow YAML to modl run. Returns immediately with a run_id — the job continues in the background. Use job_status to poll for completion. Useful for fire-and-forget batch runs: submit from laptop, close lid, check back later.",
+            "description": "Submit a batch workflow YAML to modl run. Returns immediately with a run_id — the job continues in the background. Use job_status to poll for completion. Useful for fire-and-forget batch runs: submit from laptop, close lid, check back later. With pod: true the workflow executes on the active rented GPU pod (pod_up first) — model pulls and step chaining happen pod-side, artifacts sync home automatically when the run finishes.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "spec_yaml": {
                         "type": "string",
-                        "description": "Full YAML content of the workflow spec (the contents of a .yaml file)"
+                        "description": "Full YAML content of the workflow spec (the contents of a .yaml file). For pod runs, reference images must be base64 data URIs in the images: map (local file paths don't exist on the pod)."
+                    },
+                    "pod": {
+                        "type": "boolean",
+                        "description": "Run on the active BYO pod instead of this machine. Requires an active pod (pod_up). Poll with job_status(pod: true)."
                     }
                 },
                 "required": ["spec_yaml"]
@@ -398,13 +402,17 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "job_status",
-            "description": "Check the status of a workflow run submitted via run_workflow. Returns aggregate status (pending/running/completed/partial_failure) and artifact URLs. Set MODL_BASE_URL env var on the server for HTTP URLs.",
+            "description": "Check the status of a workflow run submitted via run_workflow. Returns aggregate status (pending/running/completed/partial_failure) and artifact URLs. Set MODL_BASE_URL env var on the server for HTTP URLs. For pod runs pass pod: true — status is read from the pod itself, plus synced_home/local_images once artifacts have landed locally.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "run_id": {
                         "type": "string",
                         "description": "Run ID returned by run_workflow"
+                    },
+                    "pod": {
+                        "type": "boolean",
+                        "description": "The run was submitted with pod: true"
                     }
                 },
                 "required": ["run_id"]
@@ -412,13 +420,98 @@ fn tool_definitions() -> Value {
         },
         {
             "name": "list_run_outputs",
-            "description": "List artifact paths or URLs for a completed workflow run. If MODL_BASE_URL is set on the server, returns HTTP URLs downloadable over Tailscale.",
+            "description": "List artifact paths or URLs for a completed workflow run. If MODL_BASE_URL is set on the server, returns HTTP URLs downloadable over Tailscale. For pod runs pass pod: true — lists the locally-synced artifact paths once the run has finished and synced home.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
                     "run_id": {
                         "type": "string",
                         "description": "Run ID to list outputs for"
+                    },
+                    "pod": {
+                        "type": "boolean",
+                        "description": "The run was submitted with pod: true"
+                    }
+                },
+                "required": ["run_id"]
+            }
+        },
+        {
+            "name": "pod_up",
+            "description": "Rent + bootstrap a GPU pod on the user's Vast.ai account (BILLS MONEY until pod_rm). Returns immediately — provisioning + bootstrap take 5-15 minutes; poll pod_ls until the pod shows ready: true. An already-active pod is reused (no double rent). Requires VASTAI_API_KEY on the server.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "gpu": {
+                        "type": "string",
+                        "description": "GPU type (e.g. rtx3090, rtx4090, a100-80gb, h100) or 'auto' for best value with >=24GB VRAM"
+                    },
+                    "max_price": {
+                        "type": "number",
+                        "description": "Max hourly price in USD (default 3.0)"
+                    },
+                    "min_vram": {
+                        "type": "integer",
+                        "description": "Minimum VRAM in GB (default 24 for 'auto')"
+                    },
+                    "models": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Model IDs to pre-pull into the pod's store after bootstrap (optional — workflows pull what they need anyway)"
+                    }
+                },
+                "required": ["gpu"]
+            }
+        },
+        {
+            "name": "pod_ls",
+            "description": "List GPU pod instances on the user's Vast.ai account: status, price, running cost, and whether the active modl pod is bootstrapped (ready: true means jobs can be submitted). Instances bill until destroyed with pod_rm.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {}
+            }
+        },
+        {
+            "name": "pod_rm",
+            "description": "Destroy a GPU pod instance — billing stops. Use pod_ls to find instance IDs. Destroy pods promptly when work is done; artifacts not yet pulled home die with the pod.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "instance_id": {
+                        "type": "integer",
+                        "description": "Vast.ai instance ID (from pod_up or pod_ls)"
+                    }
+                },
+                "required": ["instance_id"]
+            }
+        },
+        {
+            "name": "pod_pull",
+            "description": "Fetch a finished pod run's artifacts home (re-attach path — pod runs normally sync home automatically when the submitting process survives). Artifacts land in ~/.modl/outputs and register in the local library.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "run_id": {
+                        "type": "string",
+                        "description": "Run ID of a completed pod run"
+                    }
+                },
+                "required": ["run_id"]
+            }
+        },
+        {
+            "name": "pod_logs",
+            "description": "Tail a pod run's log (model pulls, step progress, errors). Useful while job_status shows pending/running, or post-mortem on a failed run.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "run_id": {
+                        "type": "string",
+                        "description": "Run ID of a pod run"
+                    },
+                    "lines": {
+                        "type": "integer",
+                        "description": "Trailing lines to return (default 100)"
                     }
                 },
                 "required": ["run_id"]
@@ -950,11 +1043,37 @@ fn tool_remove_bg(args: &Value) -> Result<Value, (i32, String)> {
     }
 }
 
+/// Local path of the JSON result a detached pod run writes on completion
+/// (`modl run --pod --json` stdout). Existence = the run finished AND its
+/// artifacts were synced home.
+fn pod_result_path(run_id: &str) -> std::path::PathBuf {
+    crate::core::paths::modl_root()
+        .join("run-logs")
+        .join(format!("{run_id}.result.json"))
+}
+
+/// Read + parse the pod run result file, if the run has synced home yet.
+fn read_pod_result(run_id: &str) -> Option<Value> {
+    let text = std::fs::read_to_string(pod_result_path(run_id)).ok()?;
+    serde_json::from_str(text.trim()).ok()
+}
+
 fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
     let spec_yaml = args
         .get("spec_yaml")
         .and_then(|v| v.as_str())
         .ok_or((-32602, "Missing required parameter: spec_yaml".to_string()))?;
+    let pod = args.get("pod").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    // Fail fast on the common mistake instead of a dead run minutes later.
+    // (pods.json is the local record; the spawned run re-verifies with Vast.)
+    if pod && crate::core::pod_state::load().is_empty() {
+        return Err((
+            -32602,
+            "No active pod — call pod_up first, then poll pod_ls until it shows ready: true."
+                .to_string(),
+        ));
+    }
 
     // Pre-generate the run_id. Includes a short random suffix to prevent
     // collisions when two workflows are submitted within the same second.
@@ -975,20 +1094,48 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
 
     let bin = modl_bin().map_err(|e| (-32603, e.to_string()))?;
 
+    let mut cmd_args: Vec<&str> = vec!["run", spec_path.to_str().unwrap_or("")];
+    cmd_args.extend(["--run-id", &run_id]);
+    // Pod runs poll to completion and sync artifacts home, then print a JSON
+    // result on stdout — capture it to a file job_status/list_run_outputs
+    // can read (local runs are queryable in the local DB; pod runs aren't).
+    let stdout: std::process::Stdio = if pod {
+        cmd_args.push("--pod");
+        cmd_args.push("--json");
+        std::fs::File::create(pod_result_path(&run_id))
+            .map(Into::into)
+            .unwrap_or_else(|_| std::process::Stdio::null())
+    } else {
+        std::process::Stdio::null()
+    };
+
     // Capture stderr via pipe for a short window so we can detect immediate
     // failures (bad YAML, missing model, etc.) before returning run_id.
     let mut child = std::process::Command::new(&bin)
-        .args(["run", spec_path.to_str().unwrap_or(""), "--run-id", &run_id])
+        .args(&cmd_args)
         .stdin(std::process::Stdio::null())
-        .stdout(std::process::Stdio::null())
+        .stdout(stdout)
         .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| (-32603, format!("Failed to spawn modl run: {e}")))?;
 
-    // Wait up to 500 ms — enough to catch YAML parse errors and missing files
-    // without blocking for the actual GPU work.
-    std::thread::sleep(std::time::Duration::from_millis(500));
-    if let Ok(Some(status)) = child.try_wait() {
+    // Wait long enough to catch YAML parse errors and missing files without
+    // blocking for the actual GPU work. Pod submissions get a longer window:
+    // the spec's pod-compatibility checks run after a Vast API round-trip.
+    let deadline =
+        std::time::Instant::now() + std::time::Duration::from_millis(if pod { 3000 } else { 500 });
+    let mut early_exit = None;
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            early_exit = Some(status);
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    if let Some(status) = early_exit {
         // Process already exited — read stderr to report what went wrong.
         let stderr_text = child
             .stderr
@@ -1000,6 +1147,7 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
             })
             .unwrap_or_default();
         if !status.success() {
+            let _ = std::fs::remove_file(pod_result_path(&run_id));
             return Err((
                 -32603,
                 format!("modl run failed immediately: {}", stderr_text.trim()),
@@ -1028,15 +1176,24 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         let _ = child.wait();
     });
 
+    let mut result = json!({
+        "run_id": run_id,
+        "status": "submitted",
+        "spec": spec_path.to_string_lossy(),
+        "log": log_path.to_string_lossy(),
+    });
+    if pod {
+        let obj = result.as_object_mut().expect("result is an object");
+        obj.insert("target".into(), json!("pod"));
+        obj.insert(
+            "hint".into(),
+            json!("Poll job_status with pod: true — artifacts sync home automatically when the run finishes."),
+        );
+    }
     Ok(json!({
         "content": [{
             "type": "text",
-            "text": serde_json::to_string_pretty(&json!({
-                "run_id": run_id,
-                "status": "submitted",
-                "spec": spec_path.to_string_lossy(),
-                "log": log_path.to_string_lossy(),
-            })).unwrap_or_default()
+            "text": serde_json::to_string_pretty(&result).unwrap_or_default()
         }]
     }))
 }
@@ -1046,6 +1203,11 @@ fn tool_job_status(args: &Value) -> Result<Value, (i32, String)> {
         .get("run_id")
         .and_then(|v| v.as_str())
         .ok_or((-32602, "Missing required parameter: run_id".to_string()))?;
+    let pod = args.get("pod").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    if pod {
+        return pod_job_status(run_id);
+    }
 
     let (stdout, stderr, success) =
         run_modl(&["status", "--json", run_id]).map_err(|e| (-32603, e))?;
@@ -1066,11 +1228,72 @@ fn tool_job_status(args: &Value) -> Result<Value, (i32, String)> {
     }
 }
 
+/// job_status for a pod run: the pod's own status, annotated with whether
+/// the artifacts have synced home yet. Once the detached runner has written
+/// the result file, the local paths are authoritative even if the pod is
+/// already destroyed.
+fn pod_job_status(run_id: &str) -> Result<Value, (i32, String)> {
+    let local = read_pod_result(run_id);
+
+    let (stdout, stderr, success) =
+        run_modl(&["status", "--json", "--pod", run_id]).map_err(|e| (-32603, e))?;
+
+    let mut result = if success {
+        serde_json::from_str::<Value>(&stdout).unwrap_or_else(|_| json!({ "run_id": run_id }))
+    } else if let Some(local) = &local {
+        // Pod gone or unreachable, but the run already synced home — report
+        // from the local result instead of failing the poll.
+        let mut v = local.clone();
+        if let Some(obj) = v.as_object_mut() {
+            obj.insert(
+                "note".into(),
+                json!("Pod status unavailable — reporting from the synced local result."),
+            );
+        }
+        v
+    } else {
+        let msg = if stderr.is_empty() { &stdout } else { &stderr };
+        return Err((-32603, format!("Pod status check failed: {}", msg.trim())));
+    };
+
+    if let Some(obj) = result.as_object_mut() {
+        obj.insert("synced_home".into(), json!(local.is_some()));
+        if let Some(images) = local.as_ref().and_then(|l| l.get("images")) {
+            obj.insert("local_images".into(), images.clone());
+        }
+    }
+
+    Ok(json!({
+        "content": [{"type": "text", "text": serde_json::to_string_pretty(&result).unwrap_or_default()}]
+    }))
+}
+
 fn tool_list_run_outputs(args: &Value) -> Result<Value, (i32, String)> {
     let run_id = args
         .get("run_id")
         .and_then(|v| v.as_str())
         .ok_or((-32602, "Missing required parameter: run_id".to_string()))?;
+    let pod = args.get("pod").and_then(|v| v.as_bool()).unwrap_or(false);
+
+    if pod {
+        let Some(local) = read_pod_result(run_id) else {
+            return Err((
+                -32603,
+                format!(
+                    "Run {run_id} has not synced home yet — poll job_status (pod: true) until it completes, or pod_pull to fetch it explicitly."
+                ),
+            ));
+        };
+        let images = local.get("images").cloned().unwrap_or_else(|| json!([]));
+        let count = images.as_array().map(|a| a.len()).unwrap_or(0);
+        let text = format!(
+            "{count} artifact(s) for pod run {run_id} (synced to this machine):\n{}",
+            serde_json::to_string_pretty(&images).unwrap_or_default()
+        );
+        return Ok(json!({
+            "content": [{"type": "text", "text": text}]
+        }));
+    }
 
     let (stdout, stderr, success) =
         run_modl(&["status", "--json", run_id]).map_err(|e| (-32603, e))?;
@@ -1098,6 +1321,198 @@ fn tool_list_run_outputs(args: &Value) -> Result<Value, (i32, String)> {
             "content": [{"type": "text", "text": stdout.trim()}]
         }))
     }
+}
+
+/// Rent + bootstrap a pod, fire-and-forget: provisioning takes 5-15 minutes,
+/// far beyond a reasonable tool-call budget, so the work detaches and the
+/// agent polls pod_ls until `ready: true`.
+fn tool_pod_up(args: &Value) -> Result<Value, (i32, String)> {
+    let gpu = args
+        .get("gpu")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing required parameter: gpu".to_string()))?;
+
+    let mut cmd_args: Vec<String> = vec![
+        "pod".into(),
+        "up".into(),
+        gpu.into(),
+        "--yes".into(),
+        "--json".into(),
+    ];
+    if let Some(v) = args.get("max_price").and_then(|v| v.as_f64()) {
+        cmd_args.extend(["--max-price".into(), v.to_string()]);
+    }
+    if let Some(v) = args.get("min_vram").and_then(|v| v.as_u64()) {
+        cmd_args.extend(["--min-vram".into(), v.to_string()]);
+    }
+    for m in args
+        .get("models")
+        .and_then(|v| v.as_array())
+        .into_iter()
+        .flatten()
+        .filter_map(|v| v.as_str())
+    {
+        cmd_args.extend(["--model".into(), m.into()]);
+    }
+
+    let stamp = Local::now().format("%Y%m%d-%H%M%S");
+    let run_log_dir = crate::core::paths::modl_root().join("run-logs");
+    let _ = std::fs::create_dir_all(&run_log_dir);
+    let result_path = run_log_dir.join(format!("pod-up-{stamp}.result.json"));
+    let log_path = run_log_dir.join(format!("pod-up-{stamp}.log"));
+
+    let bin = modl_bin().map_err(|e| (-32603, e.to_string()))?;
+    let stdout: std::process::Stdio = std::fs::File::create(&result_path)
+        .map(Into::into)
+        .unwrap_or_else(|_| std::process::Stdio::null());
+    let mut child = std::process::Command::new(&bin)
+        .args(&cmd_args)
+        .stdin(std::process::Stdio::null())
+        .stdout(stdout)
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| (-32603, format!("Failed to spawn modl pod up: {e}")))?;
+
+    // Catch immediate failures (no Vast key, bad GPU type) before detaching.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(2000);
+    loop {
+        if let Ok(Some(status)) = child.try_wait() {
+            let stderr_text = child
+                .stderr
+                .take()
+                .and_then(|mut r| {
+                    let mut buf = String::new();
+                    std::io::Read::read_to_string(&mut r, &mut buf).ok()?;
+                    Some(buf)
+                })
+                .unwrap_or_default();
+            if !status.success() {
+                let _ = std::fs::remove_file(&result_path);
+                return Err((
+                    -32603,
+                    format!(
+                        "pod up failed immediately: {}",
+                        strip_ansi(&stderr_text).trim()
+                    ),
+                ));
+            }
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    // Forward remaining stderr (provisioning narration) to the log file.
+    if let Some(mut stderr_pipe) = child.stderr.take() {
+        let log_path_clone = log_path.clone();
+        std::thread::spawn(move || {
+            if let Ok(mut f) = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path_clone)
+            {
+                let _ = std::io::copy(&mut stderr_pipe, &mut f);
+            }
+        });
+    }
+    std::thread::spawn(move || {
+        let _ = child.wait();
+    });
+
+    Ok(json!({
+        "content": [{
+            "type": "text",
+            "text": serde_json::to_string_pretty(&json!({
+                "status": "provisioning",
+                "gpu": gpu,
+                "log": log_path.to_string_lossy(),
+                "hint": "Provisioning + bootstrap take 5-15 minutes and BILL until pod_rm. Poll pod_ls until this pod shows ready: true, then submit with run_workflow (pod: true).",
+            })).unwrap_or_default()
+        }]
+    }))
+}
+
+fn tool_pod_ls(_args: &Value) -> Result<Value, (i32, String)> {
+    let (stdout, stderr, success) = run_modl(&["pod", "ls", "--json"]).map_err(|e| (-32603, e))?;
+    if !success {
+        let msg = if stderr.is_empty() { &stdout } else { &stderr };
+        return Err((-32603, format!("pod ls failed: {}", strip_ansi(msg).trim())));
+    }
+    Ok(json!({
+        "content": [{"type": "text", "text": stdout.trim()}]
+    }))
+}
+
+fn tool_pod_rm(args: &Value) -> Result<Value, (i32, String)> {
+    let instance_id = args.get("instance_id").and_then(|v| v.as_u64()).ok_or((
+        -32602,
+        "Missing required parameter: instance_id".to_string(),
+    ))?;
+
+    let id = instance_id.to_string();
+    let (stdout, stderr, success) =
+        run_modl(&["pod", "rm", &id, "--yes"]).map_err(|e| (-32603, e))?;
+    if !success {
+        let msg = if stderr.is_empty() { &stdout } else { &stderr };
+        return Err((-32603, format!("pod rm failed: {}", strip_ansi(msg).trim())));
+    }
+    Ok(json!({
+        "content": [{"type": "text", "text": format!("Instance {instance_id} destroyed — billing stopped.")}]
+    }))
+}
+
+fn tool_pod_pull(args: &Value) -> Result<Value, (i32, String)> {
+    let run_id = args
+        .get("run_id")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing required parameter: run_id".to_string()))?;
+
+    let (stdout, stderr, success) =
+        run_modl(&["pod", "pull", run_id, "--json"]).map_err(|e| (-32603, e))?;
+    if !success {
+        let msg = if stderr.is_empty() { &stdout } else { &stderr };
+        return Err((
+            -32603,
+            format!("pod pull failed: {}", strip_ansi(msg).trim()),
+        ));
+    }
+    if let Ok(result) = serde_json::from_str::<Value>(&stdout) {
+        Ok(json!({
+            "content": [{"type": "text", "text": serde_json::to_string_pretty(&result).unwrap_or_else(|_| stdout.clone())}]
+        }))
+    } else {
+        Ok(json!({
+            "content": [{"type": "text", "text": strip_ansi(&stdout).trim()}]
+        }))
+    }
+}
+
+fn tool_pod_logs(args: &Value) -> Result<Value, (i32, String)> {
+    let run_id = args
+        .get("run_id")
+        .and_then(|v| v.as_str())
+        .ok_or((-32602, "Missing required parameter: run_id".to_string()))?;
+    let lines = args
+        .get("lines")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(100)
+        .to_string();
+
+    let (stdout, stderr, success) =
+        run_modl(&["pod", "logs", run_id, "--lines", &lines]).map_err(|e| (-32603, e))?;
+    if !success {
+        let msg = if stderr.is_empty() { &stdout } else { &stderr };
+        return Err((
+            -32603,
+            format!("pod logs failed: {}", strip_ansi(msg).trim()),
+        ));
+    }
+    let text = strip_ansi(&stdout);
+    Ok(json!({
+        "content": [{"type": "text", "text": if text.trim().is_empty() { "(log is empty so far)" } else { text.trim() }}]
+    }))
 }
 
 fn tool_enhance(args: &Value) -> Result<Value, (i32, String)> {
@@ -1186,6 +1601,11 @@ fn handle_request(request: &JsonRpcRequest) -> Option<JsonRpcResponse> {
                 "run_workflow" => tool_run_workflow(&arguments),
                 "job_status" => tool_job_status(&arguments),
                 "list_run_outputs" => tool_list_run_outputs(&arguments),
+                "pod_up" => tool_pod_up(&arguments),
+                "pod_ls" => tool_pod_ls(&arguments),
+                "pod_rm" => tool_pod_rm(&arguments),
+                "pod_pull" => tool_pod_pull(&arguments),
+                "pod_logs" => tool_pod_logs(&arguments),
                 _ => Err((-32601, format!("Unknown tool: {}", name))),
             }
         }
@@ -1360,7 +1780,64 @@ mod tests {
         assert!(names.contains(&"run_workflow"));
         assert!(names.contains(&"job_status"));
         assert!(names.contains(&"list_run_outputs"));
-        assert_eq!(tool_list.len(), 15);
+        assert!(names.contains(&"pod_up"));
+        assert!(names.contains(&"pod_ls"));
+        assert!(names.contains(&"pod_rm"));
+        assert!(names.contains(&"pod_pull"));
+        assert!(names.contains(&"pod_logs"));
+        assert_eq!(tool_list.len(), 20);
+    }
+
+    #[test]
+    fn test_pod_up_missing_gpu() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            method: "tools/call".into(),
+            params: Some(json!({"name": "pod_up", "arguments": {}})),
+            id: Some(json!(20)),
+        };
+        let resp = handle_request(&req).unwrap();
+        assert!(resp.error.is_some());
+        assert!(resp.error.unwrap().message.contains("gpu"));
+    }
+
+    #[test]
+    fn test_pod_rm_missing_instance_id() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            method: "tools/call".into(),
+            params: Some(json!({"name": "pod_rm", "arguments": {}})),
+            id: Some(json!(21)),
+        };
+        let resp = handle_request(&req).unwrap();
+        assert!(resp.error.is_some());
+        assert!(resp.error.unwrap().message.contains("instance_id"));
+    }
+
+    #[test]
+    fn test_pod_pull_missing_run_id() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            method: "tools/call".into(),
+            params: Some(json!({"name": "pod_pull", "arguments": {}})),
+            id: Some(json!(22)),
+        };
+        let resp = handle_request(&req).unwrap();
+        assert!(resp.error.is_some());
+        assert!(resp.error.unwrap().message.contains("run_id"));
+    }
+
+    #[test]
+    fn test_pod_logs_missing_run_id() {
+        let req = JsonRpcRequest {
+            jsonrpc: "2.0".into(),
+            method: "tools/call".into(),
+            params: Some(json!({"name": "pod_logs", "arguments": {}})),
+            id: Some(json!(23)),
+        };
+        let resp = handle_request(&req).unwrap();
+        assert!(resp.error.is_some());
+        assert!(resp.error.unwrap().message.contains("run_id"));
     }
 
     #[test]

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -444,15 +444,19 @@ fn tool_definitions() -> Value {
                 "properties": {
                     "gpu": {
                         "type": "string",
-                        "description": "GPU type (e.g. rtx3090, rtx4090, a100-80gb, h100) or 'auto' for best value with >=24GB VRAM"
+                        "description": "'auto' (recommended — best all-in value across GPU models with >=24GB VRAM, tune with min_vram) or a specific type (rtx3090, rtx4090, a100-80gb, h100)"
                     },
                     "max_price": {
                         "type": "number",
-                        "description": "Max hourly price in USD (default 3.0)"
+                        "description": "Max hourly GPU price in USD (default 3.0). Storage is quoted and capped separately (all-in = gpu + storage)."
                     },
                     "min_vram": {
                         "type": "integer",
                         "description": "Minimum VRAM in GB (default 24 for 'auto')"
+                    },
+                    "disk": {
+                        "type": "number",
+                        "description": "Disk to provision in GB (default 120 — fits the runtime env plus several fp8 models; storage bills hourly on the full amount, so go leaner for single-model sessions)"
                     },
                     "models": {
                         "type": "array",
@@ -1331,6 +1335,9 @@ fn tool_pod_up(args: &Value) -> Result<Value, (i32, String)> {
     }
     if let Some(v) = args.get("min_vram").and_then(|v| v.as_u64()) {
         cmd_args.extend(["--min-vram".into(), v.to_string()]);
+    }
+    if let Some(v) = args.get("disk").and_then(|v| v.as_f64()) {
+        cmd_args.extend(["--disk".into(), v.to_string()]);
     }
     for m in args
         .get("models")

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -589,6 +589,9 @@ pub enum PodCommands {
         /// Skip the rent-confirmation prompt
         #[arg(long)]
         yes: bool,
+        /// Emit a machine-readable pod record on stdout (progress on stderr)
+        #[arg(long)]
+        json: bool,
     },
     /// Run a command on a pod over SSH (defaults to the active pod)
     ///
@@ -602,15 +605,34 @@ pub enum PodCommands {
         cmd: Vec<String>,
     },
     /// List Vast.ai instances on your account (they bill until destroyed)
-    Ls,
+    Ls {
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
+    },
     /// Fetch a finished run's artifacts from the active pod (re-attach after
     /// a closed laptop or dropped link — runs finish on the pod regardless)
     Pull {
         /// Run ID printed when the run was submitted (pod-YYYYMMDD-…)
         run_id: String,
-        /// Local destination directory (default: ./pod-outputs/<run-id>)
+        /// Local destination directory (default: import into ~/.modl/outputs)
         #[arg(long)]
         dest: Option<std::path::PathBuf>,
+        /// Emit a machine-readable result on stdout (progress on stderr)
+        #[arg(long)]
+        json: bool,
+    },
+    /// Tail a run's log on the active pod (re-attach to a fire-and-forget
+    /// run's output after the submitting watcher died)
+    Logs {
+        /// Run ID printed when the run was submitted
+        run_id: String,
+        /// Keep following the log (like tail -F); Ctrl-C to stop
+        #[arg(long, short = 'f')]
+        follow: bool,
+        /// Number of trailing lines to show
+        #[arg(long, default_value_t = 100)]
+        lines: u32,
     },
     /// Destroy an instance (billing stops)
     Rm {
@@ -1280,6 +1302,10 @@ See `modl/docs/guides/workflows.md` for the full reference.")]
         /// Emit machine-readable JSON
         #[arg(long)]
         json: bool,
+        /// Query the active pod's own status instead of the local DB (pod
+        /// runs live in the pod's DB until their artifacts are pulled home)
+        #[arg(long)]
+        pod: bool,
     },
 
     // ── Hidden ───────────────────────────────────────────────────────
@@ -1649,10 +1675,16 @@ pub async fn run(cli: Cli) -> Result<()> {
                 fresh,
                 models,
                 yes,
-            } => pod::up(gpu, max_price, disk, min_vram, fresh, models, yes).await,
+                json,
+            } => pod::up(gpu, max_price, disk, min_vram, fresh, models, yes, json).await,
             PodCommands::Exec { id, cmd } => pod::exec(id, cmd).await,
-            PodCommands::Ls => pod::ls().await,
-            PodCommands::Pull { run_id, dest } => pod::pull(run_id, dest).await,
+            PodCommands::Ls { json } => pod::ls(json).await,
+            PodCommands::Pull { run_id, dest, json } => pod::pull(run_id, dest, json).await,
+            PodCommands::Logs {
+                run_id,
+                follow,
+                lines,
+            } => pod::logs(run_id, follow, lines).await,
             PodCommands::Rm { id, yes } => pod::rm(id, yes).await,
             PodCommands::Ssh { id } => pod::ssh(id).await,
         },
@@ -1708,7 +1740,7 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
-        Commands::Status { run_id, json } => run_status::run(&run_id, json).await,
+        Commands::Status { run_id, json, pod } => run_status::run(&run_id, json, pod).await,
 
         // ── Hidden ───────────────────────────────────────────────────
         Commands::Init { defaults, root } => init::run(defaults, root.as_deref()).await,

--- a/src/cli/pod.rs
+++ b/src/cli/pod.rs
@@ -11,17 +11,55 @@ use crate::core::pod::{self, PodOptions};
 use crate::core::pod_state::{self, PodRecord};
 use crate::core::vast;
 
-pub async fn ls() -> Result<()> {
+/// The CLI's interactive rent confirmation — a dialoguer prompt injected into
+/// [`PodOptions`] so `core::pod` never touches a TTY itself.
+pub(crate) fn dialoguer_confirm() -> crate::core::pod::ConfirmRent {
+    Box::new(|prompt: &str| {
+        dialoguer::Confirm::new()
+            .with_prompt(prompt.to_string())
+            .default(true)
+            .interact()
+            .context("Cancelled")
+    })
+}
+
+pub async fn ls(json: bool) -> Result<()> {
     let instances = vast::list_instances().await?;
-    if instances.is_empty() {
-        println!("No Vast.ai instances on this account.");
-        return Ok(());
-    }
 
     // Local records let us mark the active pod and show its age/label.
     let records = pod_state::load();
     let rec_by_id: std::collections::HashMap<u64, &PodRecord> =
         records.iter().map(|r| (r.instance_id, r)).collect();
+
+    if json {
+        let out: Vec<serde_json::Value> = instances
+            .iter()
+            .map(|i| {
+                let rec = rec_by_id.get(&i.id);
+                serde_json::json!({
+                    "instance_id": i.id,
+                    "gpu_name": i.gpu_name,
+                    "status": i.actual_status,
+                    "dph_total": i.dph_total,
+                    "ssh_host": i.ssh_host,
+                    "ssh_port": i.ssh_port,
+                    // Tracked in pods.json — the pod train/run/pull reuse.
+                    "active": rec.is_some(),
+                    "label": rec.map(|r| r.label.clone()),
+                    "cost_so_far": rec.map(|r| r.cost_so_far()),
+                    // Bootstrapped and ready for jobs (fingerprint recorded).
+                    "ready": rec.map(|r| r.bootstrap_fingerprint.is_some()).unwrap_or(false),
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    if instances.is_empty() {
+        println!("No Vast.ai instances on this account.");
+        return Ok(());
+    }
 
     println!(
         "{:<3}{:<12} {:<14} {:<10} {:>8} {:>8}  {}",
@@ -65,6 +103,7 @@ pub async fn ls() -> Result<()> {
 }
 
 /// `modl pod up <gpu|auto>` — rent + bootstrap a persistent pod.
+#[allow(clippy::too_many_arguments)]
 pub async fn up(
     gpu: String,
     max_price: f64,
@@ -73,11 +112,12 @@ pub async fn up(
     fresh: bool,
     models: Vec<String>,
     yes: bool,
+    json: bool,
 ) -> Result<()> {
     // 1. Reuse is automatic — an existing pod short-circuits unless --fresh.
     if let Some(rec) = pod_state::active_pod().await? {
         if !fresh {
-            println!(
+            eprintln!(
                 "{} Pod {} already up — {}, ${:.3}/hr. Reuse is automatic; pass {} to replace it.",
                 style("✓").green(),
                 rec.instance_id,
@@ -88,10 +128,17 @@ pub async fn up(
             if !models.is_empty() {
                 crate::core::pod_run::prepare(&pod::Pod::from(rec.clone()), &models)?;
             }
-            print_summary(&rec);
+            if json {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&up_result_json(&rec, true))?
+                );
+            } else {
+                print_summary(&rec);
+            }
             return Ok(());
         }
-        println!(
+        eprintln!(
             "{} --fresh: destroying active pod {} before provisioning a new one…",
             style("→").cyan(),
             rec.instance_id
@@ -108,7 +155,7 @@ pub async fn up(
         min_vram
     };
     if auto {
-        println!(
+        eprintln!(
             "{} auto: picking the best-value GPU with ≥{}GB VRAM (override with --min-vram).",
             style("→").cyan(),
             min_vram_gb.unwrap()
@@ -122,6 +169,7 @@ pub async fn up(
         yes,
         keep_pod: true, // pod up is persistent by definition — never auto-destroys
         label: format!("modl-pod-{}", gpu),
+        confirm_rent: Some(dialoguer_confirm()),
     };
 
     // 3. Provision + bootstrap.
@@ -141,15 +189,38 @@ pub async fn up(
     }
 
     // 6. Summary.
-    println!(
+    eprintln!(
         "{} Pod {} up — {}, ${:.3}/hr, billing until destroyed",
         style("✓").green().bold(),
         pod_obj.instance_id,
         pod_obj.gpu_name,
         pod_obj.dph_total
     );
-    print_summary(&rec);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&up_result_json(&rec, false))?
+        );
+    } else {
+        print_summary(&rec);
+    }
     Ok(())
+}
+
+/// Machine-readable `pod up` result — everything an agent needs to reuse,
+/// monitor, and eventually destroy the pod.
+fn up_result_json(rec: &PodRecord, reused: bool) -> serde_json::Value {
+    serde_json::json!({
+        "instance_id": rec.instance_id,
+        "gpu_name": rec.gpu_name,
+        "dph_total": rec.dph_total,
+        "ssh_host": rec.ssh_host,
+        "ssh_port": rec.ssh_port,
+        "label": rec.label,
+        "created_at": rec.created_at,
+        "ready": rec.bootstrap_fingerprint.is_some(),
+        "reused": reused,
+    })
 }
 
 /// `modl pod exec [--id N] -- <cmd…>` — ssh passthrough for debugging.
@@ -189,7 +260,7 @@ pub async fn exec(id: Option<u64>, cmd: Vec<String>) -> Result<()> {
 /// active pod. The re-attach path: runs are fire-and-forget on the pod, so
 /// if the watching command died (closed laptop, dropped link), this brings
 /// the results home directly over SSH.
-pub async fn pull(run_id: String, dest: Option<std::path::PathBuf>) -> Result<()> {
+pub async fn pull(run_id: String, dest: Option<std::path::PathBuf>, json: bool) -> Result<()> {
     let rec = pod_state::active_pod().await?.context(
         "No active pod — the run's pod may already be destroyed (artifacts die with it).",
     )?;
@@ -198,7 +269,7 @@ pub async fn pull(run_id: String, dest: Option<std::path::PathBuf>) -> Result<()
     let status = crate::core::pod_run::run_status(&pod_obj, &run_id)?;
     match status.as_str() {
         "completed" => {}
-        "partial_failure" => println!(
+        "partial_failure" => eprintln!(
             "{} Run ended with partial failures — pulling the artifacts that completed.",
             style("⚠").yellow()
         ),
@@ -212,7 +283,49 @@ pub async fn pull(run_id: String, dest: Option<std::path::PathBuf>) -> Result<()
         ),
     }
 
-    crate::core::pod_run::export_run(&pod_obj, &run_id, dest.as_deref())?;
+    let (local_dir, artifacts) =
+        crate::core::pod_run::export_run(&pod_obj, &run_id, dest.as_deref())?;
+    if json {
+        // Same shape as `run --pod --json` so agents parse one schema.
+        println!(
+            "{}",
+            serde_json::to_string(&serde_json::json!({
+                "status": status,
+                "run_id": run_id,
+                "output_dir": local_dir,
+                "images": artifacts,
+            }))?
+        );
+    }
+    Ok(())
+}
+
+/// `modl pod logs <run-id> [-f]` — tail a fire-and-forget run's log on the
+/// active pod. The re-attach story for watching: `pod pull` brings artifacts
+/// home, this brings the log stream back after the submitting watcher died.
+pub async fn logs(run_id: String, follow: bool, lines: u32) -> Result<()> {
+    let rec = pod_state::active_pod()
+        .await?
+        .context("No active pod — run logs live on the pod and die with it.")?;
+
+    let log = format!("{}/runs/{}.log", pod::REMOTE_ROOT, run_id);
+    let quoted = crate::core::pod::shell_quote(&log);
+    let tail_flags = if follow {
+        format!("-n {lines} -F")
+    } else {
+        format!("-n {lines}")
+    };
+    // One round-trip: a missing log gets a clear error instead of tail noise.
+    let cmd = format!(
+        "if [ -f {quoted} ]; then tail {tail_flags} {quoted}; \
+         else echo 'No log for run {run_id} on this pod — check the run id (modl pod exec -- ls {}/runs/)' >&2; exit 2; fi",
+        pod::REMOTE_ROOT
+    );
+    let status = pod::ssh_exec(&rec.ssh_host, rec.ssh_port, &cmd)?;
+    if !status.success() {
+        // Ctrl-C on -f lands here too — only propagate real failures.
+        std::process::exit(status.code().unwrap_or(1));
+    }
     Ok(())
 }
 

--- a/src/cli/run_status.rs
+++ b/src/cli/run_status.rs
@@ -1,9 +1,12 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use console::style;
 
 use crate::core::db::Database;
 
-pub async fn run(run_id: &str, json: bool) -> Result<()> {
+pub async fn run(run_id: &str, json: bool, pod: bool) -> Result<()> {
+    if pod {
+        return run_on_pod(run_id, json).await;
+    }
     let db = Database::open()?;
 
     let jobs = db.list_jobs_by_run_id(run_id)?;
@@ -137,5 +140,57 @@ pub async fn run(run_id: &str, json: bool) -> Result<()> {
         );
     }
 
+    Ok(())
+}
+
+/// `modl status <run-id> --pod` — proxy the active pod's own status. A pod
+/// run's step-jobs live in the pod's DB; locally it only becomes visible
+/// once its artifacts are pulled home. The JSON is the pod's status payload
+/// verbatim plus `"target": "pod"` (artifact paths in it are pod-side).
+async fn run_on_pod(run_id: &str, json: bool) -> Result<()> {
+    let rec = crate::core::pod_state::active_pod()
+        .await?
+        .context("No active pod — pod run state dies with the pod (modl pod ls).")?;
+    let pod = crate::core::pod::Pod::from(rec.clone());
+
+    let mut v = crate::core::pod_run::run_status_json(&pod, run_id)?;
+    if let Some(obj) = v.as_object_mut() {
+        obj.insert("target".into(), serde_json::json!("pod"));
+        obj.insert("instance_id".into(), serde_json::json!(rec.instance_id));
+    }
+    if json {
+        println!("{}", serde_json::to_string_pretty(&v)?);
+        return Ok(());
+    }
+
+    let status = v.get("status").and_then(|s| s.as_str()).unwrap_or("?");
+    let steps = v.get("steps").cloned().unwrap_or_default();
+    println!("{}", style("Workflow run status (on pod)").bold().cyan());
+    println!();
+    println!("  {}  {}", style("Run ID:").dim(), run_id);
+    println!(
+        "  {}  {} (pod {})",
+        style("Status:").dim(),
+        status,
+        rec.instance_id
+    );
+    println!(
+        "  {}  {}/{} steps complete{}",
+        style("Steps:").dim(),
+        steps.get("completed").and_then(|x| x.as_u64()).unwrap_or(0),
+        steps.get("total").and_then(|x| x.as_u64()).unwrap_or(0),
+        match steps.get("failed").and_then(|x| x.as_u64()).unwrap_or(0) {
+            0 => String::new(),
+            n => format!(", {n} failed"),
+        }
+    );
+    if status == "completed" || status == "partial_failure" {
+        println!();
+        println!(
+            "  {} Bring artifacts home: {}",
+            style("ℹ").dim(),
+            style(format!("modl pod pull {run_id}")).cyan()
+        );
+    }
     Ok(())
 }

--- a/src/cli/train.rs
+++ b/src/cli/train.rs
@@ -55,6 +55,7 @@ impl PodArgs {
             yes: self.yes,
             keep_pod: self.keep_pod,
             label,
+            confirm_rent: Some(super::pod::dialoguer_confirm()),
         }
     }
 }

--- a/src/core/pod.rs
+++ b/src/core/pod.rs
@@ -45,10 +45,14 @@ pub const POD_DISK_GB: f64 = 80.0;
 /// Duds get destroyed and the next offer is tried, so this can be tight —
 /// good hosts come up in 1-3 minutes.
 const PROVISION_STALL_SECS: u64 = 8 * 60;
-/// Absolute per-host boot cap even while progress is visible — the pod image
-/// is multi-GB, so an honest host with mediocre Hub peering can legitimately
-/// need more than the stall budget to finish pulling layers.
-const PROVISION_HARD_CAP_SECS: u64 = 20 * 60;
+/// Absolute per-host boot cap even while progress is visible. The pod image
+/// is 7.6GB compressed — an honest uncached host at real-world Hub speeds
+/// legitimately needs 10-25 minutes, and abandoning an advancing pull only
+/// to restart from zero on the next host costs more than waiting (storage
+/// bills pennies/hour; measured live 2026-07-16 when a healthy California
+/// host was killed at a 20-minute cap mid-pull). This cap only guards
+/// against a host drip-feeding progress forever.
+const PROVISION_HARD_CAP_SECS: u64 = 30 * 60;
 /// Give up if SSH never accepts a connection after the instance reports running.
 const SSH_TIMEOUT_SECS: u64 = 6 * 60;
 /// Seconds of event silence before probing whether the worker is still alive.

--- a/src/core/pod.rs
+++ b/src/core/pod.rs
@@ -49,6 +49,12 @@ const SSH_TIMEOUT_SECS: u64 = 6 * 60;
 /// Seconds of event silence before probing whether the worker is still alive.
 const LIVENESS_CHECK_SECS: u64 = 60;
 
+/// Rental confirmation injected by the caller. Receives a human-readable
+/// price line; returns whether to proceed. Core never talks to a TTY itself —
+/// the CLI injects a dialoguer prompt, non-interactive callers (MCP, web UI)
+/// inject nothing and must pass `yes` explicitly to rent.
+pub type ConfirmRent = Box<dyn Fn(&str) -> Result<bool> + Send + Sync>;
+
 /// Rental configuration shared by `train --pod` (one-shot) and `pod up`.
 pub struct PodOptions {
     pub gpu_type: String,
@@ -58,6 +64,9 @@ pub struct PodOptions {
     pub keep_pod: bool,
     /// Vast instance label (shows in `pod ls` / the Vast console).
     pub label: String,
+    /// Interactive rent confirmation. Only consulted when `yes` is false;
+    /// `None` + `yes: false` refuses to rent rather than block on a TTY.
+    pub confirm_rent: Option<ConfirmRent>,
 }
 
 /// SSH target for a booted pod. Fields are `pub(crate)` so `pod_executor`
@@ -150,7 +159,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
     // ---------------------------------------------------------------
     // 1. Find and confirm an offer
     // ---------------------------------------------------------------
-    println!(
+    eprintln!(
         "{} Searching Vast.ai for {} offers (max ${:.2}/hr, ranked by perf-per-dollar)...",
         style("→").cyan(),
         opts.gpu_type,
@@ -169,7 +178,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
     }
 
     let best = &offers[0];
-    println!(
+    eprintln!(
         "  {} — {:.0}GB VRAM, {:.0}GB disk, {:.0} Mbps down, ${:.3}/hr (reliability {:.1}%, value {:.0} dlperf/$)",
         style(&best.gpu_name).bold(),
         best.gpu_ram_mb as f64 / 1024.0,
@@ -181,14 +190,17 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
     );
 
     if !opts.yes {
-        let ok = dialoguer::Confirm::new()
-            .with_prompt(format!(
-                "Rent this pod on your Vast.ai account (~${:.3}/hr, billed until destroyed)?",
+        let prompt = format!(
+            "Rent this pod on your Vast.ai account (~${:.3}/hr, billed until destroyed)?",
+            best.dph_total
+        );
+        let ok = match &opts.confirm_rent {
+            Some(confirm) => confirm(&prompt)?,
+            None => bail!(
+                "Refusing to rent a pod (~${:.3}/hr) without confirmation — pass --yes / yes: true to opt in.",
                 best.dph_total
-            ))
-            .default(true)
-            .interact()
-            .context("Cancelled")?;
+            ),
+        };
         if !ok {
             bail!("Aborted before renting a pod.");
         }
@@ -214,7 +226,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
             continue; // same physical box as one that just failed to boot
         }
         if offer.dph_total > price_cap {
-            println!(
+            eprintln!(
                 "{} Skipping fallback offer {} at ${:.3}/hr — more than 25% over the confirmed ${:.3}/hr",
                 style("!").yellow(),
                 offer.id,
@@ -235,7 +247,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
         {
             Ok(id) => id,
             Err(e) => {
-                println!(
+                eprintln!(
                     "{} Offer {} unavailable ({e}), trying next...",
                     style("!").yellow(),
                     offer.id
@@ -244,7 +256,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
             }
         };
 
-        println!(
+        eprintln!(
             "{} Rented instance {} (${:.3}/hr). If anything goes wrong: modl pod rm {}",
             style("✓").green(),
             style(id).bold(),
@@ -266,7 +278,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
             bootstrap_fingerprint: None,
             label: opts.label.clone(),
         }) {
-            println!(
+            eprintln!(
                 "{} Could not record pod {id} in pods.json: {e}",
                 style("⚠").yellow()
             );
@@ -278,8 +290,8 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
                 break;
             }
             Err(e) => {
-                println!("{} {e}", style("!").yellow());
-                println!(
+                eprintln!("{} {e}", style("!").yellow());
+                eprintln!(
                     "{} Host never booted — destroying instance {} and trying the next offer...",
                     style("!").yellow(),
                     id
@@ -291,7 +303,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
                     Ok(()) => {
                         let _ = pod_state::remove(id);
                     }
-                    Err(e) => println!(
+                    Err(e) => eprintln!(
                         "{} Could not destroy {id}: {e} — still billing, check with: modl pod ls",
                         style("✗").red()
                     ),
@@ -312,7 +324,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
     };
     // Refresh the record with the SSH target now that we have one.
     if let Err(e) = pod_state::upsert(pod.to_record(&opts.label)) {
-        println!(
+        eprintln!(
             "{} Could not update pods.json for {instance_id}: {e}",
             style("⚠").yellow()
         );
@@ -342,7 +354,7 @@ pub fn bootstrap(pod: &Pod) -> Result<()> {
 
     // Always refresh the worker — small, and it picks up local worker edits
     // between jobs on a persistent pod.
-    println!("{} Uploading worker...", style("→").cyan());
+    eprintln!("{} Uploading worker...", style("→").cyan());
     run_ssh_quiet(ssh, &format!("mkdir -p {REMOTE_ROOT}/worker"))?;
     rsync_to(
         ssh,
@@ -352,7 +364,7 @@ pub fn bootstrap(pod: &Pod) -> Result<()> {
 
     crate::core::pod_run::ensure_modl(pod)?;
 
-    println!(
+    eprintln!(
         "{} Ensuring managed runtime ({POD_RUNTIME_PROFILE}) on pod...",
         style("→").cyan()
     );
@@ -392,7 +404,7 @@ pub fn run_train_job(pod: &Pod, spec: &TrainJobSpec) -> Result<()> {
 
     let hf_token = huggingface_token();
     if hf_token.is_none() {
-        println!(
+        eprintln!(
             "{} No HuggingFace token found — gated base models (Flux, Klein) will fail to download on the pod. Add one with: modl auth add huggingface",
             style("⚠").yellow()
         );
@@ -413,7 +425,7 @@ pub fn run_train_job(pod: &Pod, spec: &TrainJobSpec) -> Result<()> {
     // 4. Ship dataset + spec
     // ---------------------------------------------------------------
     let dataset_path = PathBuf::from(&spec.dataset.path);
-    println!("{} Uploading dataset...", style("→").cyan());
+    eprintln!("{} Uploading dataset...", style("→").cyan());
     run_ssh_quiet(ssh, &format!("mkdir -p {REMOTE_ROOT}/dataset"))?;
     rsync_to(ssh, &dataset_path, &format!("{REMOTE_ROOT}/dataset-up/"))?;
     // rsync of a dir path (no trailing slash) nests it: dataset-up/<basename>.
@@ -481,7 +493,7 @@ pub fn run_train_job(pod: &Pod, spec: &TrainJobSpec) -> Result<()> {
     // "running" (phantom running jobs in `modl ls` / the UI training tab).
     let result = (|| -> Result<()> {
         run_ssh_quiet(ssh, &launch)?;
-        println!(
+        eprintln!(
             "{} Training started on pod — {}",
             style("→").cyan(),
             style(&job_id).dim()
@@ -499,7 +511,7 @@ pub fn run_train_job(pod: &Pod, spec: &TrainJobSpec) -> Result<()> {
         // ---------------------------------------------------------------
         // 6. Sync artifacts back + register locally
         // ---------------------------------------------------------------
-        println!("{} Syncing artifacts back...", style("→").cyan());
+        eprintln!("{} Syncing artifacts back...", style("→").cyan());
         let local_out = PathBuf::from(&spec.output.destination_dir);
         std::fs::create_dir_all(&local_out)?;
         rsync_from(ssh, &format!("{REMOTE_ROOT}/output/"), &local_out)?;
@@ -517,12 +529,12 @@ pub fn run_train_job(pod: &Pod, spec: &TrainJobSpec) -> Result<()> {
         )?;
         db.update_job_status(&job_id, "completed")?;
 
-        println!(
+        eprintln!(
             "{} LoRA registered: {}",
             style("✓").green().bold(),
             collected.store_path.display()
         );
-        println!(
+        eprintln!(
             "  Try it: modl generate \"{} ...\" --lora {} --base {}",
             spec.params.trigger_word, spec.output.lora_name, spec.model.base_model_id
         );
@@ -546,14 +558,14 @@ pub fn run_train_job(pod: &Pod, spec: &TrainJobSpec) -> Result<()> {
 /// destroy is an error so callers (e.g. `pod up --fresh`) don't proceed to
 /// rent a second pod while the first one still bills.
 pub async fn teardown(pod: &Pod) -> Result<()> {
-    println!(
+    eprintln!(
         "{} Destroying instance {}...",
         style("→").cyan(),
         pod.instance_id
     );
     match vast::destroy_instance(pod.instance_id).await {
         Ok(()) => {
-            println!("{} Pod destroyed — billing stopped.", style("✓").green());
+            eprintln!("{} Pod destroyed — billing stopped.", style("✓").green());
             let _ = pod_state::remove(pod.instance_id);
             Ok(())
         }
@@ -575,7 +587,7 @@ pub async fn teardown(pod: &Pod) -> Result<()> {
 pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()> {
     let min_vram_gb = min_vram_for_train(&spec);
     if let Some(gb) = min_vram_gb {
-        println!(
+        eprintln!(
             "{} {} needs ≥{}GB VRAM for training ({})",
             style("→").cyan(),
             spec.model.base_model_id,
@@ -603,7 +615,7 @@ pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()
         if let Err(e) = pod_state::upsert(kept.to_record(&opts.label)) {
             eprintln!("{} Could not record kept pod: {e}", style("⚠").yellow());
         }
-        println!(
+        eprintln!(
             "{} --keep-pod: instance {} still running & billing.\n  Reuse:  modl train --pod {} …  /  modl pod run …\n  Kill:   modl pod rm {}",
             style("⚠").yellow(),
             pod.instance_id,
@@ -619,7 +631,7 @@ pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()
             if std::fs::create_dir_all(&local_out).is_ok()
                 && rsync_from(&pod.ssh, &format!("{REMOTE_ROOT}/output/"), &local_out).is_ok()
             {
-                println!(
+                eprintln!(
                     "{} Salvaged partial artifacts → {}",
                     style("→").cyan(),
                     local_out.display()
@@ -634,7 +646,7 @@ pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()
     }
 
     let hours = started_at.elapsed().as_secs_f64() / 3600.0;
-    println!(
+    eprintln!(
         "  Pod time: {:.0}m — estimated cost ${:.2}",
         hours * 60.0,
         hours * pod.dph_total
@@ -801,7 +813,7 @@ fn stream_events(ssh: &SshTarget, job_id: &str, db: &Database) -> Result<TrainOu
                 reconnects
             );
         }
-        println!(
+        eprintln!(
             "{} SSH stream dropped — reconnecting ({reconnects})...",
             style("!").yellow()
         );
@@ -842,16 +854,16 @@ fn handle_event_line(
             ..
         } => {
             let loss_str = loss.map(|l| format!("  loss {l:.4}")).unwrap_or_default();
-            println!("  [{stage}] step {step}/{total_steps}{loss_str}");
+            eprintln!("  [{stage}] step {step}/{total_steps}{loss_str}");
         }
         EventPayload::Log { level, message } if level != "debug" => {
-            println!("  {}", style(message).dim());
+            eprintln!("  {}", style(message).dim());
         }
         EventPayload::Warning { message, .. } => {
-            println!("  {} {message}", style("⚠").yellow());
+            eprintln!("  {} {message}", style("⚠").yellow());
         }
         EventPayload::Artifact { path, .. } => {
-            println!("  {} checkpoint: {path}", style("•").cyan());
+            eprintln!("  {} checkpoint: {path}", style("•").cyan());
         }
         EventPayload::Completed { .. } => return Some(TrainOutcome::Completed),
         EventPayload::Error { message, .. } => {
@@ -884,7 +896,7 @@ fn probe_worker(ssh: &SshTarget) -> WorkerProbe {
 }
 
 async fn wait_for_instance(instance_id: u64) -> Result<SshTarget> {
-    println!(
+    eprintln!(
         "{} Waiting for instance to boot (usually 1-3 minutes)...",
         style("→").cyan()
     );
@@ -909,7 +921,7 @@ async fn wait_for_instance(instance_id: u64) -> Result<SshTarget> {
                         "Vast API failed {poll_failures} consecutive status polls for instance {instance_id}"
                     )));
                 }
-                println!(
+                eprintln!(
                     "{} Vast API error while polling ({poll_failures}/5), retrying...",
                     style("!").yellow()
                 );
@@ -918,7 +930,7 @@ async fn wait_for_instance(instance_id: u64) -> Result<SshTarget> {
             }
         };
         if inst.actual_status != last_status {
-            println!("  status: {}", inst.actual_status);
+            eprintln!("  status: {}", inst.actual_status);
             last_status = inst.actual_status.clone();
         }
         if inst.actual_status == "running"
@@ -950,7 +962,7 @@ async fn wait_for_instance(instance_id: u64) -> Result<SshTarget> {
 }
 
 fn wait_for_ssh(ssh: &SshTarget) -> Result<()> {
-    println!(
+    eprintln!(
         "{} Waiting for SSH at {}:{}...",
         style("→").cyan(),
         ssh.host,

--- a/src/core/pod.rs
+++ b/src/core/pod.rs
@@ -41,9 +41,14 @@ const POD_AITOOLKIT: &str = "/root/.modl/runtime/ai-toolkit";
 /// Default disk for one-shot train pods. `pod up` raises this (persistent
 /// pods accumulate an HF cache across jobs — that's the point).
 pub const POD_DISK_GB: f64 = 80.0;
-/// Per-host boot budget. Duds get destroyed and the next offer is tried,
-/// so this can be tight — good hosts come up in 1-3 minutes.
-const PROVISION_TIMEOUT_SECS: u64 = 8 * 60;
+/// Per-host boot budget without visible progress (status/status_msg frozen).
+/// Duds get destroyed and the next offer is tried, so this can be tight —
+/// good hosts come up in 1-3 minutes.
+const PROVISION_STALL_SECS: u64 = 8 * 60;
+/// Absolute per-host boot cap even while progress is visible — the pod image
+/// is multi-GB, so an honest host with mediocre Hub peering can legitimately
+/// need more than the stall budget to finish pulling layers.
+const PROVISION_HARD_CAP_SECS: u64 = 20 * 60;
 /// Give up if SSH never accepts a connection after the instance reports running.
 const SSH_TIMEOUT_SECS: u64 = 6 * 60;
 /// Seconds of event silence before probing whether the worker is still alive.
@@ -165,7 +170,13 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
         opts.gpu_type,
         opts.max_price_per_hour
     );
-    let offers = vast::search_offers(&opts.gpu_type, opts.max_price_per_hour, min_vram_gb).await?;
+    let offers = vast::search_offers(
+        &opts.gpu_type,
+        opts.max_price_per_hour,
+        min_vram_gb,
+        opts.disk_gb,
+    )
+    .await?;
     if offers.is_empty() {
         bail!(
             "No rentable {} offers under ${:.2}/hr{}. Try a bigger GPU type or raise --max-price.",
@@ -178,27 +189,32 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
     }
 
     let best = &offers[0];
+    // Storage bills on the provisioned disk from the moment of rent (even
+    // while loading/stopped) and varies several-fold between hosts — quote
+    // the real all-in rate, not just the GPU line.
+    let best_total = best.dph_total + best.storage_dph(opts.disk_gb);
     eprintln!(
-        "  {} — {:.0}GB VRAM, {:.0}GB disk, {:.0} Mbps down, ${:.3}/hr (reliability {:.1}%, value {:.0} dlperf/$)",
+        "  {} — {:.0}GB VRAM, {:.0}GB disk, {:.0} Mbps down, ${:.3}/hr all-in (${:.3} gpu + ${:.3} storage for {:.0}GB; reliability {:.1}%, value {:.0} dlperf/$)",
         style(&best.gpu_name).bold(),
         best.gpu_ram_mb as f64 / 1024.0,
         best.disk_gb,
         best.inet_down,
+        best_total,
         best.dph_total,
+        best.storage_dph(opts.disk_gb),
+        opts.disk_gb,
         best.reliability * 100.0,
-        vast::offer_value(best)
+        vast::offer_value(best, opts.disk_gb)
     );
 
     if !opts.yes {
         let prompt = format!(
-            "Rent this pod on your Vast.ai account (~${:.3}/hr, billed until destroyed)?",
-            best.dph_total
+            "Rent this pod on your Vast.ai account (~${best_total:.3}/hr all-in, billed until destroyed)?"
         );
         let ok = match &opts.confirm_rent {
             Some(confirm) => confirm(&prompt)?,
             None => bail!(
-                "Refusing to rent a pod (~${:.3}/hr) without confirmation — pass --yes / yes: true to opt in.",
-                best.dph_total
+                "Refusing to rent a pod (~${best_total:.3}/hr all-in) without confirmation — pass --yes / yes: true to opt in."
             ),
         };
         if !ok {
@@ -216,8 +232,9 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
 
     // The user confirmed offers[0]'s price; fallback offers are ranked by
     // perf-per-dollar, not price, so without a cap a failed first rent could
-    // silently land on anything up to --max-price.
-    let price_cap = best.dph_total * 1.25;
+    // silently land on anything up to --max-price. All-in (gpu + storage),
+    // same as the confirmed quote.
+    let price_cap = best_total * 1.25;
 
     let mut booted: Option<(u64, vast::Offer, SshTarget)> = None;
     let mut bad_machines: std::collections::HashSet<u64> = std::collections::HashSet::new();
@@ -225,13 +242,14 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
         if offer.machine_id != 0 && bad_machines.contains(&offer.machine_id) {
             continue; // same physical box as one that just failed to boot
         }
-        if offer.dph_total > price_cap {
+        let offer_total = offer.dph_total + offer.storage_dph(opts.disk_gb);
+        if offer_total > price_cap {
             eprintln!(
-                "{} Skipping fallback offer {} at ${:.3}/hr — more than 25% over the confirmed ${:.3}/hr",
+                "{} Skipping fallback offer {} at ${:.3}/hr all-in — more than 25% over the confirmed ${:.3}/hr",
                 style("!").yellow(),
                 offer.id,
-                offer.dph_total,
-                best.dph_total
+                offer_total,
+                best_total
             );
             continue;
         }
@@ -900,9 +918,13 @@ async fn wait_for_instance(instance_id: u64) -> Result<SshTarget> {
         "{} Waiting for instance to boot (usually 1-3 minutes)...",
         style("→").cyan()
     );
-    let deadline =
-        std::time::Instant::now() + std::time::Duration::from_secs(PROVISION_TIMEOUT_SECS);
+    // Two clocks: a stall budget that resets on any visible progress
+    // (status or status_msg change — e.g. docker layers advancing), and a
+    // hard cap so a host drip-feeding progress can't hold the rent forever.
+    let started = std::time::Instant::now();
+    let mut last_progress = std::time::Instant::now();
     let mut last_status = String::new();
+    let mut last_msg = String::new();
     let mut poll_failures = 0u32;
 
     loop {
@@ -932,6 +954,7 @@ async fn wait_for_instance(instance_id: u64) -> Result<SshTarget> {
         if inst.actual_status != last_status {
             eprintln!("  status: {}", inst.actual_status);
             last_status = inst.actual_status.clone();
+            last_progress = std::time::Instant::now();
         }
         if inst.actual_status == "running"
             && let (Some(host), Some(port)) = (inst.ssh_host.clone(), inst.ssh_port)
@@ -941,20 +964,34 @@ async fn wait_for_instance(instance_id: u64) -> Result<SshTarget> {
         // Hosts sometimes fail at container init (runc/kernel mismatches,
         // broken nvidia runtime). The daemon error is terminal — don't
         // burn the whole boot budget waiting for it to change.
-        if let Some(msg) = &inst.status_msg
-            && (msg.contains("Error response from daemon")
+        if let Some(msg) = &inst.status_msg {
+            if msg.contains("Error response from daemon")
                 || msg.contains("OCI runtime")
-                || msg.contains("failed to start containers"))
-        {
+                || msg.contains("failed to start containers")
+            {
+                bail!(
+                    "Host failed to start the container: {}",
+                    msg.lines().next().unwrap_or(msg)
+                );
+            }
+            // Layer-pull progress shows up here — a changing message means
+            // the host is working, so keep waiting (up to the hard cap).
+            if *msg != last_msg {
+                last_msg = msg.clone();
+                last_progress = std::time::Instant::now();
+            }
+        }
+        if last_progress.elapsed().as_secs() > PROVISION_STALL_SECS {
             bail!(
-                "Host failed to start the container: {}",
-                msg.lines().next().unwrap_or(msg)
+                "Instance {instance_id} made no boot progress for {} minutes (status: {}).",
+                PROVISION_STALL_SECS / 60,
+                last_status
             );
         }
-        if std::time::Instant::now() > deadline {
+        if started.elapsed().as_secs() > PROVISION_HARD_CAP_SECS {
             bail!(
                 "Instance {instance_id} did not reach running state within {} minutes.",
-                PROVISION_TIMEOUT_SECS / 60
+                PROVISION_HARD_CAP_SECS / 60
             );
         }
         tokio::time::sleep(std::time::Duration::from_secs(10)).await;

--- a/src/core/pod_run.rs
+++ b/src/core/pod_run.rs
@@ -720,16 +720,31 @@ fn wait_for_run(pod: &Pod, run_id: &str, log: &str, pidfile: &str) -> Result<Str
 }
 
 pub(crate) fn run_status(pod: &Pod, run_id: &str) -> Result<String> {
-    let out = run_ssh_capture(
-        &pod.ssh,
-        &format!("{REMOTE_MODL} status {} --json", shell_quote(run_id)),
-    )?;
-    let v: serde_json::Value =
-        serde_json::from_str(out.trim()).context("modl status returned invalid JSON")?;
+    let v = run_status_json(pod, run_id)?;
     v.get("status")
         .and_then(|s| s.as_str())
         .map(|s| s.to_string())
         .context("modl status JSON missing 'status'")
+}
+
+/// The pod's own `modl status --json` for a run, verbatim. Pod runs live in
+/// the pod's DB — the local DB only learns about them when artifacts are
+/// pulled home — so status queries for in-flight runs must ask the pod.
+pub fn run_status_json(pod: &Pod, run_id: &str) -> Result<serde_json::Value> {
+    let out = run_ssh_capture(
+        &pod.ssh,
+        &format!("{REMOTE_MODL} status {} --json", shell_quote(run_id)),
+    )?;
+    serde_json::from_str(out.trim()).with_context(|| {
+        format!(
+            "Pod did not return status JSON for run {run_id} — the run may not exist there{}",
+            if out.trim().is_empty() {
+                String::new()
+            } else {
+                format!(" (got: {})", out.trim())
+            }
+        )
+    })
 }
 
 /// Best-effort `tail -F` of the remote run log through a reader thread.

--- a/src/core/pod_run.rs
+++ b/src/core/pod_run.rs
@@ -122,11 +122,20 @@ pub fn ensure_modl(pod: &Pod) -> Result<()> {
         run_ssh_quiet(&pod.ssh, &format!("chmod +x {REMOTE_MODL}"))?;
     }
 
-    let v = run_ssh_capture(&pod.ssh, &format!("{REMOTE_MODL} --version"))?;
+    // 2>&1: the failure detail (e.g. a GLIBC version error from a non-static
+    // dev binary on an older-libc image) arrives on stderr.
+    let v = run_ssh_capture(&pod.ssh, &format!("{REMOTE_MODL} --version 2>&1"))?;
     if !v.contains(version) {
         bail!(
-            "modl on the pod reports '{}' but this CLI is v{version} — install failed?",
-            v.trim()
+            "modl on the pod reports '{}' but this CLI is v{version} — install failed?{}",
+            v.trim(),
+            if v.contains("GLIBC") {
+                "\n  The uploaded dev binary is dynamically linked against a newer glibc than \
+                 the pod image ships. Build a static one:\n    \
+                 cargo build --release --target x86_64-unknown-linux-musl"
+            } else {
+                ""
+            }
         );
     }
     Ok(())

--- a/src/core/vast.rs
+++ b/src/core/vast.rs
@@ -32,6 +32,17 @@ pub struct Offer {
     pub inet_up: f64,
     pub reliability: f64,
     pub dlperf: f64,
+    /// Host's storage price in $/GB/month — billed on the provisioned disk
+    /// even while the instance is loading/stopped, and it varies several-fold
+    /// between hosts, so quotes that omit it mislead.
+    pub storage_cost: f64,
+}
+
+impl Offer {
+    /// Hourly storage cost for `disk_gb` of provisioned disk on this host.
+    pub fn storage_dph(&self, disk_gb: f64) -> f64 {
+        self.storage_cost * disk_gb / (30.0 * 24.0)
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -111,21 +122,28 @@ async fn check(resp: reqwest::Response, what: &str) -> Result<serde_json::Value>
 
 /// Compute per-dollar value of an offer: AI throughput (dlperf) per $/hr.
 /// This is the ranking metric — a slightly slower host at half the price wins.
-pub fn offer_value(offer: &Offer) -> f64 {
-    if offer.dph_total <= 0.0 {
+/// Perf per all-in dollar: GPU rate plus storage for the disk we'll actually
+/// provision. Storage varies several-fold between hosts (measured $0.13 to
+/// $0.87/GB/month on one search page) — at 3090 price points it can exceed
+/// the GPU rate, so ranking on the GPU line alone picks expensive hosts.
+pub fn offer_value(offer: &Offer, disk_gb: f64) -> f64 {
+    let all_in = offer.dph_total + offer.storage_dph(disk_gb);
+    if all_in <= 0.0 {
         return 0.0;
     }
-    offer.dlperf / offer.dph_total
+    offer.dlperf / all_in
 }
 
 /// Search the marketplace for rentable offers matching a GPU type.
 ///
 /// `min_vram_gb` is a hard filter (job won't fit below it). Results are
-/// sorted by value (dlperf per dollar) — not raw speed, not raw price.
+/// sorted by all-in value (dlperf per dollar including storage for
+/// `disk_gb`) — not raw speed, not raw price.
 pub async fn search_offers(
     gpu_type: &str,
     max_price_per_hour: f64,
     min_vram_gb: Option<u32>,
+    disk_gb: f64,
 ) -> Result<Vec<Offer>> {
     let (client, key) = client()?;
 
@@ -142,9 +160,14 @@ pub async fn search_offers(
         // below it pass search, then fail at create_instance, burning a
         // failover attempt.
         "disk_space": {"gte": 80},
-        "reliability2": {"gte": 0.98},
+        "reliability2": {"gte": 0.99},
         "direct_port_count": {"gte": 1},
         "cuda_max_good": {"gte": 12.9},
+        // Docker Hub is unreachable/throttled from mainland China — pulling
+        // the pod image stalls indefinitely, so CN hosts fail every boot
+        // despite passing every other filter (verified, 99%+ reliability).
+        // Measured live 2026-07-16: 4 consecutive CN duds, ~8 min each.
+        "geolocation": {"notin": ["CN"]},
         "order": [["dlperf", "desc"]],
         "limit": 40,
     });
@@ -166,8 +189,8 @@ pub async fn search_offers(
 
     let mut offers = parse_offers(&data);
     offers.sort_by(|a, b| {
-        offer_value(b)
-            .partial_cmp(&offer_value(a))
+        offer_value(b, disk_gb)
+            .partial_cmp(&offer_value(a, disk_gb))
             .unwrap_or(std::cmp::Ordering::Equal)
     });
     Ok(offers)
@@ -196,6 +219,10 @@ fn parse_offers(data: &serde_json::Value) -> Vec<Offer> {
                     .and_then(|v| v.as_f64())
                     .unwrap_or(0.0),
                 dlperf: o.get("dlperf").and_then(|v| v.as_f64()).unwrap_or(0.0),
+                storage_cost: o
+                    .get("storage_cost")
+                    .and_then(|v| v.as_f64())
+                    .unwrap_or(0.0),
             })
         })
         .collect()

--- a/src/core/vast.rs
+++ b/src/core/vast.rs
@@ -160,9 +160,15 @@ pub async fn search_offers(
         // below it pass search, then fail at create_instance, burning a
         // failover attempt.
         "disk_space": {"gte": 80},
-        "reliability2": {"gte": 0.99},
+        "reliability2": {"gte": 0.98},
         "direct_port_count": {"gte": 1},
         "cuda_max_good": {"gte": 12.9},
+        // Storage bills on the provisioned disk from the moment of rent and
+        // is set per host — observed $0.13-$0.87/GB/month on a single search
+        // page. Above ~$0.50 it rivals the GPU rate on cheap cards; those
+        // hosts are never worth it (all-in ranking already penalizes them,
+        // this keeps them out of the fallback pool entirely).
+        "storage_cost": {"lte": 0.50},
         // Docker Hub is unreachable/throttled from mainland China — pulling
         // the pod image stalls indefinitely, so CN hosts fail every boot
         // despite passing every other filter (verified, 99%+ reliability).

--- a/src/core/vast.rs
+++ b/src/core/vast.rs
@@ -10,11 +10,14 @@ use serde_json::json;
 
 const API_BASE: &str = "https://console.vast.ai/api/v0";
 
-/// Docker image for rented pods. Vast's minimal base image on a PINNED tag:
-/// the bootstrap builds its own python/torch venv, so the fat pytorch image
-/// buys nothing — and a stable digest means host docker caches actually hit
-/// (`:latest` churns and forces multi-GB re-pulls fleet-wide).
-pub const POD_IMAGE: &str = "vastai/base-image:cuda-12.9.2-auto";
+/// Docker image for rented pods. Vast's own default PyTorch template: hosts
+/// pre-cache whatever the console default pulls, so it boots in ~1 minute
+/// fleet-wide, while a pinned niche tag pulls 7.6GB cold (measured live
+/// 2026-07-16: an afternoon of 10-25+ min boots and abandoned rents; the
+/// modl-cloud orchestrator learned the same lesson and carries the same
+/// comment). The bootstrap builds its own python/torch venv either way, so
+/// the image only needs to exist quickly — `:latest` churn is irrelevant.
+pub const POD_IMAGE: &str = "vastai/pytorch:latest";
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)] // full marketplace row — some fields are display-only for now
@@ -169,8 +172,12 @@ pub async fn search_offers(
         "rentable": {"eq": true},
         "num_gpus": {"eq": 1},
         "dph_total": {"lte": max_price_per_hour},
-        "inet_down": {"gte": 500},
-        "inet_up": {"gte": 200},
+        // Fast links cut billed dead time on every transfer (image, runtime,
+        // model pulls, artifact sync). modl-cloud runs 2000 down in prod;
+        // pods keep a slightly wider pool and let the value ranking's
+        // link-speed tax sort within it.
+        "inet_down": {"gte": 1000},
+        "inet_up": {"gte": 300},
         // Must cover the POD_DISK_GB (80) requested at rent time — hosts
         // below it pass search, then fail at create_instance, burning a
         // failover attempt.

--- a/src/core/vast.rs
+++ b/src/core/vast.rs
@@ -122,16 +122,31 @@ async fn check(resp: reqwest::Response, what: &str) -> Result<serde_json::Value>
 
 /// Compute per-dollar value of an offer: AI throughput (dlperf) per $/hr.
 /// This is the ranking metric — a slightly slower host at half the price wins.
+/// Transfer a fresh pod performs before it earns anything: docker image
+/// (7.6GB) + managed runtime (~5GB of torch wheels) + one fp8 model
+/// (~15GB). All of it downloads at full GPU-hour billing.
+const STARTUP_TRANSFER_GB: f64 = 30.0;
+/// Horizon the startup transfer is amortized over when ranking offers —
+/// roughly a typical interactive pod session.
+const VALUE_SESSION_HOURS: f64 = 2.0;
+
 /// Perf per all-in dollar: GPU rate plus storage for the disk we'll actually
-/// provision. Storage varies several-fold between hosts (measured $0.13 to
+/// provision, plus a tax for the GPU-time a slow link burns on the startup
+/// downloads. Storage varies several-fold between hosts (measured $0.13 to
 /// $0.87/GB/month on one search page) — at 3090 price points it can exceed
-/// the GPU rate, so ranking on the GPU line alone picks expensive hosts.
+/// the GPU rate. Likewise a cheap host on a slow link spends its discount
+/// on billed dead minutes: 30GB at 500 Mbps is 8 min (~7% of a session), at
+/// 100 Mbps it's 40 min (~33%). `inet_down` is the host's self-rated speed
+/// — real CDN throughput is often lower (hard floors in the search query
+/// still apply) — so this is a prior, not a guarantee.
 pub fn offer_value(offer: &Offer, disk_gb: f64) -> f64 {
     let all_in = offer.dph_total + offer.storage_dph(disk_gb);
     if all_in <= 0.0 {
         return 0.0;
     }
-    offer.dlperf / all_in
+    let pull_hours = STARTUP_TRANSFER_GB * 8000.0 / offer.inet_down.max(1.0) / 3600.0;
+    let pull_tax = all_in * (pull_hours / VALUE_SESSION_HOURS);
+    offer.dlperf / (all_in + pull_tax)
 }
 
 /// Search the marketplace for rentable offers matching a GPU type.
@@ -403,6 +418,45 @@ mod tests {
         let inst = parse_instance(&sparse, 777).unwrap();
         assert_eq!(inst.id, 777);
         assert!(inst.ssh_host.is_none());
+    }
+
+    fn offer_with(dph: f64, storage: f64, inet_down: f64, dlperf: f64) -> Offer {
+        Offer {
+            id: 1,
+            machine_id: 0,
+            gpu_name: "RTX 3090".into(),
+            num_gpus: 1,
+            gpu_ram_mb: 24576,
+            disk_gb: 200.0,
+            dph_total: dph,
+            inet_down,
+            inet_up: 500.0,
+            reliability: 0.99,
+            dlperf,
+            storage_cost: storage,
+        }
+    }
+
+    #[test]
+    fn value_penalizes_expensive_storage() {
+        // Same GPU price and perf; $0.87/GB/mo storage vs $0.20 — the cheap
+        // storage host must win once the provisioned disk is priced in.
+        let gouger = offer_with(0.12, 0.87, 1000.0, 44.0);
+        let fair = offer_with(0.12, 0.20, 1000.0, 44.0);
+        assert!(offer_value(&fair, 120.0) > offer_value(&gouger, 120.0));
+    }
+
+    #[test]
+    fn value_penalizes_slow_links() {
+        // Identical all-in pricing; 100 Mbps burns ~40 GPU-billed minutes on
+        // startup downloads vs ~2 min at 2 Gbps.
+        let slow = offer_with(0.12, 0.20, 100.0, 44.0);
+        let fast = offer_with(0.12, 0.20, 2000.0, 44.0);
+        assert!(offer_value(&fast, 120.0) > offer_value(&slow, 120.0));
+        // ...but a slightly slower link must not outweigh a big price gap.
+        let fast_pricey = offer_with(0.40, 0.20, 2000.0, 44.0);
+        let modest_cheap = offer_with(0.12, 0.20, 800.0, 44.0);
+        assert!(offer_value(&modest_cheap, 120.0) > offer_value(&fast_pricey, 120.0));
     }
 
     #[test]


### PR DESCRIPTION
Priority 1 from the pod roadmap: the agent-on-a-GPU-less-laptop flow. Rent a pod, submit fire-and-forget workflows, poll status, artifacts sync home — all over MCP. Includes its prerequisite (the `core/pod.rs` dialoguer/println extraction) and the `pod logs` rider.

## MCP (15 → 20 tools)

| Tool | What it does |
|---|---|
| `pod_up` | Rent + bootstrap (fire-and-forget — provisioning takes 5-15 min; poll `pod_ls` until `ready: true`). 2s early-failure window catches missing Vast key / bad GPU type before detaching. |
| `pod_ls` | Instances with status, price, running cost, `ready` flag |
| `pod_rm` | Destroy an instance — billing stops |
| `pod_pull` | Re-attach: fetch a finished run's artifacts home |
| `pod_logs` | Re-attach: tail a run's pod-side log |

- `run_workflow` accepts `pod: true` → spawns detached `modl run --pod --json --run-id <id>`; the runner polls the pod, exports + imports artifacts into `~/.modl/outputs` (the #120 landing path), and its JSON result is captured to `~/.modl/run-logs/<run-id>.result.json`. Fails fast when pods.json is empty.
- `job_status` accepts `pod: true` → proxies the pod's own `modl status --json` (pod runs live in the pod's DB, invisible locally until synced), annotated with `synced_home` + `local_images`; falls back to the synced local result if the pod is already destroyed.
- `list_run_outputs` accepts `pod: true` → locally-synced artifact paths.

## CLI surface backing the tools

- `modl pod up --json`, `modl pod ls --json`, `modl pod pull --json` — results on stdout, progress on stderr
- `modl pod logs <run-id> [-f] [--lines N]` — tail a fire-and-forget run's log after the watcher died (was: `pod exec -- tail -f`)
- `modl status <run-id> --pod` — the active pod's status verbatim (+ `target: "pod"`, `instance_id`)

## Prerequisite extraction

`core/pod.rs` no longer owns a TTY: the dialoguer rent prompt became a `confirm_rent` callback injected by the CLI layer (non-interactive callers must pass `yes` to rent — never silently), and all 35 narration sites moved to stderr, matching the pod_run.rs convention from #115. Also unblocks the web UI targeting pods later.

## Tests

- 186 lib + 11 CLI tests pass; new tests for the 20-tool list and required-param errors on the pod tools.
- Drove `modl mcp` over stdio: `tools/list` returns 20 tools; `run_workflow(pod: true)` with no pod fails fast with the pod_up hint; `pod_logs` errors cleanly with no active pod.
- Live 3090 smoke next (doubles as #120's pending pod-side landing smoke); will report results on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)