### PR TITLE
Promote offloaded pipelines to full GPU residency when they fit

### DIFF
--- a/python/modl_worker/adapters/gen_adapter.py
+++ b/python/modl_worker/adapters/gen_adapter.py
@@ -411,12 +411,28 @@ def run_generate_with_pipeline(
             result = pipe(**gen_kwargs)
             image = result.images[0]
         except Exception as exc:
-            emitter.error(
-                "GENERATION_FAILED",
-                f"Generation failed on image {i + 1}/{count}: {exc}",
-                recoverable=(i + 1 < count),
-            )
-            continue
+            # A resident-placed pipeline can OOM on denoise transients the
+            # placement estimate missed. Demote to cpu offload and retry the
+            # image once instead of failing the job.
+            from modl_worker.device import demote_pipe_to_offload
+            if demote_pipe_to_offload(pipe, exc, emitter):
+                try:
+                    result = pipe(**gen_kwargs)
+                    image = result.images[0]
+                except Exception as exc2:
+                    emitter.error(
+                        "GENERATION_FAILED",
+                        f"Generation failed on image {i + 1}/{count}: {exc2}",
+                        recoverable=(i + 1 < count),
+                    )
+                    continue
+            else:
+                emitter.error(
+                    "GENERATION_FAILED",
+                    f"Generation failed on image {i + 1}/{count}: {exc}",
+                    recoverable=(i + 1 < count),
+                )
+                continue
 
         elapsed = time.time() - t0
 

--- a/python/modl_worker/adapters/lora_utils.py
+++ b/python/modl_worker/adapters/lora_utils.py
@@ -155,8 +155,21 @@ def apply_lora_from_spec(pipeline, spec: dict, emitter) -> bool:
       - Missing file warning
       - Key conversion fallback via ``load_lora_with_conversion``
 
+    Afterwards — once LoRA / deferred-fp8 state is final and the pipeline's
+    true footprint is known — promotes the pipeline to full GPU residency
+    when it fits VRAM (skipped for ControlNet jobs, which need the offload
+    headroom for the ControlNet weights).
+
     Returns True if LoRA was applied, False otherwise.
     """
+    applied = _apply_lora_from_spec_inner(pipeline, spec, emitter)
+    if not spec.get("params", {}).get("controlnet"):
+        from modl_worker.device import rebalance_pipe_placement
+        rebalance_pipe_placement(pipeline, emitter)
+    return applied
+
+
+def _apply_lora_from_spec_inner(pipeline, spec: dict, emitter) -> bool:
     lora_info = spec.get("lora")
     if not lora_info:
         # No LoRA — apply deferred fp8 casting now (was deferred for LoRA compat)

--- a/python/modl_worker/device.py
+++ b/python/modl_worker/device.py
@@ -71,6 +71,91 @@ def move_pipe_to_device(pipe):
         pipe.to(dev)
 
 
+def _pipe_weight_bytes(pipe) -> int:
+    """Sum of parameter + buffer bytes across all pipeline components.
+
+    fp8-stored weights count 1 byte/element, so a layerwise-cast
+    transformer is sized at its actual GPU footprint.
+    """
+    total = 0
+    for name in getattr(pipe, "components", {}) or {}:
+        comp = getattr(pipe, name, None)
+        if comp is None or not hasattr(comp, "parameters"):
+            continue
+        for p in comp.parameters():
+            total += p.numel() * p.element_size()
+        for b in comp.buffers():
+            total += b.numel() * b.element_size()
+    return total
+
+
+def _has_accelerate_hooks(pipe) -> bool:
+    """True if any component carries an accelerate offload hook."""
+    for name in getattr(pipe, "components", {}) or {}:
+        comp = getattr(pipe, name, None)
+        if comp is not None and getattr(comp, "_hf_hook", None) is not None:
+            return True
+    return False
+
+
+# Headroom for activations, per-layer dtype-cast transients, VAE decode and
+# CUDA context when deciding whether a pipeline can live fully resident.
+# Calibrated on Krea 2 Turbo (fp8, 18.4GB weights): denoise transients
+# measured ~7GB over weights (~38%) — layerwise-cast bf16 compute buffers
+# dominate. 35% of weights with a 6GB floor keeps the decision honest.
+_RESIDENT_RESERVE_FLOOR_BYTES = 6 * 1024**3
+_RESIDENT_RESERVE_WEIGHT_FRACTION = 0.35
+
+
+def rebalance_pipe_placement(pipe, emitter=None) -> None:
+    """Promote an offloaded pipeline to full GPU residency when it fits.
+
+    ``enable_model_cpu_offload`` re-transfers weights CPU→GPU on every job —
+    for a stack that genuinely fits VRAM (SDXL, SD15, Klein 4B on a 24GB
+    card) that transfer is pure per-job overhead. Called after LoRA /
+    deferred-fp8 state is final, because the footprint before layerwise
+    casting (bf16) can be ~2x the end state.
+
+    No-op on non-CUDA devices, when the pipeline is already resident, when
+    the stack doesn't fit with reserve, or when MODL_FORCE_OFFLOAD=1.
+    """
+    if get_device() != "cuda":
+        return
+    if os.environ.get("MODL_FORCE_OFFLOAD") == "1":
+        return
+    if not _has_accelerate_hooks(pipe):
+        return  # already resident (or never offloaded)
+
+    weight_bytes = _pipe_weight_bytes(pipe)
+    free_bytes, _total = torch.cuda.mem_get_info()
+    reserve = max(
+        _RESIDENT_RESERVE_FLOOR_BYTES,
+        int(weight_bytes * _RESIDENT_RESERVE_WEIGHT_FRACTION),
+    )
+    needed = weight_bytes + reserve
+    if needed > free_bytes:
+        if emitter:
+            emitter.info(
+                f"  → Keeping cpu offload: {weight_bytes / 1024**3:.1f}GB weights "
+                f"+ {reserve / 1024**3:.1f}GB reserve > {free_bytes / 1024**3:.1f}GB free"
+            )
+        return
+
+    try:
+        pipe.remove_all_hooks()
+        pipe.to("cuda")
+        if emitter:
+            emitter.info(
+                f"  → Pipeline fits VRAM ({weight_bytes / 1024**3:.1f}GB weights) — "
+                f"running fully resident (no per-job offload transfers)"
+            )
+    except torch.cuda.OutOfMemoryError:
+        torch.cuda.empty_cache()
+        pipe.enable_model_cpu_offload()
+        if emitter:
+            emitter.info("  → Resident placement OOMed, reverting to cpu offload")
+
+
 def empty_cache():
     """Free GPU cache for the active device."""
     dev = get_device()

--- a/python/modl_worker/device.py
+++ b/python/modl_worker/device.py
@@ -100,11 +100,14 @@ def _has_accelerate_hooks(pipe) -> bool:
 
 # Headroom for activations, per-layer dtype-cast transients, VAE decode and
 # CUDA context when deciding whether a pipeline can live fully resident.
-# Calibrated on Krea 2 Turbo (fp8, 18.4GB weights): denoise transients
-# measured ~7GB over weights (~38%) — layerwise-cast bf16 compute buffers
-# dominate. 35% of weights with a 6GB floor keeps the decision honest.
-_RESIDENT_RESERVE_FLOOR_BYTES = 6 * 1024**3
-_RESIDENT_RESERVE_WEIGHT_FRACTION = 0.35
+# Calibrated on Krea 2 Turbo (fp8, 17.4GiB weights): denoise transients
+# measured ≥8GB over weights (layerwise-cast bf16 compute buffers dominate)
+# — and a borderline pass promoted it straight into an OOM. 50% of weights
+# with an 8GB floor plus a 5% free-VRAM margin keeps the decision solidly
+# conservative; a wrong promote is additionally self-healed at runtime by
+# ``demote_pipe_to_offload``.
+_RESIDENT_RESERVE_FLOOR_BYTES = 8 * 1024**3
+_RESIDENT_RESERVE_WEIGHT_FRACTION = 0.50
 
 
 def rebalance_pipe_placement(pipe, emitter=None) -> None:
@@ -133,7 +136,7 @@ def rebalance_pipe_placement(pipe, emitter=None) -> None:
         int(weight_bytes * _RESIDENT_RESERVE_WEIGHT_FRACTION),
     )
     needed = weight_bytes + reserve
-    if needed > free_bytes:
+    if needed > int(free_bytes * 0.95):
         if emitter:
             emitter.info(
                 f"  → Keeping cpu offload: {weight_bytes / 1024**3:.1f}GB weights "
@@ -154,6 +157,33 @@ def rebalance_pipe_placement(pipe, emitter=None) -> None:
         pipe.enable_model_cpu_offload()
         if emitter:
             emitter.info("  → Resident placement OOMed, reverting to cpu offload")
+
+
+def demote_pipe_to_offload(pipe, exc, emitter=None) -> bool:
+    """Demote a resident pipeline back to cpu offload after a CUDA OOM.
+
+    Runtime safety net for ``rebalance_pipe_placement``: if a promoted
+    pipeline OOMs on denoise transients the placement estimate missed,
+    re-enable offload so the job can retry instead of failing.
+
+    Returns True if a retry makes sense (the pipeline was resident and has
+    been demoted), False otherwise (not an OOM, or already offloaded).
+    """
+    if not isinstance(exc, torch.cuda.OutOfMemoryError):
+        return False
+    if get_device() != "cuda":
+        return False
+    if _has_accelerate_hooks(pipe):
+        return False  # already offloaded — a retry would just OOM again
+
+    torch.cuda.empty_cache()
+    pipe.enable_model_cpu_offload()
+    torch.cuda.empty_cache()
+    if emitter:
+        emitter.info(
+            "  → OOM while fully resident — demoted to cpu offload, retrying"
+        )
+    return True
 
 
 def empty_cache():


### PR DESCRIPTION
## Summary
- New `rebalance_pipe_placement` in `device.py`: after LoRA / deferred-fp8 state is final, promotes an offloaded pipeline to full `.to("cuda")` residency when weights + reserve fit free VRAM — eliminating the per-job CPU→GPU weight transfers that `enable_model_cpu_offload` incurs in the persistent worker.
- Single choke point: wired into `apply_lora_from_spec`, so the one-shot, daemon-cached, and edit paths all get it. Skipped for ControlNet jobs (they need the offload headroom); `MODL_FORCE_OFFLOAD=1` escape hatch.
- **Runtime self-healing**: `demote_pipe_to_offload` catches a CUDA OOM on a resident pipeline mid-generation, re-enables offload, and retries the image once — a wrong promote degrades to a slower job instead of a failed one.

## Calibration history (why the reserve is what it is)
1. First attempt: 4GB flat reserve → Krea 2 Turbo (17.4GiB fp8 stack) promoted and OOMed at denoise step 0 — its layerwise-cast bf16 compute transients are ≥8GB.
2. Second attempt: `max(6GB, 35%)` → still promoted on a borderline pass (won by ~hundreds of MB against free VRAM) and OOMed again.
3. Final: `max(8GB, 50% of weights)` + a 5% free-VRAM margin + the runtime demote-and-retry net. Krea on 24GB now declines solidly (needs 26.1GiB vs ~22.3 usable); SDXL/SD15/Klein-4B-class stacks promote.

## Who benefits
- 24GB cards: SDXL / SD15 / Klein-4B-class stacks skip per-job transfers in the daemon
- 32GB+ cards: Krea 2 / Qwen-class stacks will qualify automatically
- Krea 2 on 24GB: unchanged (offload kept) — the remaining gap there is fp8 matmul kernels, not placement

## Test plan (live on RTX 4090, results posted as comment when run completes)
- [x] Krea 2 Turbo regression: keeps offload, produces images, ~32s warm
- [x] SDXL: promotes to resident, produces images, warm-job speedup
- [x] Idle VRAM shows resident SDXL retained between jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)