### PR TITLE
fix: pod zombie-run pipeline + billing correctness

### DIFF
--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -121,7 +121,7 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
         style("→").cyan(),
         rec.instance_id,
         rec.gpu_name,
-        rec.dph_total
+        rec.dph_all_in()
     );
     let pod = crate::core::pod::Pod::from(rec.clone());
     let outcome =
@@ -136,7 +136,7 @@ async fn run_on_pod(args: &EditArgs<'_>) -> Result<()> {
         "{} Pod {} still running (${:.3}/hr) — {} when done.",
         style("⚠").yellow(),
         rec.instance_id,
-        rec.dph_total,
+        rec.dph_all_in(),
         style(format!("modl pod rm {}", rec.instance_id)).bold()
     );
     Ok(())

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -211,7 +211,7 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         style("→").cyan(),
         rec.instance_id,
         rec.gpu_name,
-        rec.dph_total
+        rec.dph_all_in()
     );
     let pod = crate::core::pod::Pod::from(rec.clone());
     let outcome =
@@ -223,7 +223,7 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
         "{} Pod {} still running (${:.3}/hr) — {} when done.",
         style("⚠").yellow(),
         rec.instance_id,
-        rec.dph_total,
+        rec.dph_all_in(),
         style(format!("modl pod rm {}", rec.instance_id)).bold()
     );
     Ok(())

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1079,6 +1079,14 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
         ));
     }
 
+    // Validate pod specs in-process, not via the spawned child: the child
+    // only reaches its spec checks after a Vast API round-trip, so a slow
+    // response outlives the early-exit watch window below and an invalid
+    // spec would be reported "submitted" — a run that can never complete.
+    if pod && let Err(e) = crate::core::pod_run::check_pod_supported(spec_yaml) {
+        return Err((-32602, format!("{e:#}")));
+    }
+
     // Pre-generate the run_id. Includes a short random suffix to prevent
     // collisions when two workflows are submitted within the same second.
     let run_id = format!(
@@ -1162,9 +1170,31 @@ fn tool_run_workflow(args: &Value) -> Result<Value, (i32, String)> {
 
     // Reap the child process when it exits so it doesn't linger as a zombie.
     // Rust's Drop on Child does NOT wait, so a long-running MCP server would
-    // accumulate defunct processes without this.
+    // accumulate defunct processes without this. For pod runs the reaper also
+    // records failure: the result file is only ever written by the child's
+    // stdout, so a runner that dies after the watch window (pod lost, sync
+    // failed) would otherwise leave job_status answering "pending" forever.
+    let reap_run_id = run_id.clone();
+    let reap_log = log_path.clone();
     std::thread::spawn(move || {
-        let _ = child.wait();
+        let exit = child.wait();
+        if !pod || exit.map(|s| s.success()).unwrap_or(false) {
+            return;
+        }
+        // Never clobber a real result — `run --pod --json` may have printed
+        // one (e.g. partial_failure) before exiting nonzero.
+        if read_pod_result(&reap_run_id).is_none() {
+            let _ = std::fs::write(
+                pod_result_path(&reap_run_id),
+                json!({
+                    "run_id": reap_run_id,
+                    "status": "failed",
+                    "note": "The detached pod runner exited before syncing results home — the log has the failure. If the pod is still up, pod_logs / pod_pull may recover the run.",
+                    "log": reap_log.to_string_lossy(),
+                })
+                .to_string(),
+            );
+        }
     });
 
     let mut result = json!({
@@ -1225,17 +1255,33 @@ fn tool_job_status(args: &Value) -> Result<Value, (i32, String)> {
 /// already destroyed.
 fn pod_job_status(run_id: &str) -> Result<Value, (i32, String)> {
     let local = read_pod_result(run_id);
+    // A "failed" result is the reaper's marker that the detached runner died
+    // — terminal for polling, but nothing has synced home.
+    let runner_failed = local
+        .as_ref()
+        .and_then(|l| l.get("status"))
+        .and_then(|s| s.as_str())
+        == Some("failed");
 
     let (stdout, stderr, success) =
         run_modl(&["status", "--json", "--pod", run_id]).map_err(|e| (-32603, e))?;
 
     let mut result = if success {
-        serde_json::from_str::<Value>(&stdout).unwrap_or_else(|_| json!({ "run_id": run_id }))
+        let mut v =
+            serde_json::from_str::<Value>(&stdout).unwrap_or_else(|_| json!({ "run_id": run_id }));
+        if runner_failed && let Some(obj) = v.as_object_mut() {
+            obj.insert(
+                "note".into(),
+                json!("The local watcher for this run died — artifacts will NOT sync home automatically. Use pod_pull once the pod-side run completes."),
+            );
+        }
+        v
     } else if let Some(local) = &local {
-        // Pod gone or unreachable, but the run already synced home — report
-        // from the local result instead of failing the poll.
+        // Pod gone or unreachable, but a local result exists (synced home, or
+        // the reaper's failure marker) — report it instead of failing the
+        // poll. Either way this is a terminal answer: stop polling.
         let mut v = local.clone();
-        if let Some(obj) = v.as_object_mut() {
+        if !runner_failed && let Some(obj) = v.as_object_mut() {
             obj.insert(
                 "note".into(),
                 json!("Pod status unavailable — reporting from the synced local result."),
@@ -1262,7 +1308,10 @@ fn pod_job_status(run_id: &str) -> Result<Value, (i32, String)> {
     };
 
     if let Some(obj) = result.as_object_mut() {
-        obj.insert("synced_home".into(), json!(local.is_some()));
+        obj.insert(
+            "synced_home".into(),
+            json!(local.is_some() && !runner_failed),
+        );
         if let Some(images) = local.as_ref().and_then(|l| l.get("images")) {
             obj.insert("local_images".into(), images.clone());
         }
@@ -1289,6 +1338,15 @@ fn tool_list_run_outputs(args: &Value) -> Result<Value, (i32, String)> {
                 ),
             ));
         };
+        if local.get("status").and_then(|s| s.as_str()) == Some("failed") {
+            let log = local.get("log").and_then(|l| l.as_str()).unwrap_or("");
+            return Err((
+                -32603,
+                format!(
+                    "Run {run_id} failed before syncing home — the log has the failure: {log}. If the pod is still up, pod_pull may recover completed artifacts."
+                ),
+            ));
+        }
         let images = local.get("images").cloned().unwrap_or_else(|| json!([]));
         let count = images.as_array().map(|a| a.len()).unwrap_or(0);
         let text = format!(

--- a/src/cli/pod.rs
+++ b/src/cli/pod.rs
@@ -46,6 +46,9 @@ pub async fn ls(json: bool) -> Result<()> {
                     // Tracked in pods.json — the pod train/run/pull reuse.
                     "active": rec.is_some(),
                     "label": rec.map(|r| r.label.clone()),
+                    // All-in (gpu + storage) — dph_total above is Vast's live
+                    // GPU rate and excludes the storage line.
+                    "dph_all_in": rec.map(|r| r.dph_all_in()),
                     "cost_so_far": rec.map(|r| r.cost_so_far()),
                     // Bootstrapped and ready for jobs (fingerprint recorded).
                     "ready": rec.map(|r| r.bootstrap_fingerprint.is_some()).unwrap_or(false),
@@ -115,14 +118,15 @@ pub async fn up(
     json: bool,
 ) -> Result<()> {
     // 1. Reuse is automatic — an existing pod short-circuits unless --fresh.
+    let mut replacing: Option<PodRecord> = None;
     if let Some(rec) = pod_state::active_pod().await? {
         if !fresh {
             eprintln!(
-                "{} Pod {} already up — {}, ${:.3}/hr. Reuse is automatic; pass {} to replace it.",
+                "{} Pod {} already up — {}, ${:.3}/hr all-in. Reuse is automatic; pass {} to replace it.",
                 style("✓").green(),
                 rec.instance_id,
                 rec.gpu_name,
-                rec.dph_total,
+                rec.dph_all_in(),
                 style("--fresh").bold()
             );
             if !models.is_empty() {
@@ -138,12 +142,17 @@ pub async fn up(
             }
             return Ok(());
         }
+        // Don't destroy the working pod yet: if no offer fits the price cap,
+        // the rent is declined, or every host duds out, we'd end with zero
+        // pods and a lost warm cache. Provision the replacement first — a few
+        // minutes of double billing is strictly cheaper than losing the old
+        // pod for nothing.
         eprintln!(
-            "{} --fresh: destroying active pod {} before provisioning a new one…",
+            "{} --fresh: provisioning a replacement for pod {} — the old pod is destroyed only once the new one is up…",
             style("→").cyan(),
             rec.instance_id
         );
-        pod::teardown(&pod::Pod::from(rec)).await?;
+        replacing = Some(rec);
     }
 
     // 2. VRAM floor: for an explicit GPU the user chose deliberately (none);
@@ -182,6 +191,16 @@ pub async fn up(
     let rec = recorded.to_record(&opts.label);
     pod_state::upsert(rec.clone())?;
 
+    // 4b. --fresh: the replacement is up and bootstrapped — now destroy the
+    //     old pod. A failed teardown doesn't fail the command (the new pod is
+    //     live); the old record stays tracked and nagged about.
+    if let Some(old) = replacing
+        && old.instance_id != rec.instance_id
+        && let Err(e) = pod::teardown(&pod::Pod::from(old)).await
+    {
+        eprintln!("{} {e}", style("✗").red());
+    }
+
     // 5. Warm the store: install modl + pull the requested models so the
     //    first job doesn't pay the download.
     if !models.is_empty() {
@@ -190,11 +209,11 @@ pub async fn up(
 
     // 6. Summary.
     eprintln!(
-        "{} Pod {} up — {}, ${:.3}/hr, billing until destroyed",
+        "{} Pod {} up — {}, ${:.3}/hr all-in, billing until destroyed",
         style("✓").green().bold(),
         pod_obj.instance_id,
         pod_obj.gpu_name,
-        pod_obj.dph_total
+        pod_obj.dph_total + pod_obj.dph_storage
     );
     if json {
         println!(
@@ -214,6 +233,8 @@ fn up_result_json(rec: &PodRecord, reused: bool) -> serde_json::Value {
         "instance_id": rec.instance_id,
         "gpu_name": rec.gpu_name,
         "dph_total": rec.dph_total,
+        "dph_storage": rec.dph_storage,
+        "dph_all_in": rec.dph_all_in(),
         "ssh_host": rec.ssh_host,
         "ssh_port": rec.ssh_port,
         "label": rec.label,
@@ -341,13 +362,21 @@ pub async fn rm(instance_id: u64, yes: bool) -> Result<()> {
             return Ok(());
         }
     }
-    vast::destroy_instance(instance_id).await?;
+    let outcome = vast::destroy_instance(instance_id).await?;
     // Drop it from pods.json too, whether or not it was a tracked modl pod.
     let _ = pod_state::remove(instance_id);
-    println!(
-        "{} Instance {instance_id} destroyed — billing stopped.",
-        style("✓").green()
-    );
+    match outcome {
+        vast::DestroyOutcome::Destroyed => println!(
+            "{} Instance {instance_id} destroyed — billing stopped.",
+            style("✓").green()
+        ),
+        // Don't confirm "billing stopped" for an id Vast never knew: on a
+        // typo the REAL pod is still billing — send the user to pod ls.
+        vast::DestroyOutcome::AlreadyGone => println!(
+            "{} Instance {instance_id} not found on Vast (already destroyed, or a mistyped id).\n  Check what is still running: modl pod ls",
+            style("!").yellow()
+        ),
+    }
     Ok(())
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -363,34 +363,45 @@ async fn run_on_pod(
         return Ok(());
     }
 
+    // Read + validate every spec BEFORE the Vast round-trip in active_pod():
+    // an invalid spec must fail in milliseconds, not after a slow API call —
+    // MCP's submit watch window is short, and anything slower reports a
+    // dead-on-arrival run as "submitted".
+    let mut specs: Vec<(&String, String)> = Vec::with_capacity(spec_paths.len());
+    for path in spec_paths {
+        let yaml =
+            std::fs::read_to_string(path).with_context(|| format!("Failed to read {path}"))?;
+        crate::core::pod_run::check_pod_supported(&yaml)
+            .with_context(|| format!("In workflow file: {path}"))?;
+        specs.push((path, yaml));
+    }
+
     let rec = crate::core::pod_state::active_pod()
         .await?
         .context("No pod up — run `modl pod up <gpu>` first, or drop --pod to run locally.")?;
     let pod = crate::core::pod::Pod::from(rec.clone());
 
-    for (i, path) in spec_paths.iter().enumerate() {
+    for (i, (path, yaml)) in specs.iter().enumerate() {
         if spec_paths.len() > 1 {
             if i > 0 {
                 eprintln!();
             }
             eprintln!("── {}/{}: {} ──", i + 1, spec_paths.len(), path);
         }
-        let yaml =
-            std::fs::read_to_string(path).with_context(|| format!("Failed to read {path}"))?;
         eprintln!(
             "{} Running {} on pod {} ({}, ${:.3}/hr)…",
             style("→").cyan(),
             path,
             rec.instance_id,
             rec.gpu_name,
-            rec.dph_total
+            rec.dph_all_in()
         );
         let opts = crate::core::pod_run::RemoteRunOptions {
             run_id: run_id_override.map(String::from),
             force: !skip_existing,
             in_order,
         };
-        let outcome = crate::core::pod_run::run_workflow_on_pod(&pod, &yaml, None, opts).await?;
+        let outcome = crate::core::pod_run::run_workflow_on_pod(&pod, yaml, None, opts).await?;
         if json {
             println!(
                 "{}",
@@ -403,7 +414,7 @@ async fn run_on_pod(
         "{} Pod {} still running (${:.3}/hr) — {} when done.",
         style("⚠").yellow(),
         rec.instance_id,
-        rec.dph_total,
+        rec.dph_all_in(),
         style(format!("modl pod rm {}", rec.instance_id)).bold()
     );
     Ok(())

--- a/src/cli/train.rs
+++ b/src/cli/train.rs
@@ -80,7 +80,7 @@ async fn run_pod(spec: TrainJobSpec, args: PodArgs) -> Result<()> {
             style("→").cyan(),
             rec.instance_id,
             rec.gpu_name,
-            rec.dph_total
+            rec.dph_all_in()
         );
 
         // VRAM guard: if we can estimate the pod's VRAM and it's below the
@@ -123,7 +123,7 @@ async fn run_pod(spec: TrainJobSpec, args: PodArgs) -> Result<()> {
             "{} Pod {} still running (${:.3}/hr) — {} when done.",
             style("⚠").yellow(),
             rec.instance_id,
-            rec.dph_total,
+            rec.dph_all_in(),
             style(format!("modl pod rm {}", rec.instance_id)).bold()
         );
         return Ok(());

--- a/src/core/pod.rs
+++ b/src/core/pod.rs
@@ -116,6 +116,8 @@ pub struct Pod {
     pub instance_id: u64,
     pub gpu_name: String,
     pub dph_total: f64,
+    /// Hourly storage cost for the provisioned disk (see `PodRecord`).
+    pub dph_storage: f64,
     pub(crate) ssh: SshTarget,
     /// RFC3339 — set when the pod was first provisioned.
     pub created_at: String,
@@ -129,6 +131,7 @@ impl Pod {
             instance_id: self.instance_id,
             gpu_name: self.gpu_name.clone(),
             dph_total: self.dph_total,
+            dph_storage: self.dph_storage,
             ssh_host: self.ssh.host.clone(),
             ssh_port: self.ssh.port,
             created_at: self.created_at.clone(),
@@ -144,6 +147,7 @@ impl From<PodRecord> for Pod {
             instance_id: r.instance_id,
             gpu_name: r.gpu_name,
             dph_total: r.dph_total,
+            dph_storage: r.dph_storage,
             ssh: SshTarget {
                 host: r.ssh_host,
                 port: r.ssh_port,
@@ -294,6 +298,7 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
             instance_id: id,
             gpu_name: offer.gpu_name.clone(),
             dph_total: offer.dph_total,
+            dph_storage: offer.storage_dph(opts.disk_gb),
             ssh_host: String::new(),
             ssh_port: 0,
             created_at: pod_state::now_rfc3339(),
@@ -306,31 +311,37 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
             );
         }
 
-        match wait_for_instance(id).await {
-            Ok(ssh) => {
-                booted = Some((id, offer.clone(), ssh));
-                break;
-            }
-            Err(e) => {
-                eprintln!("{} {e}", style("!").yellow());
-                eprintln!(
-                    "{} Host never booted — destroying instance {} and trying the next offer...",
-                    style("!").yellow(),
-                    id
-                );
-                bad_machines.insert(offer.machine_id);
-                match vast::destroy_instance(id).await {
-                    // Only forget a dud we actually destroyed — a record for
-                    // a still-billing instance must survive.
-                    Ok(()) => {
-                        let _ = pod_state::remove(id);
-                    }
-                    Err(e) => eprintln!(
-                        "{} Could not destroy {id}: {e} — still billing, check with: modl pod ls",
-                        style("✗").red()
-                    ),
+        // Boot AND ssh-readiness both count as "did this host work": an
+        // instance that reaches `running` but never accepts SSH is just as
+        // much a dud as one that never boots — destroy it and try the next
+        // offer instead of bailing out with a silently-billing instance.
+        let dud_reason = match wait_for_instance(id).await {
+            Ok(ssh) => match wait_for_ssh(&ssh) {
+                Ok(()) => {
+                    booted = Some((id, offer.clone(), ssh));
+                    break;
                 }
+                Err(e) => e,
+            },
+            Err(e) => e,
+        };
+        eprintln!("{} {dud_reason}", style("!").yellow());
+        eprintln!(
+            "{} Host never became reachable — destroying instance {} and trying the next offer...",
+            style("!").yellow(),
+            id
+        );
+        bad_machines.insert(offer.machine_id);
+        match vast::destroy_instance(id).await {
+            // Only forget a dud we actually destroyed — a record for
+            // a still-billing instance must survive.
+            Ok(_) => {
+                let _ = pod_state::remove(id);
             }
+            Err(e) => eprintln!(
+                "{} Could not destroy {id}: {e} — still billing, check with: modl pod ls",
+                style("✗").red()
+            ),
         }
     }
     let (instance_id, rented_offer, ssh) =
@@ -338,8 +349,9 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
 
     let pod = Pod {
         instance_id,
-        gpu_name: rented_offer.gpu_name,
         dph_total: rented_offer.dph_total,
+        dph_storage: rented_offer.storage_dph(opts.disk_gb),
+        gpu_name: rented_offer.gpu_name,
         ssh,
         created_at: pod_state::now_rfc3339(),
         bootstrap_fingerprint: None,
@@ -351,11 +363,6 @@ pub async fn provision(opts: &PodOptions, min_vram_gb: Option<u32>) -> Result<Po
             style("⚠").yellow()
         );
     }
-
-    // ---------------------------------------------------------------
-    // 3. Wait for sshd to accept connections (running != ssh-ready)
-    // ---------------------------------------------------------------
-    wait_for_ssh(&pod.ssh)?;
 
     Ok(pod)
 }
@@ -586,7 +593,7 @@ pub async fn teardown(pod: &Pod) -> Result<()> {
         pod.instance_id
     );
     match vast::destroy_instance(pod.instance_id).await {
-        Ok(()) => {
+        Ok(_) => {
             eprintln!("{} Pod destroyed — billing stopped.", style("✓").green());
             let _ = pod_state::remove(pod.instance_id);
             Ok(())
@@ -622,8 +629,11 @@ pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()
         );
     }
 
-    let pod = provision(&opts, min_vram_gb).await?;
+    // Clock starts before provision so the billed boot minutes count toward
+    // the estimate (an interactive confirm inflates it slightly — better a
+    // little high than silently low).
     let started_at = std::time::Instant::now();
+    let pod = provision(&opts, min_vram_gb).await?;
 
     // Everything after boot runs inside a fallible block so the pod is
     // destroyed on error unless --keep-pod was passed.
@@ -669,9 +679,9 @@ pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()
 
     let hours = started_at.elapsed().as_secs_f64() / 3600.0;
     eprintln!(
-        "  Pod time: {:.0}m — estimated cost ${:.2}",
+        "  Pod time: {:.0}m — estimated cost ${:.2} all-in (gpu + storage)",
         hours * 60.0,
-        hours * pod.dph_total
+        hours * (pod.dph_total + pod.dph_storage)
     );
 
     result
@@ -1010,22 +1020,41 @@ fn wait_for_ssh(ssh: &SshTarget) -> Result<()> {
         ssh.port
     );
     let deadline = std::time::Instant::now() + std::time::Duration::from_secs(SSH_TIMEOUT_SECS);
+    // Keep the last real ssh error: without it every retry fails identically
+    // and invisibly for the whole window, and the final message blames a
+    // missing account key when the actual cause is often a stale known_hosts
+    // entry (Vast reuses proxy host:port pairs across tenants, so accept-new
+    // hard-fails with "HOST IDENTIFICATION HAS CHANGED").
+    let mut last_err = String::new();
     loop {
-        let ok = Command::new("ssh")
+        match Command::new("ssh")
             .args(ssh.base_args())
             .arg("true")
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
-            .map(|s| s.success())
-            .unwrap_or(false);
-        if ok {
-            return Ok(());
+            .output()
+        {
+            Ok(out) if out.status.success() => return Ok(()),
+            Ok(out) => {
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                if let Some(line) = stderr.lines().rev().find(|l| !l.trim().is_empty()) {
+                    last_err = line.trim().to_string();
+                }
+            }
+            Err(e) => last_err = format!("failed to spawn ssh: {e}"),
         }
         if std::time::Instant::now() > deadline {
             bail!(
-                "SSH to root@{}:{} never came up. Is an SSH key registered on your \
-                 Vast.ai account (https://cloud.vast.ai/account)?",
+                "SSH to root@{}:{} never came up.\n  Last ssh error: {}\n  \
+                 If a key isn't registered on your Vast.ai account, add one: \
+                 https://cloud.vast.ai/account\n  \
+                 For a host-key mismatch, clear the stale entry: ssh-keygen -R '[{}]:{}'",
+                ssh.host,
+                ssh.port,
+                if last_err.is_empty() {
+                    "(none captured)"
+                } else {
+                    &last_err
+                },
                 ssh.host,
                 ssh.port
             );
@@ -1290,6 +1319,7 @@ mod tests {
             instance_id: 999,
             gpu_name: "RTX 3090".into(),
             dph_total: 0.19,
+            dph_storage: 0.04,
             ssh: SshTarget {
                 host: "ssh5.vast.ai".into(),
                 port: 4242,
@@ -1305,6 +1335,7 @@ mod tests {
         assert_eq!(back.instance_id, 999);
         assert_eq!(back.ssh.host, "ssh5.vast.ai");
         assert_eq!(back.dph_total, 0.19);
+        assert_eq!(back.dph_storage, 0.04);
     }
 
     #[test]

--- a/src/core/pod_run.rs
+++ b/src/core/pod_run.rs
@@ -511,6 +511,16 @@ pub fn check_pod_supported(yaml: &str) -> Result<()> {
             }
         }
     }
+
+    // The checks above are pod-specific messaging; the pod runs the real
+    // parser, so run it here too — schema errors, unknown `$name`/`$step`
+    // refs, and undecodable base64 must fail at submit time, not minutes
+    // later on the pod after install/auth/model-pull time is already paid.
+    // Everything left is data URIs and `$refs` (bare paths bailed above), so
+    // data URIs materialize into a throwaway dir and a parse success here is
+    // a parse success on the pod.
+    let tmp = tempfile::tempdir().context("Failed to create a scratch dir for validation")?;
+    crate::core::workflow::parse_str(yaml, tmp.path())?;
     Ok(())
 }
 
@@ -686,6 +696,21 @@ pub fn export_run(
 fn wait_for_run(pod: &Pod, run_id: &str, log: &str, pidfile: &str) -> Result<String> {
     let mut tail = spawn_log_tail(pod, log);
     let mut poll_failures = 0u32;
+    // Liveness probe for the detached runner. `run_ssh_capture` returns Ok("")
+    // on transport failure, which matches neither "alive" nor "dead" — so a
+    // flaky link never masquerades as a verdict.
+    let probe_cmd = format!(
+        "if [ -f {pf} ] && kill -0 \"$(cat {pf})\" 2>/dev/null; \
+         then echo alive; else echo dead; fi",
+        pf = shell_quote(pidfile)
+    );
+    let dead_runner_err = |status: &str| -> anyhow::Error {
+        let tail_txt = run_ssh_capture(&pod.ssh, &format!("tail -n 30 {}", shell_quote(log)))
+            .unwrap_or_default();
+        anyhow::anyhow!(
+            "The workflow runner on the pod died before finishing (status: {status}).\n\nLast run log:\n{tail_txt}"
+        )
+    };
 
     loop {
         // Drain whatever the tail has produced since the last poll.
@@ -717,29 +742,28 @@ fn wait_for_run(pod: &Pod, run_id: &str, log: &str, pidfile: &str) -> Result<Str
                 }
                 // Not terminal — if the runner process died the DB will never
                 // reach a terminal state; catch that instead of hanging.
-                if status == "running" || status == "pending" {
-                    let probe = run_ssh_capture(
-                        &pod.ssh,
-                        &format!(
-                            "if [ -f {pf} ] && kill -0 \"$(cat {pf})\" 2>/dev/null; \
-                             then echo alive; else echo dead; fi",
-                            pf = shell_quote(pidfile)
-                        ),
-                    );
-                    if let Ok(out) = probe
-                        && out.contains("dead")
-                    {
-                        let tail_txt =
-                            run_ssh_capture(&pod.ssh, &format!("tail -n 30 {}", shell_quote(log)))
-                                .unwrap_or_default();
-                        bail!(
-                            "The workflow runner on the pod died before finishing (status still '{status}').\n\nLast run log:\n{tail_txt}"
-                        );
-                    }
+                if (status == "running" || status == "pending")
+                    && let Ok(out) = run_ssh_capture(&pod.ssh, &probe_cmd)
+                    && out.contains("dead")
+                {
+                    return Err(dead_runner_err(&format!("still '{status}'")));
                 }
             }
             Err(e) => {
-                // Flaky link — the run is unaffected, keep trying.
+                // A failed status poll is either a flaky link (run unaffected,
+                // keep trying) or a runner that died before the run was ever
+                // registered in the pod's DB — a state the status query alone
+                // can't distinguish, and one that would otherwise burn the
+                // full poll budget before bailing with a wrong "lost contact"
+                // diagnosis. Probe the runner: a reachable pod with a dead
+                // pid means the run is never coming.
+                if let Ok(out) = run_ssh_capture(&pod.ssh, &probe_cmd)
+                    && out.contains("dead")
+                {
+                    return Err(dead_runner_err(
+                        "never registered — it likely failed at startup",
+                    ));
+                }
                 poll_failures += 1;
                 if poll_failures >= MAX_POLL_FAILURES {
                     bail!(
@@ -1415,8 +1439,27 @@ steps:
             assert!(err.contains("local file path"), "{yaml}: {err}");
         }
         // Sentinel masks are fine.
-        let ok = "name: t\nmodel: m\nsteps:\n  - id: a\n    edit: \"$x\"\n    prompt: p\n    mask: from-alpha\n";
+        let ok = "name: t\nmodel: m\nimages:\n  x: \"data:image/png;base64,aWs=\"\nsteps:\n  - id: a\n    edit: \"$x\"\n    prompt: p\n    mask: from-alpha\n";
         check_pod_supported(ok).unwrap();
+    }
+
+    #[test]
+    fn runs_the_full_parser_at_submit_time() {
+        // An undefined $name passed the path-only checks before — now the
+        // real parser runs locally, so it fails at submit instead of minutes
+        // later pod-side.
+        let undefined =
+            "name: t\nmodel: m\nsteps:\n  - id: a\n    edit: \"$nope\"\n    prompt: p\n";
+        let err = check_pod_supported(undefined).unwrap_err().to_string();
+        assert!(err.contains("not defined"), "{err}");
+
+        // Undecodable base64 in the images map fails the same way.
+        let bad_b64 = "name: t\nmodel: m\nimages:\n  x: \"data:image/png;base64,%%%\"\nsteps:\n  - id: a\n    edit: \"$x\"\n    prompt: p\n";
+        assert!(check_pod_supported(bad_b64).is_err());
+
+        // A $step ref into a step id that doesn't exist is caught too.
+        let bad_step = "name: t\nmodel: m\nsteps:\n  - id: a\n    edit: \"$ghost.outputs[0]\"\n    prompt: p\n";
+        assert!(check_pod_supported(bad_step).is_err());
     }
 
     #[test]

--- a/src/core/pod_state.rs
+++ b/src/core/pod_state.rs
@@ -26,6 +26,12 @@ pub struct PodRecord {
     pub instance_id: u64,
     pub gpu_name: String,
     pub dph_total: f64,
+    /// Hourly storage cost for the provisioned disk — bills alongside the GPU
+    /// rate from the moment of rent, and can rival it on cheap cards.
+    /// Recorded at rent time (the instances API doesn't report it); defaults
+    /// to 0 for records written before this field existed.
+    #[serde(default)]
+    pub dph_storage: f64,
     pub ssh_host: String,
     pub ssh_port: u16,
     /// RFC3339 timestamp of when the record was first created.
@@ -44,9 +50,16 @@ impl PodRecord {
             .unwrap_or(0)
     }
 
-    /// Running-cost estimate so far: age × hourly rate.
+    /// All-in hourly rate: GPU + storage. Every user-facing cost figure must
+    /// use this — the rent quote deliberately prices all-in, and a stale nag
+    /// showing half the true burn defeats its purpose.
+    pub fn dph_all_in(&self) -> f64 {
+        self.dph_total + self.dph_storage
+    }
+
+    /// Running-cost estimate so far: age × all-in hourly rate.
     pub fn cost_so_far(&self) -> f64 {
-        (self.age_secs() as f64 / 3600.0) * self.dph_total
+        (self.age_secs() as f64 / 3600.0) * self.dph_all_in()
     }
 }
 
@@ -234,6 +247,7 @@ mod tests {
             instance_id: id,
             gpu_name: "RTX 3090".into(),
             dph_total: 0.20,
+            dph_storage: 0.0,
             ssh_host: "ssh5.vast.ai".into(),
             ssh_port: 12345,
             created_at: now_rfc3339(),
@@ -258,6 +272,24 @@ mod tests {
         r.dph_total = 0.30;
         assert!(r.age_secs() >= 3 * 3600 - 5);
         assert!((r.cost_so_far() - 0.90).abs() < 0.01);
+    }
+
+    #[test]
+    fn cost_so_far_includes_storage() {
+        let mut r = rec(1);
+        r.created_at = (now() - chrono::Duration::hours(10)).to_rfc3339();
+        r.dph_total = 0.12;
+        r.dph_storage = 0.10; // storage can rival the GPU rate on cheap cards
+        assert!((r.cost_so_far() - 2.20).abs() < 0.02);
+    }
+
+    #[test]
+    fn old_records_without_storage_field_still_parse() {
+        let json = r#"{"instance_id": 7, "gpu_name": "RTX 3090", "dph_total": 0.2,
+                       "ssh_host": "h", "ssh_port": 1, "created_at": "x",
+                       "bootstrap_fingerprint": null, "label": "modl-pod"}"#;
+        let r: PodRecord = serde_json::from_str(json).unwrap();
+        assert_eq!(r.dph_storage, 0.0);
     }
 
     #[test]

--- a/src/core/vast.rs
+++ b/src/core/vast.rs
@@ -178,10 +178,9 @@ pub async fn search_offers(
         // link-speed tax sort within it.
         "inet_down": {"gte": 1000},
         "inet_up": {"gte": 300},
-        // Must cover the POD_DISK_GB (80) requested at rent time — hosts
-        // below it pass search, then fail at create_instance, burning a
-        // failover attempt.
-        "disk_space": {"gte": 80},
+        // Must cover the disk requested at rent time — hosts below it pass
+        // search, then fail at create_instance, burning a failover attempt.
+        "disk_space": {"gte": disk_gb},
         "reliability2": {"gte": 0.98},
         "direct_port_count": {"gte": 1},
         "cuda_max_good": {"gte": 12.9},
@@ -367,8 +366,19 @@ fn parse_instance(inst: &serde_json::Value, fallback_id: u64) -> Result<Instance
     })
 }
 
+/// What actually happened on a destroy request. Teardown treats both as
+/// success (idempotency), but user-facing surfaces must not confirm
+/// "billing stopped" for an id Vast has never heard of — a typo'd
+/// `pod rm` would false-confirm while the real pod bills on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DestroyOutcome {
+    Destroyed,
+    /// Vast returned 404 — already destroyed, or the id never existed.
+    AlreadyGone,
+}
+
 /// Destroy (terminate) an instance. Billing stops.
-pub async fn destroy_instance(instance_id: u64) -> Result<()> {
+pub async fn destroy_instance(instance_id: u64) -> Result<DestroyOutcome> {
     let (client, key) = client()?;
     let resp = client
         .delete(format!("{API_BASE}/instances/{instance_id}/"))
@@ -380,10 +390,10 @@ pub async fn destroy_instance(instance_id: u64) -> Result<()> {
     // successful destroy — `pod rm` and teardown must be idempotent so the
     // local record can still be pruned instead of nagging forever.
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
-        return Ok(());
+        return Ok(DestroyOutcome::AlreadyGone);
     }
     check(resp, "instance destroy").await?;
-    Ok(())
+    Ok(DestroyOutcome::Destroyed)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes the two highest-severity clusters from the pod-stack code review (`docs/reviews/pods-review-2026-07-16.md`, private): runs that die into an undiagnosable forever-"pending", and billing figures/paths that under-report or leak billed instances.

## Zombie-run pipeline

- **Reaper records failure** (`cli/mcp.rs`): the result file (`<run-id>.result.json`) was only ever written by the child's stdout on success — a detached runner dying after the 3s watch window left `job_status(pod: true)` answering "pending" forever, even after `pod_rm`. The reaper thread now writes `{"status": "failed", note, log}` on nonzero exit (never clobbering a real result); `job_status` treats it as terminal with `synced_home: false`, and `list_run_outputs` explains the failure instead of "0 artifacts".
- **`wait_for_run` probes the pidfile on poll errors too** (`core/pod_run.rs`): a runner that died before registering the run made every status poll error, which counted as "flaky link" — 5 minutes of retries, then the wrong diagnosis. Now a reachable pod + dead pid fails immediately with the last 30 log lines. An SSH flake matches neither "alive" nor "dead", so genuine link failures still retry.
- **`check_pod_supported` runs the real workflow parser locally** (data URIs materialize into a tempdir): undefined `$name` refs, `$step` refs to nonexistent steps, undecodable base64, and schema errors now fail at submit time instead of pod-side after install/auth/model-pull time is paid. This also caught an invalid fixture in an existing test (undefined `$x`).
- **Validation happens before anything slow**: MCP `run_workflow(pod: true)` validates in-process before spawning (it previously relied on the child failing within 3s — but the child hits its checks only after a Vast API round-trip), and `run --pod` reads + validates all specs before `active_pod()`'s API call.

## Billing correctness

- **`wait_for_ssh` inside the boot-failover loop** (`core/pod.rs`): an instance that reaches `running` but never accepts SSH was the one provisioning leg with no failover and no cleanup — it aborted with the instance still billing. Now it's destroyed and the next offer is tried, same as a boot failure. The last real ssh stderr line (previously sent to /dev/null) surfaces in the timeout error, with an `ssh-keygen -R` hint — Vast reuses proxy host:ports, so stale known_hosts failures were invisible and retried identically for 6 minutes.
- **`pod up --fresh` provisions first, destroys after**: tearing down the warm pod before the offer search meant a failed rent (no offers under the cap, declined confirm, all hosts dud) left zero pods. A few minutes of double billing is strictly cheaper.
- **`pod rm <typo'd-id>` no longer prints "destroyed — billing stopped"** for an id Vast never knew: `destroy_instance` returns `Destroyed | AlreadyGone`; teardown keeps its idempotency, `rm` reports honestly and points at `pod ls`.
- **All cost figures are all-in (gpu + storage)**: the rent quote deliberately prices all-in because storage can rival the GPU rate on cheap cards, but `cost_so_far()` — feeding `pod ls` and the stale-pod nag (the billing backstop) — used `dph_total` alone, showing up to ~half the true burn. `PodRecord`/`Pod` now carry `dph_storage` (recorded at rent; `#[serde(default)]` so existing pods.json files parse), and every display uses the all-in rate: stale nag, `pod ls`/`pod up` JSON (`dph_all_in`), run/generate/edit/train epilogues, and the training estimate — whose clock now starts before provision so billed boot minutes count.
- **Offer search disk filter uses the requested `disk_gb`** instead of a hardcoded 80 — under the 120 GB default, hosts with 80–119 GB passed search and failed at `create_instance`, burning failover attempts (exactly the failure the old comment claimed to prevent).

## Testing

- 223 tests pass; 5 new: full-parse-at-submit cases (undefined `$name`, bad base64, ghost `$step` ref), storage-inclusive `cost_so_far`, old-record deserialization without `dph_storage`.
- clippy + fmt clean.
- Not live-smoked: the SSH/Vast failover and reaper paths need a rented pod — worth folding into the next 3090 test rent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)