### PR TITLE
feat: workflow image inputs + multi-image edit (closes Tier 1 of the pod gaps)

### DIFF
--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -41,19 +41,11 @@ pub struct EditArgs<'a> {
     pub json: bool,
 }
 
-/// Edit on the active pod: inline the input image as a base64 data URI in a
-/// one-step workflow (client paths don't exist on the pod) and hand it to
-/// the remote modl (`core::pod_run`).
+/// Edit on the active pod: inline every input image (and mask) as base64 data
+/// URIs in a one-step workflow (client paths don't exist on the pod) and hand
+/// it to the remote modl (`core::pod_run`).
 async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
-    if args.images.len() != 1 {
-        anyhow::bail!("--pod supports exactly one --image for now.");
-    }
-    for (flag, set) in [
-        ("--mask", args.mask.is_some()),
-        ("--blend", args.blend != BlendMode::Pixel),
-        ("--cloud", args.cloud),
-        ("--attach-gpu", args.attach_gpu),
-    ] {
+    for (flag, set) in [("--cloud", args.cloud), ("--attach-gpu", args.attach_gpu)] {
         if set {
             anyhow::bail!("{flag} isn't supported with --pod yet — run locally or drop the flag.");
         }
@@ -70,7 +62,20 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
         );
     }
     let model = args.base.unwrap_or("qwen-image-edit-2511");
-    let local_image = resolve_image_input(&args.images[0]).await?;
+    let mut local_images = Vec::with_capacity(args.images.len());
+    for img in args.images {
+        local_images.push(PathBuf::from(resolve_image_input(img).await?));
+    }
+    // Sentinel masks pass through to the pod; paths/URLs resolve locally and
+    // get inlined by the spec builder.
+    let local_mask: Option<String> = match args.mask {
+        None => None,
+        Some(m @ ("auto" | "from-alpha")) => Some(m.to_string()),
+        Some(m) => Some(resolve_image_input(m).await?),
+    };
+    if args.blend == BlendMode::Latent && local_mask.is_none() {
+        anyhow::bail!("--blend latent requires --mask");
+    }
 
     let (width, height) = match args.size {
         Some(s) => {
@@ -96,7 +101,9 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
     let spec = crate::core::pod_run::single_edit_spec(
         model,
         args.prompt,
-        std::path::Path::new(&local_image),
+        &local_images,
+        local_mask.as_deref(),
+        Some(args.blend),
         args.lora,
         args.fast,
         width,

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -17,34 +17,7 @@ use crate::core::remote_executor::RemoteExecutor;
 use crate::core::runtime;
 
 /// Known control type suffixes for auto-detection from filenames.
-const CONTROL_SUFFIXES: &[(&str, &str)] = &[
-    ("_canny", "canny"),
-    ("_depth", "depth"),
-    ("_pose", "pose"),
-    ("_softedge", "softedge"),
-    ("_scribble", "scribble"),
-    ("_hed", "hed"),
-    ("_mlsd", "mlsd"),
-    ("_gray", "gray"),
-    ("_normal", "normal"),
-    ("_lineart", "lineart"),
-];
-
-/// Try to detect the control type from a filename suffix (e.g. "photo_depth.png" → "depth").
-fn detect_control_type_from_filename(path: &str) -> Option<String> {
-    let stem = PathBuf::from(path)
-        .file_stem()
-        .unwrap_or_default()
-        .to_string_lossy()
-        .to_lowercase();
-
-    for &(suffix, control_type) in CONTROL_SUFFIXES {
-        if stem.ends_with(suffix) {
-            return Some(control_type.to_string());
-        }
-    }
-    None
-}
+use crate::core::model_family::detect_control_type_from_filename;
 
 /// Read image dimensions from a file on disk.
 fn image_dimensions(path: &str) -> Result<(u32, u32)> {
@@ -133,17 +106,31 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
     let model = args.base.context(
         "--pod needs an explicit --base <model-id> (e.g. flux-schnell) — it's pulled into the pod's store.",
     )?;
-    for (flag, set) in [
-        ("--init-image", args.init_image.is_some()),
-        ("--mask", args.mask.is_some()),
-        ("--controlnet", !args.controlnet.is_empty()),
-        ("--style-ref", !args.style_ref.is_empty()),
-        ("--cloud", args.cloud),
-        ("--attach-gpu", args.attach_gpu),
-    ] {
+    for (flag, set) in [("--cloud", args.cloud), ("--attach-gpu", args.attach_gpu)] {
         if set {
             anyhow::bail!("{flag} isn't supported with --pod yet — run locally or drop the flag.");
         }
+    }
+    // Inpaint method selection isn't a workflow field yet — only the default
+    // auto behaviour ships to pods.
+    if args.mask.is_some() && !matches!(args.inpaint, InpaintMethod::Auto) {
+        anyhow::bail!("--inpaint isn't supported with --pod yet — run locally or drop the flag.");
+    }
+    // Same mode validation as local runs, against models.toml (no store needed).
+    // Note: no automatic inpaint-model swap on pods — pick an inpaint-capable
+    // --base explicitly; the error below lists them.
+    let mode = match (args.init_image.is_some(), args.mask.is_some()) {
+        (_, true) => Some("inpaint"),
+        (true, false) => Some("img2img"),
+        (false, false) => None,
+    };
+    if args.mask.is_some() && args.init_image.is_none() {
+        anyhow::bail!("--mask requires --init-image (inpainting regenerates a masked region).");
+    }
+    if let Some(mode) = mode
+        && let Err(msg) = model_family::validate_mode(model, mode)
+    {
+        anyhow::bail!(msg);
     }
     if args.fast.is_some() && args.lora.is_some() {
         anyhow::bail!(
@@ -179,6 +166,30 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         (None, _) => vec![],
     };
 
+    // Build + validate ControlNet / style-ref inputs against models.toml,
+    // exactly like a local run — the spec builder inlines the image files.
+    let cn_inputs = build_cn_inputs(
+        args.controlnet,
+        args.cn_strength,
+        args.cn_end,
+        args.cn_type,
+        model,
+    )?;
+    let style_inputs =
+        build_style_inputs(args.style_ref, args.style_strength, args.style_type, model)?;
+    for p in [args.init_image, args.mask].into_iter().flatten() {
+        if !std::path::Path::new(p).exists() {
+            anyhow::bail!("Image not found: {p}");
+        }
+    }
+    let image_inputs = crate::core::pod_run::GenImageInputs {
+        init_image: args.init_image.map(std::path::Path::new),
+        mask: args.mask.map(std::path::Path::new),
+        strength: args.strength,
+        controlnet: &cn_inputs,
+        style_ref: &style_inputs,
+    };
+
     let spec = crate::core::pod_run::single_generate_spec(
         model,
         args.prompt,
@@ -189,6 +200,7 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         args.steps,
         args.guidance.map(|g| g as f64),
         &seeds,
+        &image_inputs,
     )?;
 
     let rec = crate::core::pod_state::active_pod()
@@ -215,6 +227,102 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         style(format!("modl pod rm {}", rec.instance_id)).bold()
     );
     Ok(())
+}
+
+/// Validate and build ControlNet inputs from CLI flags. Shared between local
+/// and pod execution — `effective_model` drives support validation.
+fn build_cn_inputs(
+    controlnet: &[String],
+    cn_strength: &str,
+    cn_end: &str,
+    cn_type: Option<&str>,
+    effective_model: &str,
+) -> Result<Vec<ControlNetInput>> {
+    if controlnet.is_empty() {
+        return Ok(Vec::new());
+    }
+    if controlnet.len() > 2 {
+        anyhow::bail!(
+            "Maximum 2 ControlNet inputs supported. You provided {}.",
+            controlnet.len()
+        );
+    }
+
+    // Parse comma-separated strengths/ends
+    let strengths: Vec<f32> = cn_strength
+        .split(',')
+        .map(|s| s.trim().parse::<f32>().unwrap_or(0.75))
+        .collect();
+    let ends: Vec<f32> = cn_end
+        .split(',')
+        .map(|s| s.trim().parse::<f32>().unwrap_or(0.8))
+        .collect();
+
+    let mut inputs = Vec::new();
+    for (i, cn_path) in controlnet.iter().enumerate() {
+        let path = PathBuf::from(cn_path);
+        if !path.exists() {
+            anyhow::bail!("ControlNet image not found: {cn_path}");
+        }
+
+        // Resolve control type: explicit flag > filename suffix > error
+        let control_type = if let Some(explicit) = cn_type {
+            explicit.to_string()
+        } else {
+            detect_control_type_from_filename(cn_path).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "Could not auto-detect control type for '{}'. \
+                     Use --cn-type to specify. Options: canny, depth, pose, softedge, scribble, hed, mlsd, gray, normal",
+                    path.file_name().unwrap_or_default().to_string_lossy()
+                )
+            })?
+        };
+
+        // Validate this model + type combination
+        if let Err(msg) = model_family::validate_controlnet(effective_model, &control_type) {
+            anyhow::bail!(msg);
+        }
+
+        inputs.push(ControlNetInput {
+            image: cn_path.clone(),
+            control_type,
+            strength: strengths.get(i).copied().unwrap_or(0.75),
+            control_end: ends.get(i).copied().unwrap_or(0.8),
+        });
+    }
+    Ok(inputs)
+}
+
+/// Validate and build style-ref inputs from CLI flags. Shared between local
+/// and pod execution.
+fn build_style_inputs(
+    style_ref: &[String],
+    style_strength: f32,
+    style_type: Option<&str>,
+    effective_model: &str,
+) -> Result<Vec<StyleRefInput>> {
+    if style_ref.is_empty() {
+        return Ok(Vec::new());
+    }
+    if let Err(msg) = model_family::validate_style_ref(effective_model) {
+        anyhow::bail!(msg);
+    }
+
+    let style_type_str = style_type.unwrap_or("style").to_string();
+
+    style_ref
+        .iter()
+        .map(|path| {
+            if !PathBuf::from(path).exists() {
+                anyhow::bail!("Style reference image not found: {path}");
+            }
+            Ok(StyleRefInput {
+                image: path.clone(),
+                strength: style_strength,
+                style_type: style_type_str.clone(),
+            })
+        })
+        .collect::<Result<Vec<_>>>()
 }
 
 /// JSON result for a pod run — same shape for generate/edit/run so agents
@@ -433,90 +541,10 @@ async fn run_local(args: GenerateArgs<'_>, db: Database) -> Result<()> {
     }
 
     // -------------------------------------------------------------------
-    // Validate and build ControlNet inputs
+    // Validate and build ControlNet + style-ref inputs
     // -------------------------------------------------------------------
-    let cn_inputs = if !controlnet.is_empty() {
-        if controlnet.len() > 2 {
-            anyhow::bail!(
-                "Maximum 2 ControlNet inputs supported. You provided {}.",
-                controlnet.len()
-            );
-        }
-
-        // Parse comma-separated strengths/ends
-        let strengths: Vec<f32> = cn_strength
-            .split(',')
-            .map(|s| s.trim().parse::<f32>().unwrap_or(0.75))
-            .collect();
-        let ends: Vec<f32> = cn_end
-            .split(',')
-            .map(|s| s.trim().parse::<f32>().unwrap_or(0.8))
-            .collect();
-
-        let mut inputs = Vec::new();
-        for (i, cn_path) in controlnet.iter().enumerate() {
-            let path = PathBuf::from(cn_path);
-            if !path.exists() {
-                anyhow::bail!("ControlNet image not found: {cn_path}");
-            }
-
-            // Resolve control type: explicit flag > filename suffix > error
-            let control_type = if let Some(explicit) = cn_type {
-                explicit.to_string()
-            } else {
-                detect_control_type_from_filename(cn_path).ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "Could not auto-detect control type for '{}'. \
-                         Use --cn-type to specify. Options: canny, depth, pose, softedge, scribble, hed, mlsd, gray, normal",
-                        path.file_name().unwrap_or_default().to_string_lossy()
-                    )
-                })?
-            };
-
-            // Validate this model + type combination
-            if let Err(msg) = model_family::validate_controlnet(&effective_model, &control_type) {
-                anyhow::bail!(msg);
-            }
-
-            inputs.push(ControlNetInput {
-                image: cn_path.clone(),
-                control_type,
-                strength: strengths.get(i).copied().unwrap_or(0.75),
-                control_end: ends.get(i).copied().unwrap_or(0.8),
-            });
-        }
-        inputs
-    } else {
-        Vec::new()
-    };
-
-    // -------------------------------------------------------------------
-    // Validate and build style-ref inputs
-    // -------------------------------------------------------------------
-    let style_inputs: Vec<StyleRefInput> = if !style_ref.is_empty() {
-        // Validate model supports style-ref
-        if let Err(msg) = model_family::validate_style_ref(&effective_model) {
-            anyhow::bail!(msg);
-        }
-
-        let style_type_str = style_type.unwrap_or("style").to_string();
-
-        style_ref
-            .iter()
-            .map(|path| {
-                if !PathBuf::from(path).exists() {
-                    anyhow::bail!("Style reference image not found: {path}");
-                }
-                Ok(StyleRefInput {
-                    image: path.clone(),
-                    strength: style_strength,
-                    style_type: style_type_str.clone(),
-                })
-            })
-            .collect::<Result<Vec<_>>>()?
-    } else {
-        Vec::new()
-    };
+    let cn_inputs = build_cn_inputs(controlnet, cn_strength, cn_end, cn_type, &effective_model)?;
+    let style_inputs = build_style_inputs(style_ref, style_strength, style_type, &effective_model)?;
 
     // -------------------------------------------------------------------
     // Build output directory: ~/.modl/outputs/<date>/

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -390,7 +390,7 @@ fn tool_definitions() -> Value {
                 "properties": {
                     "spec_yaml": {
                         "type": "string",
-                        "description": "Full YAML content of the workflow spec (the contents of a .yaml file). For pod runs, reference images must be base64 data URIs in the images: map (local file paths don't exist on the pod)."
+                        "description": "Full YAML content of the workflow spec (the contents of a .yaml file). Steps take image inputs as $name (images: map entry), $step-id.outputs[N], or a server path: edit steps accept one source or a list (edit: [\"$a\", \"$b\"] for multi-image editing) plus mask/blend; generate steps accept init_image, mask, strength, controlnet ([{image, type, strength, end}]), and style_ref ([{image, strength}]). For pod runs, reference images must be base64 data URIs in the images: map (local file paths don't exist on the pod)."
                     },
                     "pod": {
                         "type": "boolean",

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -30,7 +30,9 @@ use crate::core::outputs::{SidecarMetadata, write_sidecar_yaml};
 
 /// Key used for the skip-existing completion index: (prompt, seed, base_model_id).
 type CompletionKey = (String, u64, String);
-use crate::core::workflow::{EditStep, GenerateStep, ImageRef, StepKind, Workflow, parse_file};
+use crate::core::workflow::{
+    EditMask, EditStep, GenerateStep, ImageRef, StepKind, Workflow, parse_file,
+};
 use crate::core::{model_family, model_resolve, paths, registry, runtime};
 
 // ---------------------------------------------------------------------------
@@ -536,6 +538,24 @@ pub fn build_plan(
         // capabilities) — same policy as `arch_key`.
         check_capability(&step.id, &resolved_model.id, &step.kind)?;
 
+        // ControlNet / style-ref support is model-dependent — validate against
+        // the step's effective model so the run fails at plan time, not after
+        // the worker has loaded weights.
+        if let StepKind::Generate(g) = &step.kind {
+            for cn in &g.controlnet {
+                if let Err(msg) =
+                    model_family::validate_controlnet(&resolved_model.id, &cn.control_type)
+                {
+                    return Err(PlanError::Other(format!("step `{}`: {msg}", step.id)));
+                }
+            }
+            if !g.style_ref.is_empty()
+                && let Err(msg) = model_family::validate_style_ref(&resolved_model.id)
+            {
+                return Err(PlanError::Other(format!("step `{}`: {msg}", step.id)));
+            }
+        }
+
         // Resolve `fast:` against the model's Lightning config. The parser
         // already rejects `fast` + `lora` on the same step; an inherited
         // workflow-level `lora` is overridden by the Lightning LoRA.
@@ -620,21 +640,21 @@ fn schedule_steps(wf: &Workflow, planned: &[PlannedStep]) -> Schedule {
         .collect();
 
     // 2. Build dependency graph: deps[i] = set of step indices i depends on.
-    // Only edit steps can have deps (via `ImageRef::StepOutput`).
+    // Any image slot can carry a `$step.outputs[N]` ref — edit sources and
+    // masks, generate init images, controlnet and style-ref inputs.
     let mut deps: Vec<HashSet<usize>> = vec![HashSet::new(); n];
     let mut reverse_deps: Vec<Vec<usize>> = vec![Vec::new(); n];
     for (i, step) in wf.steps.iter().enumerate() {
-        let StepKind::Edit(e) = &step.kind else {
-            continue;
-        };
-        let ImageRef::StepOutput { step_id, .. } = &e.source else {
-            continue;
-        };
-        let Some(&dep_idx) = id_to_idx.get(step_id.as_str()) else {
-            continue;
-        };
-        if deps[i].insert(dep_idx) {
-            reverse_deps[dep_idx].push(i);
+        for r in step.image_refs() {
+            let ImageRef::StepOutput { step_id, .. } = r else {
+                continue;
+            };
+            let Some(&dep_idx) = id_to_idx.get(step_id.as_str()) else {
+                continue;
+            };
+            if deps[i].insert(dep_idx) {
+                reverse_deps[dep_idx].push(i);
+            }
         }
     }
 
@@ -736,7 +756,8 @@ fn resolve_model(id: &str, db: &Database) -> Result<ResolvedModel, PlanError> {
 
 /// Check that a resolved model supports the operation a step is asking for.
 ///
-/// `Generate` requires `txt2img`; `Edit` requires `edit`. Models not present in
+/// `Generate` requires `txt2img` (or `img2img`/`inpaint` when the step has an
+/// `init_image`/`mask`); `Edit` requires `edit`. Models not present in
 /// `models.toml` (registry-only) are skipped — we don't have capability metadata
 /// for them, and refusing would be more surprising than letting the worker fail.
 fn check_capability(step_id: &str, model_id: &str, kind: &StepKind) -> Result<(), PlanError> {
@@ -744,6 +765,14 @@ fn check_capability(step_id: &str, model_id: &str, kind: &StepKind) -> Result<()
         return Ok(());
     };
     let (kind_str, required, ok) = match kind {
+        StepKind::Generate(g) if g.mask.is_some() => (
+            "generate",
+            "inpaint",
+            info.capabilities.inpaint || info.capabilities.lanpaint_inpaint,
+        ),
+        StepKind::Generate(g) if g.init_image.is_some() => {
+            ("generate", "img2img", info.capabilities.img2img)
+        }
         StepKind::Generate(_) => ("generate", "txt2img", info.capabilities.txt2img),
         StepKind::Edit(_) => ("edit", "edit", info.capabilities.edit),
     };
@@ -934,6 +963,7 @@ pub async fn execute_plan(
 
         match &step.kind {
             StepKind::Generate(g) => {
+                let gen_inputs = resolve_generate_inputs(g, &step_outputs, &step.id)?;
                 print_generate_preview(g, sub_jobs.len());
                 for (sub_idx, (seed, count)) in sub_jobs.iter().enumerate() {
                     // Skip sub-jobs already in the completion index (default behaviour).
@@ -979,6 +1009,7 @@ pub async fn execute_plan(
                         resolved_lora.clone(),
                         planned.lightning.as_ref(),
                         g,
+                        &gen_inputs,
                         *seed,
                         *count,
                         &plan.output_dir,
@@ -1034,8 +1065,22 @@ pub async fn execute_plan(
                 }
             }
             StepKind::Edit(e) => {
-                let source_path = resolve_image_ref(&e.source, &step_outputs, &step.id)?;
-                print_edit_preview(e, &source_path, sub_jobs.len());
+                let source_paths: Vec<PathBuf> = e
+                    .sources
+                    .iter()
+                    .map(|r| resolve_image_ref(r, &step_outputs, &step.id))
+                    .collect::<Result<_>>()?;
+                let mask_path: Option<String> = match &e.mask {
+                    None => None,
+                    Some(EditMask::Auto) => Some("auto".to_string()),
+                    Some(EditMask::FromAlpha) => Some("from-alpha".to_string()),
+                    Some(EditMask::Image(r)) => Some(
+                        resolve_image_ref(r, &step_outputs, &step.id)?
+                            .to_string_lossy()
+                            .to_string(),
+                    ),
+                };
+                print_edit_preview(e, &source_paths, sub_jobs.len());
                 for (sub_idx, (seed, count)) in sub_jobs.iter().enumerate() {
                     if sub_jobs.len() > 1 {
                         println!(
@@ -1055,7 +1100,8 @@ pub async fn execute_plan(
                         resolved_lora.clone(),
                         planned.lightning.as_ref(),
                         e,
-                        &source_path,
+                        &source_paths,
+                        mask_path.clone(),
                         *seed,
                         *count,
                         &plan.output_dir,
@@ -1337,12 +1383,17 @@ fn print_plan_human(plan: &Plan, in_order: bool) {
             StepKind::Edit(e) => {
                 let steps = e.steps.unwrap_or(default_steps);
                 let guidance = e.guidance.unwrap_or(default_guidance);
-                let source = match &e.source {
-                    ImageRef::Local(p) => format!("local: {}", p.display()),
-                    ImageRef::StepOutput { step_id, index } => {
-                        format!("${step_id}.outputs[{index}]")
-                    }
-                };
+                let source = e
+                    .sources
+                    .iter()
+                    .map(|r| match r {
+                        ImageRef::Local(p) => format!("local: {}", p.display()),
+                        ImageRef::StepOutput { step_id, index } => {
+                            format!("${step_id}.outputs[{index}]")
+                        }
+                    })
+                    .collect::<Vec<_>>()
+                    .join(", ");
                 let seed_desc = if let Some(ref seeds) = e.seeds {
                     format!("{} seeds {:?}", seeds.len(), seeds)
                 } else if let Some(s) = e.seed {
@@ -1404,6 +1455,7 @@ fn print_plan_json(plan: &Plan, in_order: bool) -> Result<()> {
                     kind: "generate",
                     prompt: g.prompt.clone(),
                     source_ref: None,
+                    source_refs: None,
                     model: model_json,
                     lora: lora_json,
                     seed: g.seed,
@@ -1421,12 +1473,12 @@ fn print_plan_json(plan: &Plan, in_order: bool) -> Result<()> {
                     id: step.id.clone(),
                     kind: "edit",
                     prompt: e.prompt.clone(),
-                    source_ref: Some(match &e.source {
-                        ImageRef::Local(p) => p.to_string_lossy().into_owned(),
-                        ImageRef::StepOutput { step_id, index } => {
-                            format!("${step_id}.outputs[{index}]")
-                        }
-                    }),
+                    source_ref: Some(image_ref_json(&e.sources[0])),
+                    source_refs: if e.sources.len() > 1 {
+                        Some(e.sources.iter().map(image_ref_json).collect())
+                    } else {
+                        None
+                    },
                     model: model_json,
                     lora: lora_json,
                     seed: e.seed,
@@ -1560,6 +1612,10 @@ struct StepJson {
     prompt: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     source_ref: Option<String>,
+    /// All edit source refs, present only on multi-image edit steps
+    /// (`source_ref` stays the first source for backward compatibility).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_refs: Option<Vec<String>>,
     /// Present only when the step overrides the workflow-level model.
     /// Absent means "uses workflow default" (see `WorkflowJson::model`).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1633,6 +1689,54 @@ fn expand_seeds(
 // Spec builders
 // ---------------------------------------------------------------------------
 
+/// Image inputs of a generate step, resolved from `ImageRef`s to local paths
+/// once per step (before the sub-job loop — the paths don't vary per seed).
+struct ResolvedGenInputs {
+    init_image: Option<String>,
+    mask: Option<String>,
+    controlnet: Vec<crate::core::job::ControlNetInput>,
+    style_ref: Vec<crate::core::job::StyleRefInput>,
+}
+
+fn resolve_generate_inputs(
+    step: &GenerateStep,
+    step_outputs: &HashMap<String, Vec<PathBuf>>,
+    step_id: &str,
+) -> Result<ResolvedGenInputs> {
+    let resolve = |r: &ImageRef| -> Result<String> {
+        Ok(resolve_image_ref(r, step_outputs, step_id)?
+            .to_string_lossy()
+            .to_string())
+    };
+    Ok(ResolvedGenInputs {
+        init_image: step.init_image.as_ref().map(resolve).transpose()?,
+        mask: step.mask.as_ref().map(resolve).transpose()?,
+        controlnet: step
+            .controlnet
+            .iter()
+            .map(|cn| {
+                Ok(crate::core::job::ControlNetInput {
+                    image: resolve(&cn.image)?,
+                    control_type: cn.control_type.clone(),
+                    strength: cn.strength.unwrap_or(0.75),
+                    control_end: cn.end.unwrap_or(0.8),
+                })
+            })
+            .collect::<Result<_>>()?,
+        style_ref: step
+            .style_ref
+            .iter()
+            .map(|sr| {
+                Ok(crate::core::job::StyleRefInput {
+                    image: resolve(&sr.image)?,
+                    strength: sr.strength.unwrap_or(0.6),
+                    style_type: sr.style_type.clone().unwrap_or_else(|| "style".to_string()),
+                })
+            })
+            .collect::<Result<_>>()?,
+    })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn build_generate_spec(
     wf_model: &str,
@@ -1642,6 +1746,7 @@ fn build_generate_spec(
     lora: Option<LoraRef>,
     lightning: Option<&ResolvedLightning>,
     step: &GenerateStep,
+    inputs: &ResolvedGenInputs,
     seed: Option<u64>,
     count: u32,
     output_dir: &Path,
@@ -1679,14 +1784,14 @@ fn build_generate_spec(
             guidance,
             seed,
             count,
-            init_image: None,
-            mask: None,
-            strength: None,
+            init_image: inputs.init_image.clone(),
+            mask: inputs.mask.clone(),
+            strength: step.strength,
             scheduler_overrides: lightning
                 .map(|l| l.scheduler_overrides.clone())
                 .unwrap_or_default(),
-            controlnet: Vec::new(),
-            style_ref: Vec::new(),
+            controlnet: inputs.controlnet.clone(),
+            style_ref: inputs.style_ref.clone(),
             inpaint_method: None,
         },
         runtime: RuntimeRef {
@@ -1707,7 +1812,8 @@ fn build_edit_spec(
     lora: Option<LoraRef>,
     lightning: Option<&ResolvedLightning>,
     step: &EditStep,
-    source_path: &Path,
+    source_paths: &[PathBuf],
+    mask_path: Option<String>,
     seed: Option<u64>,
     count: u32,
     output_dir: &Path,
@@ -1736,15 +1842,18 @@ fn build_edit_spec(
             output_dir: output_dir.to_string_lossy().to_string(),
         },
         params: EditParams {
-            image_paths: vec![source_path.to_string_lossy().to_string()],
+            image_paths: source_paths
+                .iter()
+                .map(|p| p.to_string_lossy().to_string())
+                .collect(),
             steps,
             guidance,
             seed,
             count,
             width: step.width,
             height: step.height,
-            mask_path: None,
-            blend_mode: crate::core::job::BlendMode::Pixel,
+            mask_path,
+            blend_mode: step.blend.unwrap_or_default(),
             scheduler_overrides: lightning
                 .map(|l| l.scheduler_overrides.clone())
                 .unwrap_or_default(),
@@ -1958,6 +2067,13 @@ fn sanitize_for_path(s: &str) -> String {
         .collect()
 }
 
+fn image_ref_json(r: &ImageRef) -> String {
+    match r {
+        ImageRef::Local(p) => p.to_string_lossy().into_owned(),
+        ImageRef::StepOutput { step_id, index } => format!("${step_id}.outputs[{index}]"),
+    }
+}
+
 fn step_kind_label(kind: &StepKind) -> &'static str {
     match kind {
         StepKind::Generate(_) => "generate",
@@ -1985,8 +2101,16 @@ fn print_generate_preview(step: &GenerateStep, sub_job_count: usize) {
     let _ = sub_job_count; // accepted for symmetry with edit preview; no current use
 }
 
-fn print_edit_preview(step: &EditStep, source_path: &Path, sub_job_count: usize) {
-    println!("  Source: {}", source_path.display());
+fn print_edit_preview(step: &EditStep, source_paths: &[PathBuf], sub_job_count: usize) {
+    match source_paths {
+        [one] => println!("  Source: {}", one.display()),
+        many => {
+            println!("  Sources ({}):", many.len());
+            for p in many {
+                println!("    - {}", p.display());
+            }
+        }
+    }
     println!("  Prompt: {}", style(&step.prompt).italic());
     if let Some(ref seeds) = step.seeds {
         println!(
@@ -2025,13 +2149,20 @@ mod tests {
             steps: None,
             guidance: None,
             count: None,
+            init_image: None,
+            mask: None,
+            strength: None,
+            controlnet: Vec::new(),
+            style_ref: Vec::new(),
         })
     }
 
     fn edit_kind() -> StepKind {
         StepKind::Edit(EditStep {
-            source: ImageRef::Local(PathBuf::from("/dev/null")),
+            sources: vec![ImageRef::Local(PathBuf::from("/dev/null"))],
             prompt: "x".into(),
+            mask: None,
+            blend: None,
             model: None,
             lora: None,
             fast: None,
@@ -2111,6 +2242,59 @@ mod tests {
                 lightning: None,
             })
             .collect()
+    }
+
+    #[test]
+    fn capability_check_requires_img2img_for_init_image() {
+        let mut kind = gen_kind();
+        if let StepKind::Generate(g) = &mut kind {
+            g.init_image = Some(ImageRef::Local(PathBuf::from("/dev/null")));
+        }
+        // qwen-image-edit-2511 has no img2img capability
+        let err = check_capability("s", "qwen-image-edit-2511", &kind).unwrap_err();
+        assert!(matches!(
+            err,
+            PlanError::IncompatibleCapability {
+                required: "img2img",
+                ..
+            }
+        ));
+        check_capability("s", "flux-dev", &kind).unwrap();
+    }
+
+    #[test]
+    fn generate_init_image_step_output_creates_dependency() {
+        // Step `refine` (generate) depends on `base` via init_image, and is
+        // declared BEFORE it — scheduling must still run `base` first.
+        let yaml = r#"
+name: dag
+model: a
+steps:
+  - id: refine
+    generate: "detailed"
+    init_image: "$base.outputs[0]"
+  - id: base
+    generate: "rough"
+"#;
+        // Forward refs are rejected at parse time, so build the same DAG via
+        // the parsed-order form and assert the dependency edge instead.
+        let yaml_ok = r#"
+name: dag
+model: a
+steps:
+  - id: base
+    generate: "rough"
+  - id: refine
+    generate: "detailed"
+    init_image: "$base.outputs[0]"
+"#;
+        assert!(parse_str(yaml, Path::new(".")).is_err());
+        let wf = parse_str(yaml_ok, Path::new(".")).unwrap();
+        let planned = build_planned(&wf, &["a", "a"]);
+        let schedule = schedule_steps(&wf, &planned);
+        let pos_base = schedule.order.iter().position(|&i| i == 0).unwrap();
+        let pos_refine = schedule.order.iter().position(|&i| i == 1).unwrap();
+        assert!(pos_base < pos_refine);
     }
 
     #[test]

--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -536,6 +536,35 @@ pub fn validate_mode(model_id: &str, mode: &str) -> Result<(), String> {
     ))
 }
 
+const CONTROL_SUFFIXES: &[(&str, &str)] = &[
+    ("_canny", "canny"),
+    ("_depth", "depth"),
+    ("_pose", "pose"),
+    ("_softedge", "softedge"),
+    ("_scribble", "scribble"),
+    ("_hed", "hed"),
+    ("_mlsd", "mlsd"),
+    ("_gray", "gray"),
+    ("_normal", "normal"),
+    ("_lineart", "lineart"),
+];
+
+/// Try to detect the control type from a filename suffix (e.g. "photo_depth.png" → "depth").
+pub fn detect_control_type_from_filename(path: &str) -> Option<String> {
+    let stem = std::path::Path::new(path)
+        .file_stem()
+        .unwrap_or_default()
+        .to_string_lossy()
+        .to_lowercase();
+
+    for &(suffix, control_type) in CONTROL_SUFFIXES {
+        if stem.ends_with(suffix) {
+            return Some(control_type.to_string());
+        }
+    }
+    None
+}
+
 pub fn validate_controlnet(model_id: &str, control_type: &str) -> Result<(), String> {
     let resolved = match resolve_model(model_id) {
         Some(m) => m,

--- a/src/core/pod_run.rs
+++ b/src/core/pod_run.rs
@@ -467,15 +467,48 @@ pub fn check_pod_supported(yaml: &str) -> Result<()> {
         }
     }
     for step in steps.into_iter().flatten() {
-        let Some(src) = step.get("edit").and_then(|e| e.as_str()) else {
-            continue;
-        };
-        if !src.starts_with('$') && !src.starts_with("data:image/") {
-            let id = step.get("id").and_then(|i| i.as_str()).unwrap_or("?");
-            bail!(
-                "step `{id}`: edit source `{src}` is a local file path — it won't exist on the pod.\n  \
-                 Add it to the `images:` map as a base64 data URI and reference it as `$name`."
-            );
+        let id = step.get("id").and_then(|i| i.as_str()).unwrap_or("?");
+        // (field label, ref string) pairs across every image slot.
+        let mut refs: Vec<(&str, &str)> = Vec::new();
+        match step.get("edit") {
+            Some(serde_yaml::Value::String(s)) => refs.push(("edit source", s)),
+            Some(serde_yaml::Value::Sequence(seq)) => {
+                refs.extend(
+                    seq.iter()
+                        .filter_map(|v| v.as_str())
+                        .map(|s| ("edit source", s)),
+                );
+            }
+            _ => {}
+        }
+        if let Some(s) = step.get("init_image").and_then(|v| v.as_str()) {
+            refs.push(("init_image", s));
+        }
+        if let Some(s) = step.get("mask").and_then(|v| v.as_str())
+            && s != "auto"
+            && s != "from-alpha"
+        {
+            refs.push(("mask", s));
+        }
+        for key in ["controlnet", "style_ref"] {
+            for entry in step
+                .get(key)
+                .and_then(|v| v.as_sequence())
+                .into_iter()
+                .flatten()
+            {
+                if let Some(s) = entry.get("image").and_then(|v| v.as_str()) {
+                    refs.push((key, s));
+                }
+            }
+        }
+        for (what, src) in refs {
+            if !src.starts_with('$') && !src.starts_with("data:image/") {
+                bail!(
+                    "step `{id}`: {what} `{src}` is a local file path — it won't exist on the pod.\n  \
+                     Add it to the `images:` map as a base64 data URI and reference it as `$name`."
+                );
+            }
         }
     }
     Ok(())
@@ -805,6 +838,56 @@ fn walk_files(dir: &Path) -> Vec<PathBuf> {
     found
 }
 
+/// Read a local image file and encode it as a `data:image/...;base64,...` URI
+/// (the MCP-safe image-ref form — client paths don't exist on pods).
+fn image_data_uri(path: &Path) -> Result<String> {
+    let bytes =
+        std::fs::read(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let mime = match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("jpg") | Some("jpeg") => "image/jpeg",
+        Some("webp") => "image/webp",
+        _ => "image/png",
+    };
+    use base64::Engine as _;
+    Ok(format!(
+        "data:{mime};base64,{}",
+        base64::engine::general_purpose::STANDARD.encode(bytes)
+    ))
+}
+
+fn insert_seeds(step: &mut serde_yaml::Mapping, seeds: &[u64]) {
+    match seeds {
+        [] => {}
+        [one] => {
+            step.insert("seed".into(), (*one).into());
+        }
+        many => {
+            step.insert(
+                "seeds".into(),
+                serde_yaml::Value::Sequence(many.iter().map(|s| (*s).into()).collect()),
+            );
+        }
+    }
+}
+
+/// Image inputs for a `generate --pod` spec. All paths are local files that
+/// get inlined into the workflow's `images:` map as base64 data URIs.
+#[derive(Default)]
+pub struct GenImageInputs<'a> {
+    pub init_image: Option<&'a Path>,
+    pub mask: Option<&'a Path>,
+    pub strength: Option<f32>,
+    /// Fully-resolved ControlNet inputs (`image` is a local path).
+    pub controlnet: &'a [crate::core::job::ControlNetInput],
+    /// Fully-resolved style-ref inputs (`image` is a local path).
+    pub style_ref: &'a [crate::core::job::StyleRefInput],
+}
+
 /// Build a one-step generate workflow so `modl generate --pod` funnels
 /// through the same remote surface as `modl run --pod`.
 #[allow(clippy::too_many_arguments)]
@@ -818,32 +901,71 @@ pub fn single_generate_spec(
     steps: Option<u32>,
     guidance: Option<f64>,
     seeds: &[u64],
+    image_inputs: &GenImageInputs<'_>,
 ) -> Result<String> {
+    let mut images = serde_yaml::Mapping::new();
+    let mut inline = |name: &str, path: &Path| -> Result<()> {
+        images.insert(name.into(), image_data_uri(path)?.into());
+        Ok(())
+    };
+
     let mut step = serde_yaml::Mapping::new();
     step.insert("id".into(), "gen".into());
     step.insert("generate".into(), prompt.into());
+    if let Some(p) = image_inputs.init_image {
+        inline("init", p)?;
+        step.insert("init_image".into(), "$init".into());
+    }
+    if let Some(p) = image_inputs.mask {
+        inline("mask", p)?;
+        step.insert("mask".into(), "$mask".into());
+    }
+    insert_opt(
+        &mut step,
+        "strength",
+        image_inputs.strength.map(|v| f64::from(v).into()),
+    );
+    if !image_inputs.controlnet.is_empty() {
+        let mut entries = Vec::with_capacity(image_inputs.controlnet.len());
+        for (i, cn) in image_inputs.controlnet.iter().enumerate() {
+            let name = format!("cn-{}", i + 1);
+            inline(&name, Path::new(&cn.image))?;
+            let mut entry = serde_yaml::Mapping::new();
+            entry.insert("image".into(), format!("${name}").into());
+            entry.insert("type".into(), cn.control_type.as_str().into());
+            entry.insert("strength".into(), f64::from(cn.strength).into());
+            entry.insert("end".into(), f64::from(cn.control_end).into());
+            entries.push(serde_yaml::Value::Mapping(entry));
+        }
+        step.insert("controlnet".into(), serde_yaml::Value::Sequence(entries));
+    }
+    if !image_inputs.style_ref.is_empty() {
+        let mut entries = Vec::with_capacity(image_inputs.style_ref.len());
+        for (i, sr) in image_inputs.style_ref.iter().enumerate() {
+            let name = format!("style-{}", i + 1);
+            inline(&name, Path::new(&sr.image))?;
+            let mut entry = serde_yaml::Mapping::new();
+            entry.insert("image".into(), format!("${name}").into());
+            entry.insert("strength".into(), f64::from(sr.strength).into());
+            entry.insert("type".into(), sr.style_type.as_str().into());
+            entries.push(serde_yaml::Value::Mapping(entry));
+        }
+        step.insert("style_ref".into(), serde_yaml::Value::Sequence(entries));
+    }
     insert_opt(&mut step, "lora", lora.map(|v| v.into()));
     insert_opt(&mut step, "fast", fast.map(|v| v.into()));
     insert_opt(&mut step, "width", width.map(|v| v.into()));
     insert_opt(&mut step, "height", height.map(|v| v.into()));
     insert_opt(&mut step, "steps", steps.map(|v| v.into()));
     insert_opt(&mut step, "guidance", guidance.map(|v| v.into()));
-    match seeds {
-        [] => {}
-        [one] => {
-            step.insert("seed".into(), (*one).into());
-        }
-        many => {
-            step.insert(
-                "seeds".into(),
-                serde_yaml::Value::Sequence(many.iter().map(|s| (*s).into()).collect()),
-            );
-        }
-    }
+    insert_seeds(&mut step, seeds);
 
     let mut root = serde_yaml::Mapping::new();
     root.insert("name".into(), "pod-generate".into());
     root.insert("model".into(), model.into());
+    if !images.is_empty() {
+        root.insert("images".into(), serde_yaml::Value::Mapping(images));
+    }
     root.insert(
         "steps".into(),
         serde_yaml::Value::Sequence(vec![serde_yaml::Value::Mapping(step)]),
@@ -851,13 +973,16 @@ pub fn single_generate_spec(
     serde_yaml::to_string(&serde_yaml::Value::Mapping(root)).context("Failed to build spec")
 }
 
-/// Build a one-step edit workflow with the input image inlined as a base64
-/// data URI (the MCP-safe image-ref form — client paths don't exist on pods).
+/// Build a one-step edit workflow with every input image inlined as a base64
+/// data URI. `mask` is a local path, or the `auto`/`from-alpha` sentinels
+/// which pass through as-is.
 #[allow(clippy::too_many_arguments)]
 pub fn single_edit_spec(
     model: &str,
     prompt: &str,
-    image_path: &Path,
+    image_paths: &[PathBuf],
+    mask: Option<&str>,
+    blend: Option<crate::core::job::BlendMode>,
     lora: Option<&str>,
     fast: Option<u32>,
     width: Option<u32>,
@@ -866,49 +991,62 @@ pub fn single_edit_spec(
     guidance: Option<f64>,
     seeds: &[u64],
 ) -> Result<String> {
-    let bytes = std::fs::read(image_path)
-        .with_context(|| format!("Failed to read {}", image_path.display()))?;
-    let mime = match image_path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_ascii_lowercase())
-        .as_deref()
-    {
-        Some("jpg") | Some("jpeg") => "image/jpeg",
-        Some("webp") => "image/webp",
-        _ => "image/png",
-    };
-    use base64::Engine as _;
-    let data_uri = format!(
-        "data:{mime};base64,{}",
-        base64::engine::general_purpose::STANDARD.encode(bytes)
-    );
-
     let mut images = serde_yaml::Mapping::new();
-    images.insert("input".into(), data_uri.into());
+
+    // Single image keeps the historical `$input` name; multi-image edits get
+    // `$input-1`, `$input-2`, … in order.
+    let source_refs: Vec<String> = match image_paths {
+        [one] => {
+            images.insert("input".into(), image_data_uri(one)?.into());
+            vec!["$input".to_string()]
+        }
+        many => many
+            .iter()
+            .enumerate()
+            .map(|(i, p)| {
+                let name = format!("input-{}", i + 1);
+                images.insert(name.as_str().into(), image_data_uri(p)?.into());
+                Ok(format!("${name}"))
+            })
+            .collect::<Result<_>>()?,
+    };
 
     let mut step = serde_yaml::Mapping::new();
     step.insert("id".into(), "edit".into());
-    step.insert("edit".into(), "$input".into());
+    match source_refs.as_slice() {
+        [one] => {
+            step.insert("edit".into(), one.as_str().into());
+        }
+        many => {
+            step.insert(
+                "edit".into(),
+                serde_yaml::Value::Sequence(many.iter().map(|s| s.as_str().into()).collect()),
+            );
+        }
+    }
     step.insert("prompt".into(), prompt.into());
+    match mask {
+        None => {}
+        Some(sentinel @ ("auto" | "from-alpha")) => {
+            step.insert("mask".into(), sentinel.into());
+        }
+        Some(path) => {
+            images.insert("mask".into(), image_data_uri(Path::new(path))?.into());
+            step.insert("mask".into(), "$mask".into());
+        }
+    }
+    if let Some(b) = blend
+        && b != crate::core::job::BlendMode::Pixel
+    {
+        step.insert("blend".into(), "latent".into());
+    }
     insert_opt(&mut step, "lora", lora.map(|v| v.into()));
     insert_opt(&mut step, "fast", fast.map(|v| v.into()));
     insert_opt(&mut step, "width", width.map(|v| v.into()));
     insert_opt(&mut step, "height", height.map(|v| v.into()));
     insert_opt(&mut step, "steps", steps.map(|v| v.into()));
     insert_opt(&mut step, "guidance", guidance.map(|v| v.into()));
-    match seeds {
-        [] => {}
-        [one] => {
-            step.insert("seed".into(), (*one).into());
-        }
-        many => {
-            step.insert(
-                "seeds".into(),
-                serde_yaml::Value::Sequence(many.iter().map(|s| (*s).into()).collect()),
-            );
-        }
-    }
+    insert_seeds(&mut step, seeds);
 
     let mut root = serde_yaml::Mapping::new();
     root.insert("name".into(), "pod-edit".into());
@@ -1051,6 +1189,7 @@ steps:
             Some(4),
             None,
             &[7],
+            &Default::default(),
         )
         .unwrap();
         let models = workflow_models(&spec).unwrap();
@@ -1075,6 +1214,7 @@ steps:
             None,
             None,
             &[],
+            &Default::default(),
         )
         .unwrap();
         assert!(spec.contains("lora: alice"));
@@ -1089,6 +1229,7 @@ steps:
             None,
             None,
             &[],
+            &Default::default(),
         )
         .unwrap();
         assert!(spec.contains("fast: 4"));
@@ -1101,7 +1242,9 @@ steps:
         let spec = single_edit_spec(
             "klein-9b",
             "make it golden",
-            &tmp,
+            std::slice::from_ref(&tmp),
+            None,
+            None,
             None,
             None,
             None,
@@ -1130,7 +1273,9 @@ steps:
         let spec = single_edit_spec(
             "klein-9b",
             "p",
-            &tmp,
+            std::slice::from_ref(&tmp),
+            None,
+            None,
             None,
             None,
             Some(1820),
@@ -1148,6 +1293,130 @@ steps:
         assert!(spec.contains("seeds:"));
         assert!(spec.contains("- 7"));
         assert!(spec.contains("- 8"));
+    }
+
+    #[test]
+    fn generate_spec_inlines_image_inputs() {
+        let dir = std::env::temp_dir().join(format!("modl-podrun-gen-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let init = dir.join("init.png");
+        let mask = dir.join("mask.png");
+        let pose = dir.join("ref_pose.png");
+        for p in [&init, &mask, &pose] {
+            std::fs::write(p, b"fakepng").unwrap();
+        }
+        let cn = [crate::core::job::ControlNetInput {
+            image: pose.to_string_lossy().to_string(),
+            control_type: "pose".to_string(),
+            strength: 0.9,
+            control_end: 0.7,
+        }];
+        let inputs = GenImageInputs {
+            init_image: Some(&init),
+            mask: Some(&mask),
+            strength: Some(0.6),
+            controlnet: &cn,
+            style_ref: &[],
+        };
+        let spec = single_generate_spec(
+            "flux-dev",
+            "p",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+            &inputs,
+        )
+        .unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert!(spec.contains("init: data:image/png;base64,"));
+        assert!(spec.contains("init_image: $init"));
+        assert!(spec.contains("mask: $mask"));
+        assert!(spec.contains("strength: 0.6"));
+        assert!(spec.contains("cn-1: data:image/png;base64,"));
+        assert!(spec.contains("image: $cn-1"));
+        assert!(spec.contains("type: pose"));
+        // The whole spec must pass the pod-support check (no bare paths).
+        check_pod_supported(&spec).unwrap();
+    }
+
+    #[test]
+    fn edit_spec_inlines_multiple_images_and_mask() {
+        let dir = std::env::temp_dir().join(format!("modl-podrun-edit-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let a = dir.join("a.png");
+        let b = dir.join("b.jpg");
+        let m = dir.join("m.png");
+        for p in [&a, &b, &m] {
+            std::fs::write(p, b"fakepng").unwrap();
+        }
+        let spec = single_edit_spec(
+            "klein-9b",
+            "blend them",
+            &[a.clone(), b.clone()],
+            Some(m.to_string_lossy().as_ref()),
+            Some(crate::core::job::BlendMode::Latent),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+        )
+        .unwrap();
+        std::fs::remove_dir_all(&dir).unwrap();
+        assert!(spec.contains("input-1: data:image/png;base64,"));
+        assert!(spec.contains("input-2: data:image/jpeg;base64,"));
+        assert!(spec.contains("- $input-1"));
+        assert!(spec.contains("- $input-2"));
+        assert!(spec.contains("mask: $mask"));
+        assert!(spec.contains("blend: latent"));
+        check_pod_supported(&spec).unwrap();
+    }
+
+    #[test]
+    fn edit_spec_passes_mask_sentinel_through() {
+        let tmp =
+            std::env::temp_dir().join(format!("modl-podrun-test3-{}.png", std::process::id()));
+        std::fs::write(&tmp, b"fakepng").unwrap();
+        let spec = single_edit_spec(
+            "klein-9b",
+            "p",
+            std::slice::from_ref(&tmp),
+            Some("from-alpha"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &[],
+        )
+        .unwrap();
+        std::fs::remove_file(&tmp).unwrap();
+        assert!(spec.contains("mask: from-alpha"));
+        check_pod_supported(&spec).unwrap();
+    }
+
+    #[test]
+    fn rejects_bare_paths_in_new_image_slots() {
+        for yaml in [
+            "name: t\nmodel: m\nsteps:\n  - id: a\n    generate: p\n    init_image: photo.png\n",
+            "name: t\nmodel: m\nsteps:\n  - id: a\n    generate: p\n    init_image: $x\n    mask: m.png\n",
+            "name: t\nmodel: m\nsteps:\n  - id: a\n    generate: p\n    controlnet:\n      - image: pose.png\n        type: pose\n",
+            "name: t\nmodel: m\nsteps:\n  - id: a\n    edit: [\"$x\", \"b.png\"]\n    prompt: p\n",
+        ] {
+            let err = check_pod_supported(yaml).unwrap_err().to_string();
+            assert!(err.contains("local file path"), "{yaml}: {err}");
+        }
+        // Sentinel masks are fine.
+        let ok = "name: t\nmodel: m\nsteps:\n  - id: a\n    edit: \"$x\"\n    prompt: p\n    mask: from-alpha\n";
+        check_pod_supported(ok).unwrap();
     }
 
     #[test]

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -63,12 +63,56 @@ pub struct GenerateStep {
     pub steps: Option<u32>,
     pub guidance: Option<f32>,
     pub count: Option<u32>,
+    /// img2img source image. Presence switches the step to img2img mode
+    /// (or inpaint when `mask` is also set).
+    pub init_image: Option<ImageRef>,
+    /// Inpaint mask (white = regenerate region). Requires `init_image`.
+    pub mask: Option<ImageRef>,
+    /// Denoising strength for img2img (0.0–1.0). Requires `init_image`.
+    pub strength: Option<f32>,
+    /// ControlNet inputs (max 2, same cap as `modl generate --controlnet`).
+    pub controlnet: Vec<ControlNetRef>,
+    /// Style reference inputs (IP-Adapter).
+    pub style_ref: Vec<StyleRefRef>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ControlNetRef {
+    pub image: ImageRef,
+    /// Control type (canny, depth, pose, …). Resolved at parse time from the
+    /// explicit `type:` field or, for plain file paths, the filename suffix.
+    pub control_type: String,
+    pub strength: Option<f32>,
+    pub end: Option<f32>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StyleRefRef {
+    pub image: ImageRef,
+    pub strength: Option<f32>,
+    pub style_type: Option<String>,
+}
+
+/// Mask on an edit step: an image ref, or one of the worker's sentinel modes.
+#[derive(Debug, Clone)]
+pub enum EditMask {
+    /// Worker derives the mask (reserved sentinel, `"auto"`).
+    Auto,
+    /// Derive from the first source image's alpha channel (`"from-alpha"`).
+    FromAlpha,
+    Image(ImageRef),
 }
 
 #[derive(Debug, Clone)]
 pub struct EditStep {
-    pub source: ImageRef,
+    /// Source images (1 or more). Multi-image edits feed every image to the
+    /// model as a reference (Qwen Image Edit 2511, Flux 2 Klein).
+    pub sources: Vec<ImageRef>,
     pub prompt: String,
+    /// Mask: image ref or `auto` / `from-alpha` sentinel.
+    pub mask: Option<EditMask>,
+    /// Blend mode for masked edits (`pixel` default, `latent` = native inpaint).
+    pub blend: Option<crate::core::job::BlendMode>,
     /// Per-step model override. See `GenerateStep::model`.
     pub model: Option<String>,
     /// Per-step LoRA override. See `GenerateStep::lora`.
@@ -98,6 +142,29 @@ pub struct EditStep {
 pub enum ImageRef {
     Local(PathBuf),
     StepOutput { step_id: String, index: usize },
+}
+
+impl Step {
+    /// Every image ref this step consumes, across all input slots. Used for
+    /// dependency scheduling — any slot may reference an earlier step's output.
+    pub fn image_refs(&self) -> Vec<&ImageRef> {
+        let mut refs = Vec::new();
+        match &self.kind {
+            StepKind::Generate(g) => {
+                refs.extend(g.init_image.as_ref());
+                refs.extend(g.mask.as_ref());
+                refs.extend(g.controlnet.iter().map(|c| &c.image));
+                refs.extend(g.style_ref.iter().map(|s| &s.image));
+            }
+            StepKind::Edit(e) => {
+                refs.extend(e.sources.iter());
+                if let Some(EditMask::Image(r)) = &e.mask {
+                    refs.push(r);
+                }
+            }
+        }
+        refs
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -135,15 +202,66 @@ struct StepDefaults {
     count: Option<u32>,
 }
 
+/// A YAML value that is either a single string or a list of strings.
+/// Lets `edit:` accept one source (`edit: "$a"`) or many (`edit: ["$a", "$b"]`).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum OneOrMany {
+    One(String),
+    Many(Vec<String>),
+}
+
+impl OneOrMany {
+    fn as_slice(&self) -> &[String] {
+        match self {
+            OneOrMany::One(s) => std::slice::from_ref(s),
+            OneOrMany::Many(v) => v.as_slice(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawControlNet {
+    image: String,
+    #[serde(default, rename = "type")]
+    control_type: Option<String>,
+    #[serde(default)]
+    strength: Option<f32>,
+    #[serde(default)]
+    end: Option<f32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawStyleRef {
+    image: String,
+    #[serde(default)]
+    strength: Option<f32>,
+    #[serde(default, rename = "type")]
+    style_type: Option<String>,
+}
+
 #[derive(Debug, Deserialize)]
 struct RawStep {
     id: String,
     #[serde(default)]
     generate: Option<String>,
     #[serde(default)]
-    edit: Option<String>,
+    edit: Option<OneOrMany>,
     #[serde(default)]
     prompt: Option<String>,
+    #[serde(default)]
+    init_image: Option<String>,
+    /// Mask: image ref on generate steps; ref or `auto`/`from-alpha` on edit steps.
+    #[serde(default)]
+    mask: Option<String>,
+    #[serde(default)]
+    strength: Option<f32>,
+    #[serde(default)]
+    blend: Option<crate::core::job::BlendMode>,
+    #[serde(default)]
+    controlnet: Option<Vec<RawControlNet>>,
+    #[serde(default)]
+    style_ref: Option<Vec<RawStyleRef>>,
     #[serde(default)]
     model: Option<String>,
     #[serde(default)]
@@ -260,6 +378,30 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
             );
         }
 
+        // --- image-input fields are kind-specific
+        if raw_step.generate.is_some() {
+            if raw_step.blend.is_some() {
+                bail!(
+                    "step `{}`: `blend` is only valid on edit steps",
+                    raw_step.id
+                );
+            }
+        } else {
+            for (field, set) in [
+                ("init_image", raw_step.init_image.is_some()),
+                ("strength", raw_step.strength.is_some()),
+                ("controlnet", raw_step.controlnet.is_some()),
+                ("style_ref", raw_step.style_ref.is_some()),
+            ] {
+                if set {
+                    bail!(
+                        "step `{}`: `{field}` is only valid on generate steps",
+                        raw_step.id
+                    );
+                }
+            }
+        }
+
         // When a step overrides the model, don't inherit workflow-level
         // defaults for steps/guidance — those are model-dependent and the
         // runner will fall back to the correct model-specific defaults from
@@ -278,6 +420,102 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
         };
 
         let kind = if let Some(prompt) = &raw_step.generate {
+            // img2img / inpaint inputs
+            let init_image = raw_step
+                .init_image
+                .as_deref()
+                .map(|s| parse_image_ref(s, base_dir, &seen_ids, &image_vars, &raw_step.id, "init"))
+                .transpose()?;
+            if init_image.is_none() {
+                if raw_step.mask.is_some() {
+                    bail!(
+                        "step `{}`: `mask` requires `init_image` on generate steps (inpainting regenerates a masked region of the init image)",
+                        raw_step.id
+                    );
+                }
+                if raw_step.strength.is_some() {
+                    bail!(
+                        "step `{}`: `strength` requires `init_image` (it is the img2img denoising strength)",
+                        raw_step.id
+                    );
+                }
+            }
+            let mask = raw_step
+                .mask
+                .as_deref()
+                .map(|s| parse_image_ref(s, base_dir, &seen_ids, &image_vars, &raw_step.id, "mask"))
+                .transpose()?;
+
+            // ControlNet inputs
+            let raw_cn = raw_step.controlnet.as_deref().unwrap_or_default();
+            if raw_cn.len() > 2 {
+                bail!(
+                    "step `{}`: maximum 2 `controlnet` inputs supported (got {})",
+                    raw_step.id,
+                    raw_cn.len()
+                );
+            }
+            let mut controlnet = Vec::with_capacity(raw_cn.len());
+            for (i, cn) in raw_cn.iter().enumerate() {
+                let slot = format!("cn-{}", i + 1);
+                let image = parse_image_ref(
+                    &cn.image,
+                    base_dir,
+                    &seen_ids,
+                    &image_vars,
+                    &raw_step.id,
+                    &slot,
+                )?;
+                // Explicit `type:` wins; plain file paths fall back to filename
+                // detection. `$var`/`$step.outputs[N]`/data-URI refs have no
+                // meaningful filename, so `type:` is required there.
+                let control_type = match &cn.control_type {
+                    Some(t) => t.clone(),
+                    None if !cn.image.starts_with('$') && !cn.image.starts_with("data:") => {
+                        crate::core::models::detect_control_type_from_filename(&cn.image)
+                            .ok_or_else(|| anyhow!(
+                                "step `{}`: controlnet[{i}]: cannot auto-detect control type from `{}` — add `type:` (canny, depth, pose, softedge, scribble, hed, mlsd, gray, normal)",
+                                raw_step.id, cn.image
+                            ))?
+                    }
+                    None => bail!(
+                        "step `{}`: controlnet[{i}]: `type:` is required for `$name`, step-output, and inline image refs (canny, depth, pose, …)",
+                        raw_step.id
+                    ),
+                };
+                controlnet.push(ControlNetRef {
+                    image,
+                    control_type,
+                    strength: cn.strength,
+                    end: cn.end,
+                });
+            }
+
+            // Style reference inputs
+            let mut style_ref = Vec::new();
+            for (i, sr) in raw_step
+                .style_ref
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .enumerate()
+            {
+                let slot = format!("style-{}", i + 1);
+                let image = parse_image_ref(
+                    &sr.image,
+                    base_dir,
+                    &seen_ids,
+                    &image_vars,
+                    &raw_step.id,
+                    &slot,
+                )?;
+                style_ref.push(StyleRefRef {
+                    image,
+                    strength: sr.strength,
+                    style_type: sr.style_type.clone(),
+                });
+            }
+
             StepKind::Generate(GenerateStep {
                 prompt: prompt.clone(),
                 model: raw_step.model.clone(),
@@ -290,9 +528,14 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
                 steps: raw_step.steps.or(default_steps),
                 guidance: raw_step.guidance.or(default_guidance),
                 count: raw_step.count.or(raw.defaults.count),
+                init_image,
+                mask,
+                strength: raw_step.strength,
+                controlnet,
+                style_ref,
             })
         } else {
-            let source_str = raw_step.edit.as_ref().ok_or_else(|| {
+            let source_strs = raw_step.edit.as_ref().ok_or_else(|| {
                 anyhow!(
                     "step `{}`: expected `generate:` or `edit:` field",
                     raw_step.id
@@ -304,11 +547,47 @@ pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
                     raw_step.id
                 )
             })?;
-            let source =
-                parse_image_ref(source_str, base_dir, &seen_ids, &image_vars, &raw_step.id)?;
+            let source_strs = source_strs.as_slice();
+            if source_strs.is_empty() {
+                bail!(
+                    "step `{}`: `edit: []` is empty — provide at least one image ref",
+                    raw_step.id
+                );
+            }
+            let mut sources = Vec::with_capacity(source_strs.len());
+            for (i, s) in source_strs.iter().enumerate() {
+                let slot = if i == 0 {
+                    "source".to_string()
+                } else {
+                    format!("source-{}", i + 1)
+                };
+                sources.push(parse_image_ref(
+                    s,
+                    base_dir,
+                    &seen_ids,
+                    &image_vars,
+                    &raw_step.id,
+                    &slot,
+                )?);
+            }
+            let mask = match raw_step.mask.as_deref() {
+                None => None,
+                Some("auto") => Some(EditMask::Auto),
+                Some("from-alpha") => Some(EditMask::FromAlpha),
+                Some(s) => Some(EditMask::Image(parse_image_ref(
+                    s,
+                    base_dir,
+                    &seen_ids,
+                    &image_vars,
+                    &raw_step.id,
+                    "mask",
+                )?)),
+            };
             StepKind::Edit(EditStep {
-                source,
+                sources,
                 prompt: edit_prompt.clone(),
+                mask,
+                blend: raw_step.blend,
                 model: raw_step.model.clone(),
                 lora: raw_step.lora.clone(),
                 fast: raw_step.fast,
@@ -425,18 +704,24 @@ fn resolve_image_vars(
     Ok(vars)
 }
 
-/// Parse an `edit:` source image reference.
+/// Parse an image reference (edit source, init image, mask, controlnet or
+/// style-ref input).
 ///
-/// Three forms:
+/// Four forms:
 /// - `$name` (no `.outputs[`) → named image variable from the top-level `images:` map
 /// - `$step-id.outputs[N]` → resolved at runtime to the Nth output of an earlier step
+/// - `data:image/...;base64,...` → decoded and written to `base_dir/{step}-{slot}.{ext}`
 /// - Anything else → filesystem path relative to `base_dir`, must exist
+///
+/// `slot` names the input position (`source`, `init`, `mask`, `cn-1`, …) so
+/// inline data URIs in different slots of one step get distinct filenames.
 fn parse_image_ref(
     s: &str,
     base_dir: &Path,
     earlier_step_ids: &HashSet<String>,
     image_vars: &HashMap<String, PathBuf>,
     current_step_id: &str,
+    slot: &str,
 ) -> Result<ImageRef> {
     if let Some(rest) = s.strip_prefix('$') {
         // `$name` with no dot → image variable ref.
@@ -497,7 +782,7 @@ fn parse_image_ref(
             .with_context(|| {
                 format!("step `{current_step_id}`: failed to decode base64 inline image")
             })?;
-        let out_path = base_dir.join(format!("{current_step_id}-source.{ext}"));
+        let out_path = base_dir.join(format!("{current_step_id}-{slot}.{ext}"));
         std::fs::write(&out_path, &bytes).with_context(|| {
             format!(
                 "step `{current_step_id}`: failed to write inline image to `{}`",
@@ -744,7 +1029,7 @@ steps:
 "#;
         let wf = parse(yaml).unwrap();
         match &wf.steps[1].kind {
-            StepKind::Edit(e) => match &e.source {
+            StepKind::Edit(e) => match &e.sources[0] {
                 ImageRef::StepOutput { step_id, index } => {
                     assert_eq!(step_id, "scene");
                     assert_eq!(*index, 0);
@@ -831,7 +1116,7 @@ steps:
 "#;
         let wf = parse_str(yaml, tmp.path()).unwrap();
         match &wf.steps[0].kind {
-            StepKind::Edit(e) => match &e.source {
+            StepKind::Edit(e) => match &e.sources[0] {
                 ImageRef::Local(p) => assert!(p.ends_with("input.png")),
                 _ => panic!("expected local ref"),
             },
@@ -1105,7 +1390,7 @@ steps:
         );
         let wf = parse_str(&yaml, tmp.path()).unwrap();
         match &wf.steps[0].kind {
-            StepKind::Edit(e) => match &e.source {
+            StepKind::Edit(e) => match &e.sources[0] {
                 ImageRef::Local(p) => {
                     assert!(p.exists(), "inline image should be written to disk");
                     assert!(p.to_string_lossy().ends_with("retouch-source.png"));
@@ -1133,7 +1418,7 @@ steps:
         );
         let wf = parse_str(&yaml, tmp.path()).unwrap();
         match &wf.steps[0].kind {
-            StepKind::Edit(e) => match &e.source {
+            StepKind::Edit(e) => match &e.sources[0] {
                 ImageRef::Local(p) => {
                     assert!(p.exists());
                     assert!(p.to_string_lossy().ends_with("alice-ref.png"));
@@ -1152,20 +1437,332 @@ steps:
         );
         let wf = parse_str(&yaml, tmp.path()).unwrap();
         let path0 = match &wf.steps[0].kind {
-            StepKind::Edit(e) => match &e.source {
+            StepKind::Edit(e) => match &e.sources[0] {
                 ImageRef::Local(p) => p.clone(),
                 _ => panic!(),
             },
             _ => panic!(),
         };
         let path1 = match &wf.steps[1].kind {
-            StepKind::Edit(e) => match &e.source {
+            StepKind::Edit(e) => match &e.sources[0] {
                 ImageRef::Local(p) => p.clone(),
                 _ => panic!(),
             },
             _ => panic!(),
         };
         assert_eq!(path0, path1, "both steps should point to the same file");
+    }
+
+    #[test]
+    fn multi_image_edit_parses() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("a.png"), b"fake").unwrap();
+        let yaml = format!(
+            "name: test\nmodel: klein-9b\nimages:\n  style: \"data:image/png;base64,{RED_PNG_B64}\"\nsteps:\n  - id: base\n    generate: \"a cat\"\n  - id: combine\n    edit: [\"$base.outputs[0]\", \"$style\", \"a.png\"]\n    prompt: \"blend\"\n"
+        );
+        let wf = parse_str(&yaml, tmp.path()).unwrap();
+        match &wf.steps[1].kind {
+            StepKind::Edit(e) => {
+                assert_eq!(e.sources.len(), 3);
+                assert!(
+                    matches!(&e.sources[0], ImageRef::StepOutput { step_id, index: 0 } if step_id == "base")
+                );
+                assert!(
+                    matches!(&e.sources[1], ImageRef::Local(p) if p.ends_with("style-ref.png"))
+                );
+                assert!(matches!(&e.sources[2], ImageRef::Local(p) if p.ends_with("a.png")));
+            }
+            _ => panic!("expected edit"),
+        }
+    }
+
+    #[test]
+    fn empty_edit_list_rejected() {
+        let yaml = r#"
+name: test
+model: klein-9b
+steps:
+  - id: a
+    edit: []
+    prompt: "hi"
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("at least one image"), "got: {err}");
+    }
+
+    #[test]
+    fn edit_mask_sentinels_and_blend_parsed() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("in.png"), b"fake").unwrap();
+        std::fs::write(tmp.path().join("m.png"), b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: klein-9b
+steps:
+  - id: a
+    edit: "in.png"
+    prompt: "hi"
+    mask: "from-alpha"
+    blend: latent
+  - id: b
+    edit: "in.png"
+    prompt: "hi"
+    mask: "m.png"
+"#;
+        let wf = parse_str(yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Edit(e) => {
+                assert!(matches!(e.mask, Some(EditMask::FromAlpha)));
+                assert_eq!(e.blend, Some(crate::core::job::BlendMode::Latent));
+            }
+            _ => panic!(),
+        }
+        match &wf.steps[1].kind {
+            StepKind::Edit(e) => {
+                assert!(
+                    matches!(&e.mask, Some(EditMask::Image(ImageRef::Local(p))) if p.ends_with("m.png"))
+                );
+                assert_eq!(e.blend, None);
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn generate_init_image_mask_strength_parsed() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("photo.png"), b"fake").unwrap();
+        std::fs::write(tmp.path().join("m.png"), b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+    init_image: "photo.png"
+    mask: "m.png"
+    strength: 0.6
+"#;
+        let wf = parse_str(yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => {
+                assert!(
+                    matches!(&g.init_image, Some(ImageRef::Local(p)) if p.ends_with("photo.png"))
+                );
+                assert!(matches!(&g.mask, Some(ImageRef::Local(p)) if p.ends_with("m.png")));
+                assert_eq!(g.strength, Some(0.6));
+            }
+            _ => panic!("expected generate"),
+        }
+    }
+
+    #[test]
+    fn generate_init_image_from_step_output() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: base
+    generate: "a cat"
+  - id: refine
+    generate: "a detailed cat"
+    init_image: "$base.outputs[0]"
+    strength: 0.5
+"#;
+        let wf = parse(yaml).unwrap();
+        match &wf.steps[1].kind {
+            StepKind::Generate(g) => {
+                assert!(
+                    matches!(&g.init_image, Some(ImageRef::StepOutput { step_id, index: 0 }) if step_id == "base")
+                );
+            }
+            _ => panic!("expected generate"),
+        }
+        // init_image contributes to image_refs (dependency scheduling)
+        assert_eq!(wf.steps[1].image_refs().len(), 1);
+    }
+
+    #[test]
+    fn generate_mask_without_init_image_rejected() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("m.png"), b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+    mask: "m.png"
+"#;
+        let err = parse_str(yaml, tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("requires `init_image`"), "got: {err}");
+    }
+
+    #[test]
+    fn generate_strength_without_init_image_rejected() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+    strength: 0.5
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("requires `init_image`"), "got: {err}");
+    }
+
+    #[test]
+    fn controlnet_explicit_type_and_filename_detection() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("ref_pose.png"), b"fake").unwrap();
+        std::fs::write(tmp.path().join("edges.png"), b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+    controlnet:
+      - image: "ref_pose.png"
+      - image: "edges.png"
+        type: canny
+        strength: 0.9
+        end: 0.7
+"#;
+        let wf = parse_str(yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => {
+                assert_eq!(g.controlnet.len(), 2);
+                assert_eq!(g.controlnet[0].control_type, "pose");
+                assert_eq!(g.controlnet[1].control_type, "canny");
+                assert_eq!(g.controlnet[1].strength, Some(0.9));
+                assert_eq!(g.controlnet[1].end, Some(0.7));
+            }
+            _ => panic!("expected generate"),
+        }
+    }
+
+    #[test]
+    fn controlnet_var_ref_requires_explicit_type() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "name: test\nmodel: flux-dev\nimages:\n  pose: \"data:image/png;base64,{RED_PNG_B64}\"\nsteps:\n  - id: a\n    generate: \"a cat\"\n    controlnet:\n      - image: \"$pose\"\n"
+        );
+        let err = parse_str(&yaml, tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("`type:` is required"), "got: {err}");
+    }
+
+    #[test]
+    fn controlnet_undetectable_filename_rejected() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("photo.png"), b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+    controlnet:
+      - image: "photo.png"
+"#;
+        let err = parse_str(yaml, tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("cannot auto-detect"), "got: {err}");
+    }
+
+    #[test]
+    fn more_than_two_controlnets_rejected() {
+        let tmp = TempDir::new().unwrap();
+        for n in ["a_pose.png", "b_canny.png", "c_depth.png"] {
+            std::fs::write(tmp.path().join(n), b"fake").unwrap();
+        }
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+    controlnet:
+      - image: "a_pose.png"
+      - image: "b_canny.png"
+      - image: "c_depth.png"
+"#;
+        let err = parse_str(yaml, tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("maximum 2"), "got: {err}");
+    }
+
+    #[test]
+    fn style_ref_parsed_with_var() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "name: test\nmodel: sdxl\nimages:\n  mood: \"data:image/png;base64,{RED_PNG_B64}\"\nsteps:\n  - id: a\n    generate: \"a cat\"\n    style_ref:\n      - image: \"$mood\"\n        strength: 0.8\n"
+        );
+        let wf = parse_str(&yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => {
+                assert_eq!(g.style_ref.len(), 1);
+                assert!(
+                    matches!(&g.style_ref[0].image, ImageRef::Local(p) if p.ends_with("mood-ref.png"))
+                );
+                assert_eq!(g.style_ref[0].strength, Some(0.8));
+            }
+            _ => panic!("expected generate"),
+        }
+    }
+
+    #[test]
+    fn generate_only_fields_rejected_on_edit() {
+        let tmp = TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("in.png"), b"fake").unwrap();
+        std::fs::write(tmp.path().join("i.png"), b"fake").unwrap();
+        let yaml = r#"
+name: test
+model: klein-9b
+steps:
+  - id: a
+    edit: "in.png"
+    prompt: "hi"
+    init_image: "i.png"
+"#;
+        let err = parse_str(yaml, tmp.path()).unwrap_err().to_string();
+        assert!(err.contains("only valid on generate steps"), "got: {err}");
+    }
+
+    #[test]
+    fn blend_rejected_on_generate() {
+        let yaml = r#"
+name: test
+model: flux-dev
+steps:
+  - id: a
+    generate: "a cat"
+    blend: latent
+"#;
+        let err = parse(yaml).unwrap_err().to_string();
+        assert!(err.contains("only valid on edit steps"), "got: {err}");
+    }
+
+    #[test]
+    fn inline_data_uri_slots_get_distinct_filenames() {
+        let tmp = tempfile::tempdir().unwrap();
+        let yaml = format!(
+            "name: test\nmodel: klein-9b\nsteps:\n  - id: mix\n    edit: [\"data:image/png;base64,{RED_PNG_B64}\", \"data:image/png;base64,{RED_PNG_B64}\"]\n    prompt: \"hi\"\n    mask: \"data:image/png;base64,{RED_PNG_B64}\"\n"
+        );
+        let wf = parse_str(&yaml, tmp.path()).unwrap();
+        match &wf.steps[0].kind {
+            StepKind::Edit(e) => {
+                assert!(
+                    matches!(&e.sources[0], ImageRef::Local(p) if p.ends_with("mix-source.png"))
+                );
+                assert!(
+                    matches!(&e.sources[1], ImageRef::Local(p) if p.ends_with("mix-source-2.png"))
+                );
+                assert!(
+                    matches!(&e.mask, Some(EditMask::Image(ImageRef::Local(p))) if p.ends_with("mix-mask.png"))
+                );
+            }
+            _ => panic!("expected edit"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
## What

Every image input the CLI supports now ships through workflows — and therefore through MCP `run_workflow` and pods. Closes out Tier 1 of the pod gaps roadmap (no more "works locally, blocked on pods" input gaps).

### Workflow YAML

**Generate steps** grow `init_image`, `mask`, `strength` (img2img/inpaint), `controlnet` (`[{image, type, strength, end}]`, max 2, `type` auto-detected from `_pose`/`_canny`/… filename suffixes for plain paths, required for `$refs`), and `style_ref` (`[{image, strength, type}]`).

**Edit steps**: `edit:` now also accepts a list — `edit: ["$a", "$b"]` — for multi-image editing (Klein, Qwen Edit 2511), plus `mask:` (image ref or `auto`/`from-alpha` sentinel) and `blend:` (`pixel`|`latent`).

Every slot accepts all four ref forms (`$var`, `$step.outputs[N]`, data URI, bare path) and contributes DAG edges to the scheduler, so a generate step can now img2img off an earlier step's output.

Plan-time validation: img2img/inpaint capability, ControlNet type and style-ref support checked against the effective model per step (structured `PlanError`, so `--dry-run --json` consumers get actionable errors). Dry-run JSON adds `source_refs` for multi-source edit steps (`source_ref` stays the first source).

### Pods

`generate --pod` and `edit --pod` no longer bail on image flags: init image, mask, ControlNet and style-ref files (and N edit images) are inlined as base64 `images:` map entries by the single-step spec builders. `check_pod_supported` scans all new slots (including list-form `edit:`) for bare local paths with the existing images:-map guidance. ControlNet/style-ref validation happens against models.toml before any pod time is spent.

Not included: `--inpaint` method selection on pods (bails clearly; not a workflow field), automatic inpaint-model swap on pods (explicit `--base`; the validate_mode error lists capable models), MCP `edit` tool stays single-image (`run_workflow` covers multi).

## Verification

- 26 new unit tests (parser, scheduler DAG, capability checks, pod spec builders, pod-support scan); 220 total green, clippy clean.
- Live on a 4090: 4-step workflow — plain generate → **img2img off the step output** (`strength: 0.55` correctly shortened the schedule to 5/8 steps) → **multi-image edit** (2 step outputs → Klein 9B, correctly composed result).
- The live ControlNet smokes surfaced two **pre-existing** worker bugs, both reproduced on main via plain `modl generate --controlnet`: #122 (z-image device placement), #123 (SDXL union loader fallback). The workflow layer delivered correct specs in both cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)