### PR TITLE
fix: refresh pod GPU rate from dph_base — instances dph_total is all-in

### DIFF
--- a/src/core/pod_state.rs
+++ b/src/core/pod_state.rs
@@ -210,8 +210,13 @@ pub async fn active_pod() -> Result<Option<PodRecord>> {
             if !inst.gpu_name.is_empty() {
                 rec.gpu_name = inst.gpu_name.clone();
             }
-            if inst.dph_total > 0.0 {
-                rec.dph_total = inst.dph_total;
+            // Refresh the GPU rate from `dph_base`, never `dph_total`: the
+            // instances endpoint's dph_total is ALL-IN (base + storage), so
+            // writing it into rec.dph_total would double-count storage in
+            // every dph_all_in() display after the first reconcile
+            // (observed live: $0.169 offer became a $0.247 "all-in" line).
+            if inst.dph_base > 0.0 {
+                rec.dph_total = inst.dph_base;
             }
         }
     }

--- a/src/core/vast.rs
+++ b/src/core/vast.rs
@@ -57,7 +57,15 @@ pub struct Instance {
     pub gpu_name: String,
     pub ssh_host: Option<String>,
     pub ssh_port: Option<u16>,
+    /// ALL-IN hourly rate (gpu + storage). Field-name trap: on the
+    /// *instances* endpoint `dph_total = dph_base + storage`, while on the
+    /// *offers* endpoint `dph_total` is the GPU rate alone (storage is
+    /// priced separately per GB/month). Verified live 2026-07-17: offer
+    /// quoted $0.169, same instance reported $0.207.
     pub dph_total: f64,
+    /// GPU-only hourly rate — the value comparable to an offer's
+    /// `dph_total`. 0.0 when the API omits it.
+    pub dph_base: f64,
     pub label: Option<String>,
 }
 
@@ -350,6 +358,7 @@ fn parse_instance(inst: &serde_json::Value, fallback_id: u64) -> Result<Instance
         ssh_host: Option<String>,
         ssh_port: Option<u16>,
         dph_total: Option<f64>,
+        dph_base: Option<f64>,
         label: Option<String>,
     }
     let raw: Raw = serde_json::from_value(inst.clone())
@@ -362,6 +371,7 @@ fn parse_instance(inst: &serde_json::Value, fallback_id: u64) -> Result<Instance
         ssh_host: raw.ssh_host,
         ssh_port: raw.ssh_port,
         dph_total: raw.dph_total.unwrap_or(0.0),
+        dph_base: raw.dph_base.unwrap_or(0.0),
         label: raw.label,
     })
 }
@@ -423,18 +433,22 @@ mod tests {
         let single = serde_json::json!({
             "id": 12345, "actual_status": "running", "gpu_name": "RTX 4090",
             "ssh_host": "ssh4.vast.ai", "ssh_port": 22222, "dph_total": 0.44,
-            "label": "modl-pod-train"
+            "dph_base": 0.40, "label": "modl-pod-train"
         });
         let inst = parse_instance(&single, 0).unwrap();
         assert_eq!(inst.id, 12345);
         assert_eq!(inst.ssh_port, Some(22222));
         assert_eq!(inst.actual_status, "running");
+        // Instances report dph_total ALL-IN; dph_base is the GPU-only rate.
+        assert!((inst.dph_total - 0.44).abs() < 1e-9);
+        assert!((inst.dph_base - 0.40).abs() < 1e-9);
 
         // Missing optional fields
         let sparse = serde_json::json!({"actual_status": "loading"});
         let inst = parse_instance(&sparse, 777).unwrap();
         assert_eq!(inst.id, 777);
         assert!(inst.ssh_host.is_none());
+        assert_eq!(inst.dph_base, 0.0);
     }
 
     fn offer_with(dph: f64, storage: f64, inet_down: f64, dlperf: f64) -> Offer {


### PR DESCRIPTION
Fixes the storage double-count found during the 2026-07-17 live smoke of #126/#128.

**The trap:** Vast's `dph_total` means different things per endpoint — on **offers** it's the GPU rate alone (storage is priced separately in $/GB/month since disk size isn't known at search time), but on **instances** it's all-in (`dph_base + storage`). Confirmed against the [instances API docs](https://docs.vast.ai/api-reference/instances/show-instances) and observed live: an offer quoted at $0.169 gpu reported $0.207 as a running instance.

`active_pod`'s reconcile refreshed `rec.dph_total` from the instances value, so after the first reconcile every `dph_all_in()` display (stale nag, `pod ls`, run epilogues) added the recorded storage rate on top of a figure that already contained it — the smoke's epilogue showed $0.247/hr against a true ~$0.209.

**Fix:** parse `dph_base` from the instances endpoint and refresh the record's GPU rate from that; when the API omits it, keep the rent-time offer rate instead of writing the all-in value. Documented the endpoint asymmetry on the `Instance` struct so the next reader doesn't re-trip on it.

Display-only bug (it over-reported, never under-reported); no billing behavior changes.

## Testing
- `parses_instance_shapes` extended: asserts `dph_base` parses and defaults to 0.0 when absent.
- 223 tests pass, clippy + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)