### PR TITLE
fix: SD 1.5 inference quality — Euler scheduler + native-resolution size presets

### DIFF
--- a/python/modl_worker/configs/sd15-pipeline/model_index.json
+++ b/python/modl_worker/configs/sd15-pipeline/model_index.json
@@ -11,7 +11,7 @@
   ],
   "scheduler": [
     "diffusers",
-    "PNDMScheduler"
+    "EulerDiscreteScheduler"
   ],
   "text_encoder": [
     "transformers",

--- a/python/modl_worker/configs/sd15-pipeline/scheduler/scheduler_config.json
+++ b/python/modl_worker/configs/sd15-pipeline/scheduler/scheduler_config.json
@@ -1,13 +1,18 @@
 {
-  "_class_name": "PNDMScheduler",
-  "_diffusers_version": "0.6.0",
+  "_class_name": "EulerDiscreteScheduler",
+  "_diffusers_version": "0.19.0.dev0",
   "beta_end": 0.012,
   "beta_schedule": "scaled_linear",
   "beta_start": 0.00085,
+  "clip_sample": false,
+  "interpolation_type": "linear",
   "num_train_timesteps": 1000,
+  "prediction_type": "epsilon",
+  "sample_max_value": 1.0,
   "set_alpha_to_one": false,
   "skip_prk_steps": true,
   "steps_offset": 1,
+  "timestep_spacing": "leading",
   "trained_betas": null,
-  "clip_sample": false
+  "use_karras_sigmas": false
 }

--- a/src/cli/generate.rs
+++ b/src/cli/generate.rs
@@ -147,7 +147,8 @@ async fn run_on_pod(args: &GenerateArgs<'_>) -> Result<()> {
 
     let (width, height) = match args.size {
         Some(s) => {
-            let (w, h) = model_resolve::resolve_size(s)?;
+            let (w, h) =
+                model_resolve::resolve_size_for_model(s, model_family::default_resolution(model))?;
             (Some(w), Some(h))
         }
         None => (None, None),
@@ -389,14 +390,16 @@ async fn run_local(args: GenerateArgs<'_>, db: Database) -> Result<()> {
     let base_model_path = model_resolve::resolve_base_model_path(&base_model, &db);
 
     // -------------------------------------------------------------------
-    // Resolve size: explicit --size wins, otherwise use init-image dims
+    // Resolve size: explicit --size wins, otherwise use init-image dims.
+    // Presets scale to the model's native resolution (SD 1.5: 1:1 → 512).
     // -------------------------------------------------------------------
+    let native_resolution = model_family::default_resolution(&base_model);
     let (width, height) = if let Some(s) = size {
-        model_resolve::resolve_size(s)?
+        model_resolve::resolve_size_for_model(s, native_resolution)?
     } else if let Some(path) = init_image {
         image_dimensions(path)?
     } else {
-        model_resolve::resolve_size("1:1")?
+        model_resolve::resolve_size_for_model("1:1", native_resolution)?
     };
 
     // -------------------------------------------------------------------

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -975,7 +975,11 @@ pub async fn execute_plan(
         match &step.kind {
             StepKind::Generate(g) => {
                 let gen_inputs = resolve_generate_inputs(g, &step_outputs, &step.id)?;
-                print_generate_preview(g, sub_jobs.len());
+                print_generate_preview(
+                    g,
+                    sub_jobs.len(),
+                    model_family::default_resolution(effective_model_key),
+                );
                 for (sub_idx, (seed, count)) in sub_jobs.iter().enumerate() {
                     // Skip sub-jobs already in the completion index (default behaviour).
                     // Random-seed sub-jobs (seed == None) are never skipped.
@@ -1387,8 +1391,9 @@ fn print_plan_human(plan: &Plan, in_order: bool) {
 
         match &step.kind {
             StepKind::Generate(g) => {
-                let width = g.width.unwrap_or(1024);
-                let height = g.height.unwrap_or(1024);
+                let native = model_family::default_resolution(&planned.resolved_model.id);
+                let width = g.width.unwrap_or(native);
+                let height = g.height.unwrap_or(native);
                 let steps = g.steps.unwrap_or(default_steps);
                 let guidance = g.guidance.unwrap_or(default_guidance);
                 let seed_desc = if let Some(ref seeds) = g.seeds {
@@ -1501,8 +1506,12 @@ fn print_plan_json(plan: &Plan, in_order: bool) -> Result<()> {
                     seed: g.seed,
                     seeds: g.seeds.clone(),
                     effective: EffectiveJson {
-                        width: g.width.unwrap_or(1024),
-                        height: g.height.unwrap_or(1024),
+                        width: g.width.unwrap_or_else(|| {
+                            model_family::default_resolution(&planned.resolved_model.id)
+                        }),
+                        height: g.height.unwrap_or_else(|| {
+                            model_family::default_resolution(&planned.resolved_model.id)
+                        }),
                         steps: g.steps.unwrap_or(default_steps),
                         guidance: g.guidance.unwrap_or(default_guidance),
                         count: g.count.unwrap_or(1),
@@ -1803,8 +1812,9 @@ fn build_generate_spec(
         .guidance
         .or(lightning.map(|l| l.guidance))
         .unwrap_or(default_guidance);
-    let width = step.width.unwrap_or(1024);
-    let height = step.height.unwrap_or(1024);
+    let native_resolution = model_family::default_resolution(wf_model);
+    let width = step.width.unwrap_or(native_resolution);
+    let height = step.height.unwrap_or(native_resolution);
 
     GenerateJobSpec {
         prompt: step.prompt.clone(),
@@ -2121,10 +2131,10 @@ fn step_kind_label(kind: &StepKind) -> &'static str {
     }
 }
 
-fn print_generate_preview(step: &GenerateStep, sub_job_count: usize) {
+fn print_generate_preview(step: &GenerateStep, sub_job_count: usize, native_resolution: u32) {
     println!("  Prompt: {}", style(&step.prompt).italic());
-    let width = step.width.unwrap_or(1024);
-    let height = step.height.unwrap_or(1024);
+    let width = step.width.unwrap_or(native_resolution);
+    let height = step.height.unwrap_or(native_resolution);
     println!("  Size:   {}×{}", width, height);
     if let Some(ref seeds) = step.seeds {
         println!(

--- a/src/core/model_resolve.rs
+++ b/src/core/model_resolve.rs
@@ -78,6 +78,28 @@ pub const SIZE_PRESETS: &[(&str, u32, u32)] = &[
     ("3:4", 896, 1152),
 ];
 
+/// Resolve a size preset string to (width, height), scaled to a model's
+/// native resolution. Presets are defined at 1024-native; a 512-native model
+/// (SD 1.5) gets 1:1 → 512×512, 16:9 → 704×384, etc. Explicit WxH is used
+/// as-is — the user asked for those exact dimensions.
+pub fn resolve_size_for_model(size: &str, native_resolution: u32) -> Result<(u32, u32)> {
+    for &(name, w, h) in SIZE_PRESETS {
+        if size == name {
+            return Ok((
+                scale_to_native(w, native_resolution),
+                scale_to_native(h, native_resolution),
+            ));
+        }
+    }
+    resolve_size(size)
+}
+
+/// Scale a 1024-reference dimension to a model's native resolution,
+/// snapped to the nearest multiple of 64 (UNet/DiT dimension constraint).
+fn scale_to_native(dim: u32, native: u32) -> u32 {
+    (((dim * native / 1024) + 32) / 64).max(1) * 64
+}
+
 /// Resolve a size preset string to (width, height).
 pub fn resolve_size(size: &str) -> Result<(u32, u32)> {
     for &(name, w, h) in SIZE_PRESETS {

--- a/src/core/models.rs
+++ b/src/core/models.rs
@@ -483,6 +483,15 @@ pub fn model_defaults(model_id: &str) -> (u32, f32) {
     }
 }
 
+/// Native (default) resolution for a model, from models.toml.
+/// Models like SD 1.5 are 512-native — generating at 1024 distorts anatomy.
+pub fn default_resolution(model_id: &str) -> u32 {
+    match resolve_model(model_id) {
+        Some(m) => m.default_resolution,
+        None => 1024,
+    }
+}
+
 #[allow(dead_code)]
 pub fn models_with_capability(capability: &str) -> Vec<&'static ModelInfo> {
     PARSED


### PR DESCRIPTION
## Problem

sd-1.5 output looked broken ("doesn't work well"). Root cause was two stacked bugs:

1. **Ancient scheduler**: the bundled `configs/sd15-pipeline/` still shipped the original 2022 **PNDMScheduler**, while the sdxl bundle got Euler. Note `from_single_file` takes the scheduler *class* from `model_index.json`, so both it and `scheduler_config.json` are updated.

2. **Wrong default resolution (the bigger one)**: size presets are hardcoded at 1024-native and ignored `defaults.resolution` in models.toml. sd-1.5 is 512-native, so the default 1:1 preset generated at 1024×1024 → classic melted-anatomy / broken-composition output.

## Fix

- `configs/sd15-pipeline/`: PNDM → `EulerDiscreteScheduler` (matches sdxl bundle)
- `model_family::default_resolution(model_id)` — native res from models.toml
- `resolve_size_for_model(size, native)` — presets scale to the model's native resolution, snapped to ×64 (sd-1.5: 1:1 → 512×512, 16:9 → 704×384). Explicit `WxH` is used as-is.
- Wired into `modl generate` (local + `--pod`) and the four workflow `unwrap_or(1024)` fallbacks in `run.rs`, using the step's *effective* model so per-step overrides resolve correctly.

## Verification (RTX 4090, real generations)

Same prompt/seed A/B: at 1024×1024 sd-1.5 produces a tiny warped figure in a broken composition; at the new 512×512 default the image is fully coherent. 16:9 → 704×384 also verified. All 226 tests pass.

Caveat for reviewers reproducing this: the persistent worker daemon caches pipelines — restart it between scheduler-config A/Bs or both runs reuse the cached scheduler.

Known follow-up: the web UI's size presets may still send 1024 for sd-1.5 (not audited here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)