### PR TITLE
chore: bump version to 0.2.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1521,7 +1521,7 @@ dependencies = [
 
 [[package]]
 name = "modl"
-version = "0.2.13"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modl"
-version = "0.2.13"
+version = "0.2.15"
 edition = "2024"
 description = "CLI model manager for the AI image generation ecosystem"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump for the v0.2.15 release (Krea 2 Turbo + diffusers 0.39 + fp8 TE + worker fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)