### PR TITLE
fix: pod safety follow-ups — relaunch guard, pods.json lock, pull result marker

### DIFF
--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1049,11 +1049,10 @@ fn tool_remove_bg(args: &Value) -> Result<Value, (i32, String)> {
 
 /// Local path of the JSON result a detached pod run writes on completion
 /// (`modl run --pod --json` stdout). Existence = the run finished AND its
-/// artifacts were synced home.
+/// artifacts were synced home. Shared with `modl pod pull`, which writes the
+/// same file on the re-attach path.
 fn pod_result_path(run_id: &str) -> std::path::PathBuf {
-    crate::core::paths::modl_root()
-        .join("run-logs")
-        .join(format!("{run_id}.result.json"))
+    crate::core::pod_run::run_result_path(run_id)
 }
 
 /// Read + parse the pod run result file, if the run has synced home yet.

--- a/src/cli/pod.rs
+++ b/src/cli/pod.rs
@@ -306,17 +306,30 @@ pub async fn pull(run_id: String, dest: Option<std::path::PathBuf>, json: bool) 
 
     let (local_dir, artifacts) =
         crate::core::pod_run::export_run(&pod_obj, &run_id, dest.as_deref())?;
-    if json {
-        // Same shape as `run --pod --json` so agents parse one schema.
-        println!(
-            "{}",
-            serde_json::to_string(&serde_json::json!({
-                "status": status,
-                "run_id": run_id,
-                "output_dir": local_dir,
-                "images": artifacts,
-            }))?
+    // Same shape as `run --pod --json` so agents parse one schema.
+    let result = serde_json::json!({
+        "status": status,
+        "run_id": run_id,
+        "output_dir": local_dir,
+        "images": artifacts,
+    });
+    // Record the synced-home marker the MCP tools key on. Without it, a
+    // pulled run still answers job_status/list_run_outputs with "not synced
+    // yet — use pod_pull" (circular), and after `pod rm` becomes a dead end.
+    // Deliberately overwrites a reaper "failed" marker — the artifacts being
+    // home is the truer, terminal answer.
+    let result_path = crate::core::pod_run::run_result_path(&run_id);
+    if let Some(parent) = result_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    if let Err(e) = std::fs::write(&result_path, result.to_string()) {
+        eprintln!(
+            "{} Could not record the synced-home marker ({e}) — job_status may still report the run as not synced.",
+            style("⚠").yellow()
         );
+    }
+    if json {
+        println!("{}", serde_json::to_string(&result)?);
     }
     Ok(())
 }

--- a/src/core/pod.rs
+++ b/src/core/pod.rs
@@ -441,13 +441,31 @@ pub fn run_train_job(pod: &Pod, spec: &TrainJobSpec) -> Result<()> {
 
     // A worker from a previous run may still be alive: nohup survives a
     // dropped link, and proceeding would wipe its dataset and events file
-    // out from under it and launch a second trainer on the same GPU.
-    if matches!(probe_worker(ssh), WorkerProbe::Alive) {
-        bail!(
+    // out from under it and launch a second trainer on the same GPU. Only a
+    // definitive `dead` permits relaunch — an SSH-flake `Unknown` must not
+    // fall through to the dataset wipe below, so retry the probe a couple of
+    // times and bail if it never resolves.
+    let mut probe = probe_worker(ssh);
+    for _ in 0..2 {
+        if !matches!(probe, WorkerProbe::Unknown) {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_secs(5));
+        probe = probe_worker(ssh);
+    }
+    match probe {
+        WorkerProbe::Dead => {}
+        WorkerProbe::Alive => bail!(
             "A job is already running on pod {} — wait for it to finish, or destroy the pod: modl pod rm {}",
             pod.instance_id,
             pod.instance_id
-        );
+        ),
+        WorkerProbe::Unknown => bail!(
+            "Could not verify that no job is running on pod {} (the ssh probe kept failing) — \
+             proceeding would wipe a live job's dataset. Retry shortly, or inspect the pod: \
+             modl pod exec -- nvidia-smi",
+            pod.instance_id
+        ),
     }
 
     // ---------------------------------------------------------------
@@ -914,7 +932,8 @@ enum WorkerProbe {
 
 /// Ask the pod whether the worker process (from this or a previous job) is
 /// running. `Unknown` on SSH failure — callers pick the safe direction:
-/// the liveness loop only acts on `Dead`, the relaunch guard only on `Alive`.
+/// the liveness loop only acts on `Dead`, the relaunch guard only proceeds
+/// on `Dead` (an `Unknown` must never green-light the dataset wipe).
 fn probe_worker(ssh: &SshTarget) -> WorkerProbe {
     let cmd = format!(
         "if [ -f {REMOTE_ROOT}/worker.pid ] && kill -0 \"$(cat {REMOTE_ROOT}/worker.pid)\" 2>/dev/null; \

--- a/src/core/pod_run.rs
+++ b/src/core/pod_run.rs
@@ -51,6 +51,18 @@ pub struct RemoteRunOutcome {
     pub artifacts: Vec<PathBuf>,
 }
 
+/// Local path of the JSON result recorded once a pod run's artifacts are on
+/// THIS machine — written by the MCP layer (captured `run --pod --json`
+/// stdout, or the reaper's `{"status":"failed"}` marker when the detached
+/// runner dies) and by `modl pod pull` (the re-attach path). Its existence is
+/// the terminal answer for `job_status(pod: true)`: pod runs aren't in the
+/// local DB, so this file is the only cross-process completion signal.
+pub fn run_result_path(run_id: &str) -> PathBuf {
+    crate::core::paths::modl_root()
+        .join("run-logs")
+        .join(format!("{run_id}.result.json"))
+}
+
 /// Caller-controlled knobs for a remote workflow run. Everything here maps
 /// 1:1 onto the pod-side `modl run` invocation so local and pod flags behave
 /// identically.

--- a/src/core/pod_state.rs
+++ b/src/core/pod_state.rs
@@ -67,6 +67,38 @@ fn state_path() -> PathBuf {
     crate::core::paths::modl_root().join("pods.json")
 }
 
+/// Guard for cross-process read-modify-write cycles on pods.json. The atomic
+/// rename in `save` prevents torn files, not lost updates — and concurrency
+/// is designed-in: MCP's detached `modl pod up` upserts SSH details while
+/// `pod ls`/`active_pod` reconcile-save from other processes. A lost update
+/// can drop the record of a billing instance, silently disabling the stale
+/// nag. Advisory flock on a sidecar file; released when the guard drops.
+/// Writes are tiny, so blocking on the lock is momentary.
+struct StateLock(#[allow(dead_code)] std::fs::File);
+
+fn lock_state() -> Result<StateLock> {
+    let path = state_path().with_extension("json.lock");
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("Failed to create {}", parent.display()))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .with_context(|| format!("Failed to open {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::io::AsRawFd;
+        if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX) } != 0 {
+            return Err(std::io::Error::last_os_error())
+                .with_context(|| format!("Failed to lock {}", path.display()));
+        }
+    }
+    Ok(StateLock(file))
+}
+
 fn now() -> chrono::DateTime<chrono::Utc> {
     chrono::Utc::now()
 }
@@ -110,6 +142,7 @@ pub fn save(pods: &[PodRecord]) -> Result<()> {
 
 /// Insert or replace a record by instance ID.
 pub fn upsert(rec: PodRecord) -> Result<()> {
+    let _lock = lock_state()?;
     let mut pods = load();
     if let Some(existing) = pods.iter_mut().find(|p| p.instance_id == rec.instance_id) {
         *existing = rec;
@@ -122,6 +155,7 @@ pub fn upsert(rec: PodRecord) -> Result<()> {
 /// Update the bootstrap fingerprint on an existing record. No-op if the
 /// instance isn't tracked.
 pub fn set_fingerprint(instance_id: u64, fingerprint: &str) -> Result<()> {
+    let _lock = lock_state()?;
     let mut pods = load();
     if let Some(rec) = pods.iter_mut().find(|p| p.instance_id == instance_id) {
         rec.bootstrap_fingerprint = Some(fingerprint.to_string());
@@ -132,6 +166,7 @@ pub fn set_fingerprint(instance_id: u64, fingerprint: &str) -> Result<()> {
 
 /// Remove a record by instance ID. No-op if absent.
 pub fn remove(instance_id: u64) -> Result<()> {
+    let _lock = lock_state()?;
     let mut pods = load();
     let before = pods.len();
     pods.retain(|p| p.instance_id != instance_id);
@@ -147,14 +182,22 @@ pub fn remove(instance_id: u64) -> Result<()> {
 /// - Refreshes `ssh_host`/`ssh_port`/`gpu_name`/`dph_total` from live data.
 /// - Returns the newest *running* record (warns if more than one is running).
 pub async fn active_pod() -> Result<Option<PodRecord>> {
-    let mut pods = load();
-    if pods.is_empty() {
+    // Peek without the lock — an empty cache skips the network round-trip.
+    if load().is_empty() {
         return Ok(None);
     }
 
     let live = vast::list_instances().await?;
     let by_id: std::collections::HashMap<u64, &vast::Instance> =
         live.iter().map(|i| (i.id, i)).collect();
+
+    // Reconcile under the lock against a FRESH load: the Vast call above
+    // takes seconds, and a concurrent writer (MCP's detached `pod up`
+    // recording SSH details) may have changed the file since the peek —
+    // saving that stale snapshot would clobber its update. The lock is held
+    // only for the local read-modify-write, never across the network call.
+    let lock = lock_state()?;
+    let mut pods = load();
 
     // Prune dead records; refresh survivors from live data.
     pods.retain(|rec| by_id.contains_key(&rec.instance_id));
@@ -173,6 +216,7 @@ pub async fn active_pod() -> Result<Option<PodRecord>> {
         }
     }
     save(&pods)?;
+    drop(lock);
 
     // Active = running with a usable SSH target.
     let mut running: Vec<PodRecord> = pods


### PR DESCRIPTION
Reopens #127 (auto-closed when its stacked base branch was deleted on #126's merge), now rebased onto main. Closes the three remaining medium-severity findings from the pod-stack review (M4/M6/M7).

## Relaunch guard: `Unknown` no longer green-lights the dataset wipe (M4)

`run_train_job` refused to relaunch only when the worker probe returned `Alive`; an SSH-flake `Unknown` fell through to `rm -rf` of a possibly-live job's dataset and a second trainer on the same GPU (both likely OOM). Now only a definitive `Dead` permits relaunch: the probe retries twice on `Unknown` (5s apart), then bails with instructions instead of guessing.

## pods.json flock (M6)

Every mutation was load → mutate → save with no lock. The atomic rename prevents torn files, not lost updates — and concurrency is designed-in: MCP's detached `modl pod up` upserts SSH details while `pod ls`/`active_pod` reconcile-save from other processes. A lost update can drop the record of a billing instance, silently disabling the stale-pod nag (the billing backstop).

- Advisory `flock` on a `pods.json.lock` sidecar around every read-modify-write (`upsert`, `remove`, `set_fingerprint`, `active_pod`'s reconcile). Unix-only syscall, cfg-gated (Windows builds unaffected).
- `active_pod` peeks lock-free to skip the network call when empty, then reconciles against a **fresh load under the lock** — the seconds-long Vast call stays outside it, so writers block only for the local file cycle.

## `pod pull` writes the synced-home marker (M7)

The re-attach path imported artifacts into the outputs library but never wrote `<run-id>.result.json` — the only cross-process signal the MCP tools key on. So after a successful `pod_pull`, `list_run_outputs`/`job_status` still answered "not synced yet — use pod_pull" (circular), and after `pod_rm` the run became a dead end. Now:

- The result-path convention moved to core (`pod_run::run_result_path`); the MCP layer delegates to it.
- `pull` writes the same result JSON shape as `run --pod --json`, deliberately overwriting a reaper `"failed"` marker (from #126) — artifacts being home is the truer, terminal answer.
- A write failure warns instead of failing the pull (the artifacts are already imported).

## Testing

- 223 tests pass, clippy + fmt clean.
- The flock and SSH-probe paths need a live pod to exercise end-to-end — same caveat as #126; both are worth a combined smoke on the next 3090 rent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)