### PR TITLE
feat: size pod disk from the model instead of a flat constant

### DIFF
--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -456,7 +456,7 @@ fn tool_definitions() -> Value {
                     },
                     "disk": {
                         "type": "number",
-                        "description": "Disk to provision in GB (default 120 — fits the runtime env plus several fp8 models; storage bills hourly on the full amount, so go leaner for single-model sessions)"
+                        "description": "Disk to provision in GB. Omit to auto-size: 120 by default, raised from the `models` list when it names something bigger (e.g. flux2-dev → ~160). Storage bills hourly on the full amount, so only set this explicitly to go leaner for single-small-model sessions."
                     },
                     "models": {
                         "type": "array",

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -574,9 +574,10 @@ pub enum PodCommands {
         /// Max hourly price for offers (USD)
         #[arg(long, default_value_t = 3.0)]
         max_price: f64,
-        /// Disk to provision (GB) — persistent pods accumulate an HF cache
-        #[arg(long, default_value_t = 120.0)]
-        disk: f64,
+        /// Disk to provision (GB). Default 120, raised automatically when
+        /// --model names something bigger (sized from models.toml params)
+        #[arg(long)]
+        disk: Option<f64>,
         /// Minimum VRAM (GB) floor; required for "auto" (defaults to 24)
         #[arg(long)]
         min_vram: Option<u32>,

--- a/src/cli/pod.rs
+++ b/src/cli/pod.rs
@@ -110,7 +110,7 @@ pub async fn ls(json: bool) -> Result<()> {
 pub async fn up(
     gpu: String,
     max_price: f64,
-    disk: f64,
+    disk: Option<f64>,
     min_vram: Option<u32>,
     fresh: bool,
     models: Vec<String>,
@@ -170,6 +170,24 @@ pub async fn up(
             min_vram_gb.unwrap()
         );
     }
+
+    // Disk: explicit --disk wins; otherwise size to the --model pre-pull
+    // list so fat models (flux2-dev, qwen-image) fit, never below the
+    // persistent-pod floor.
+    let disk = disk.unwrap_or_else(|| {
+        let sized = pod::estimate_disk_gb(models.iter().map(String::as_str))
+            .unwrap_or(pod::POD_UP_DISK_GB)
+            .max(pod::POD_UP_DISK_GB);
+        if sized > pod::POD_UP_DISK_GB {
+            eprintln!(
+                "{} sizing disk to {:.0}GB for {} (override with --disk)",
+                style("→").cyan(),
+                sized,
+                models.join(", ")
+            );
+        }
+        sized
+    });
 
     let opts = PodOptions {
         gpu_type: gpu.clone(),

--- a/src/cli/train.rs
+++ b/src/cli/train.rs
@@ -47,11 +47,11 @@ pub struct PodArgs {
 }
 
 impl PodArgs {
-    fn into_options(self, label: String) -> crate::core::pod::PodOptions {
+    fn into_options(self, label: String, disk_gb: f64) -> crate::core::pod::PodOptions {
         crate::core::pod::PodOptions {
             gpu_type: self.gpu_type,
             max_price_per_hour: self.max_price,
-            disk_gb: crate::core::pod::POD_DISK_GB,
+            disk_gb,
             yes: self.yes,
             keep_pod: self.keep_pod,
             label,
@@ -131,7 +131,8 @@ async fn run_pod(spec: TrainJobSpec, args: PodArgs) -> Result<()> {
 
     // No active pod (or --fresh): today's one-shot behavior.
     let label = format!("modl-pod-{}", spec.output.lora_name);
-    pod::run_pod_training(spec, args.into_options(label)).await
+    let disk_gb = pod::disk_gb_for_train(&spec);
+    pod::run_pod_training(spec, args.into_options(label, disk_gb)).await
 }
 
 /// Best-effort VRAM (GB) for a Vast GPU name. `None` when the card is unknown

--- a/src/core/pod.rs
+++ b/src/core/pod.rs
@@ -38,9 +38,14 @@ const POD_RUNTIME_PROFILE: &str = "trainer-cu124";
 /// mirror `runtime_root()/envs/<profile>` and `runtime_root()/ai-toolkit`.
 const POD_RUNTIME_PY: &str = "/root/.modl/runtime/envs/trainer-cu124/bin/python";
 const POD_AITOOLKIT: &str = "/root/.modl/runtime/ai-toolkit";
-/// Default disk for one-shot train pods. `pod up` raises this (persistent
-/// pods accumulate an HF cache across jobs — that's the point).
+/// Disk floor for one-shot train pods. `pod up` raises this (persistent
+/// pods accumulate an HF cache across jobs — that's the point). Both are
+/// floors, not sizes: [`estimate_disk_gb`] raises them per-model so fat
+/// models (flux2-dev, qwen-image) don't fill the disk mid-download.
 pub const POD_DISK_GB: f64 = 80.0;
+/// Disk floor for persistent `pod up` pods — fits the runtime env plus
+/// several fp8 models.
+pub const POD_UP_DISK_GB: f64 = 120.0;
 /// Per-host boot budget without visible progress (status/status_msg frozen).
 /// Duds get destroyed and the next offer is tried, so this can be tight —
 /// good hosts come up in 1-3 minutes.
@@ -646,6 +651,14 @@ pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()
             }
         );
     }
+    if opts.disk_gb > POD_DISK_GB {
+        eprintln!(
+            "{} sizing disk to {:.0}GB for {}",
+            style("→").cyan(),
+            opts.disk_gb,
+            spec.model.base_model_id
+        );
+    }
 
     // Clock starts before provision so the billed boot minutes count toward
     // the estimate (an interactive confirm inflates it slightly — better a
@@ -703,6 +716,31 @@ pub async fn run_pod_training(spec: TrainJobSpec, opts: PodOptions) -> Result<()
     );
 
     result
+}
+
+/// Estimated disk (GB) a pod needs to hold `model_ids`, from models.toml
+/// param counts: bf16 weights are ~2 GB per billion params, times a margin
+/// for HF cache layout and training checkpoints, plus a flat base for the
+/// extracted image + runtime env. Ids that don't resolve to a base model
+/// (LoRAs, other registry items) contribute nothing — they're hundreds of
+/// MB, inside the margin. `None` when nothing resolves.
+pub fn estimate_disk_gb<'a>(model_ids: impl IntoIterator<Item = &'a str>) -> Option<f64> {
+    const BASE_GB: f64 = 50.0;
+    const WEIGHTS_MARGIN: f64 = 1.2;
+    let weights_gb: f64 = model_ids
+        .into_iter()
+        .filter_map(crate::core::model_family::find_model)
+        .map(|m| 2.0 * f64::from(m.total_b))
+        .sum();
+    (weights_gb > 0.0).then(|| (BASE_GB + WEIGHTS_MARGIN * weights_gb).ceil())
+}
+
+/// Disk to provision for a one-shot training pod: sized to the base model
+/// when it's known, never below the flat [`POD_DISK_GB`] floor.
+pub fn disk_gb_for_train(spec: &TrainJobSpec) -> f64 {
+    estimate_disk_gb([spec.model.base_model_id.as_str()])
+        .unwrap_or(POD_DISK_GB)
+        .max(POD_DISK_GB)
 }
 
 /// VRAM floor for a training job, from models.toml. Presets enable
@@ -1355,6 +1393,22 @@ mod tests {
         assert_eq!(back.ssh.host, "ssh5.vast.ai");
         assert_eq!(back.dph_total, 0.19);
         assert_eq!(back.dph_storage, 0.04);
+    }
+
+    #[test]
+    fn disk_estimate_scales_with_model_size() {
+        // flux2-dev is 46B total params → well above the flat floors.
+        let fat = estimate_disk_gb(["flux2-dev"]).unwrap();
+        assert!(fat > POD_UP_DISK_GB, "flux2-dev estimate {fat} too small");
+        // sdxl is tiny — the estimate itself sits below the train floor,
+        // callers clamp with .max(POD_DISK_GB).
+        let small = estimate_disk_gb(["sdxl"]).unwrap();
+        assert!(small < POD_DISK_GB);
+        // Unknown ids (LoRAs, registry items) resolve to nothing.
+        assert!(estimate_disk_gb(["my-custom-lora"]).is_none());
+        // A mixed list only counts the base models.
+        let mixed = estimate_disk_gb(["flux2-dev", "my-custom-lora"]).unwrap();
+        assert_eq!(mixed, fat);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Pod disk was hardcoded (`POD_DISK_GB = 80` for one-shot train pods, `--disk` default 120 for `pod up`). Fine for flux-dev-class models, but flux2-dev's bf16 repo alone is ~92GB of weights — the download fills the disk mid-provision and burns a whole provisioning cycle.

## Change

- **`core/pod.rs`**: new `estimate_disk_gb(model_ids)` beside `min_vram_for_train()`, same pattern — reads `total_b` from models.toml and computes `50GB base + 1.2 × (2GB per billion params)`. Ids that don't resolve to a base model (LoRAs, other registry items) contribute nothing — they're hundreds of MB, inside the margin. Plus `disk_gb_for_train(spec)` clamped to the existing 80GB floor.
- **`modl train --pod`**: one-shot pods are sized to the base model; prints `→ sizing disk to 161GB for flux2-dev` next to the existing VRAM line when raised above the floor.
- **`modl pod up`**: `--disk` is now `Option<f64>` — explicit value always wins; otherwise auto-sized from the `--model` pre-pull list with the 120GB floor.
- **MCP `pod_up`**: omitting `disk` gets auto-sizing; tool description updated so agent-driven flows do the right thing unchanged.

## Resulting sizes

| Model | Disk |
|-------|------|
| sdxl / sd-1.5 | floor (80 / 120) |
| flux-dev (17B) | 91GB |
| klein-9b (18B) | 94GB |
| qwen-image | ~117GB |
| flux2-dev (46B) | 161GB |

Deliberately generous: Vast storage bills pennies/hour, an out-of-disk failure mid-download costs a provisioning cycle.

## Not covered (follow-ups if they bite)

- The **reuse path** doesn't check the active pod's disk — pods.json doesn't record disk size, so a fat-model job reusing a lean warm pod still fails pod-side.
- `pod up auto --model flux2-dev` doesn't raise the **VRAM floor** from the model list the way it now raises disk.

## Testing

- New unit test `disk_estimate_scales_with_model_size` (fat model above floor, small model below, unknown ids → None, mixed list counts base models only).
- Full suite: 213 passed. clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)