### PR TITLE
fix(cli): top-5 UX papercuts — usable output IDs, honest errors, run discovery, --json

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -67,7 +67,7 @@ pub async fn run(verify_hashes: bool, repair: bool) -> Result<()> {
             );
             println!(
                 "    Fix: {}",
-                style(format!("modl uninstall {} && modl install {}", m.id, m.id)).cyan()
+                style(format!("modl rm {} && modl pull {}", m.id, m.id)).cyan()
             );
             issues += 1;
             store_ok = false;
@@ -173,8 +173,7 @@ pub async fn run(verify_hashes: bool, repair: bool) -> Result<()> {
                         );
                         println!(
                             "    Fix: {}",
-                            style(format!("modl uninstall {} && modl install {}", m.id, m.id))
-                                .cyan()
+                            style(format!("modl rm {} && modl pull {}", m.id, m.id)).cyan()
                         );
                         hash_issues += 1;
                     }

--- a/src/cli/info.rs
+++ b/src/cli/info.rs
@@ -23,7 +23,7 @@ pub async fn run(id: &str) -> Result<()> {
     }
 
     // 3. Trained LoRA artifact.
-    show_trained_artifact(&db, id)
+    show_trained_artifact(&db, id, &index)
 }
 
 fn show_registry_model(
@@ -452,12 +452,26 @@ fn show_installed_model(model: &crate::core::db::InstalledModel) -> Result<()> {
     Ok(())
 }
 
-fn show_trained_artifact(db: &Database, query: &str) -> Result<()> {
+fn show_trained_artifact(db: &Database, query: &str, index: &RegistryIndex) -> Result<()> {
     let artifact = db.find_artifact(query)?.ok_or_else(|| {
-        anyhow::anyhow!(
-            "'{}' not found in registry or trained outputs. Run `modl system update` first?",
-            query
-        )
+        let suggestions = index.suggest(query, 5);
+        if suggestions.is_empty() {
+            anyhow::anyhow!(
+                "'{}' not found in registry or trained outputs. \
+                 If it was added recently, try `modl system update`.",
+                query
+            )
+        } else {
+            let list: Vec<String> = suggestions
+                .iter()
+                .map(|m| format!("  {} — {}", m.id, m.name))
+                .collect();
+            anyhow::anyhow!(
+                "'{}' not found in registry or trained outputs. Did you mean:\n\n{}",
+                query,
+                list.join("\n")
+            )
+        }
     })?;
 
     // Parse metadata JSON

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -42,7 +42,7 @@ const INTERNAL_TYPES: &[&str] = &[
     "ipadapter",
 ];
 
-pub async fn run(type_filter: Option<AssetType>, show_all: bool) -> Result<()> {
+pub async fn run(type_filter: Option<AssetType>, show_all: bool, json: bool) -> Result<()> {
     let db = Database::open()?;
 
     // Sync any store entries not yet in the local DB from the shared index.yaml.
@@ -51,6 +51,15 @@ pub async fn run(type_filter: Option<AssetType>, show_all: bool) -> Result<()> {
     let n = reconcile::reconcile_from_index(&db)
         .or_else(|_| reconcile::reconcile_store(&db))
         .unwrap_or(0);
+    if json {
+        let filter_str = type_filter.as_ref().map(|t| t.to_string());
+        let mut models = db.list_installed(filter_str.as_deref())?;
+        if !show_all && type_filter.is_none() {
+            models.retain(|m| !INTERNAL_TYPES.contains(&m.asset_type.as_str()));
+        }
+        println!("{}", serde_json::to_string_pretty(&models)?);
+        return Ok(());
+    }
     if n > 0 {
         println!(
             "  {} Auto-registered {} model{} found on disk",
@@ -71,7 +80,7 @@ pub async fn run(type_filter: Option<AssetType>, show_all: bool) -> Result<()> {
             println!("No models installed yet.");
             println!(
                 "  Run {} to get started.",
-                style("modl install flux-dev").cyan()
+                style("modl pull flux-dev").cyan()
             );
         }
         return Ok(());

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -955,7 +955,7 @@ pub enum Commands {
 
     // ── Model Management ─────────────────────────────────────────────
     /// Download models from registry, HuggingFace (hf:), CivitAI (civitai:), or hub (user/slug)
-    #[command(after_help = MODEL_PULL_EXAMPLES)]
+    #[command(after_help = MODEL_PULL_EXAMPLES, alias = "install")]
     Pull {
         /// Registry ID (e.g. flux-dev) or HuggingFace repo (hf:owner/model)
         id: String,
@@ -1041,9 +1041,13 @@ pub enum Commands {
         /// Show all items including internal dependencies (VAEs, text encoders, etc.)
         #[arg(long, short = 'a')]
         all: bool,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
 
     /// Remove an installed model
+    #[command(alias = "uninstall")]
     Rm {
         /// Model ID to remove
         id: String,
@@ -1298,8 +1302,9 @@ See `modl/docs/guides/workflows.md` for the full reference.")]
     ///   modl status 20240101-120000-my-workflow
     ///   MODL_BASE_URL=http://server:3939 modl status <run-id> --json
     Status {
-        /// Workflow run ID (from `modl run` output or MCP run_workflow response)
-        run_id: String,
+        /// Workflow run ID (from `modl run` output or MCP run_workflow
+        /// response). Omit to list recent runs.
+        run_id: Option<String>,
         /// Emit machine-readable JSON
         #[arg(long)]
         json: bool,
@@ -1611,11 +1616,12 @@ pub async fn run(cli: Cli) -> Result<()> {
             r#type,
             summary,
             all,
+            json,
         } => {
             if summary {
                 space::run(all).await
             } else {
-                list::run(r#type, all).await
+                list::run(r#type, all, json).await
             }
         }
         Commands::Rm { id, force } => uninstall::run(&id, force).await,
@@ -1741,7 +1747,9 @@ pub async fn run(cli: Cli) -> Result<()> {
             )
             .await
         }
-        Commands::Status { run_id, json, pod } => run_status::run(&run_id, json, pod).await,
+        Commands::Status { run_id, json, pod } => {
+            run_status::run(run_id.as_deref(), json, pod).await
+        }
 
         // ── Hidden ───────────────────────────────────────────────────
         Commands::Init { defaults, root } => init::run(defaults, root.as_deref()).await,

--- a/src/cli/outputs.rs
+++ b/src/cli/outputs.rs
@@ -20,6 +20,9 @@ pub enum OutputCommands {
         /// Show only favorited outputs
         #[arg(long, short = 'f')]
         favorites: bool,
+        /// Emit machine-readable JSON
+        #[arg(long)]
+        json: bool,
     },
     /// Show full metadata for an output (prompt, seed, model, params)
     Show {
@@ -90,7 +93,8 @@ pub async fn run(command: OutputCommands) -> Result<()> {
             limit,
             kind,
             favorites,
-        } => run_list(limit, kind.as_deref(), favorites).await,
+            json,
+        } => run_list(limit, kind.as_deref(), favorites, json).await,
         OutputCommands::Show { id } => run_show(&id).await,
         OutputCommands::Open { id } => run_open(&id).await,
         OutputCommands::Search { query, limit } => run_search(&query, limit).await,
@@ -126,13 +130,22 @@ fn run_reconcile() -> Result<()> {
 // List
 // ---------------------------------------------------------------------------
 
-async fn run_list(limit: usize, kind_filter: Option<&str>, favorites_only: bool) -> Result<()> {
+async fn run_list(
+    limit: usize,
+    kind_filter: Option<&str>,
+    favorites_only: bool,
+    json: bool,
+) -> Result<()> {
     let db = Database::open()?;
     let artifacts = db.list_artifacts(None)?;
     // Single query used both for the ⭐ column and the --favorites filter.
     let all_favorites = db.get_favorite_paths()?;
 
     if artifacts.is_empty() {
+        if json {
+            println!("[]");
+            return Ok(());
+        }
         println!("No outputs yet.");
         println!(
             "  Run {} to generate images.",
@@ -158,6 +171,26 @@ async fn run_list(limit: usize, kind_filter: Option<&str>, favorites_only: bool)
         .take(limit)
         .collect();
 
+    if json {
+        let out: Vec<serde_json::Value> = filtered
+            .iter()
+            .map(|artifact| {
+                let summary = artifact_summary(artifact, &db);
+                serde_json::json!({
+                    "id": artifact.artifact_id,
+                    "kind": artifact.kind,
+                    "prompt": summary.prompt_or_name,
+                    "model": summary.model,
+                    "path": artifact.path,
+                    "favorite": all_favorites.contains(&artifact.path),
+                    "created_at": artifact.created_at,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
     if filtered.is_empty() {
         if let Some(k) = kind_filter {
             println!("No outputs of kind '{k}'.");
@@ -178,7 +211,7 @@ async fn run_list(limit: usize, kind_filter: Option<&str>, favorites_only: bool)
     ]);
 
     for artifact in &filtered {
-        let short_id = short_id(&artifact.artifact_id);
+        let short_id = &artifact.artifact_id;
         let summary = artifact_summary(artifact, &db);
         let star = if all_favorites.contains(&artifact.path) {
             "⭐"
@@ -187,7 +220,7 @@ async fn run_list(limit: usize, kind_filter: Option<&str>, favorites_only: bool)
         };
 
         table.add_row(vec![
-            Cell::new(&short_id).fg(Color::Yellow),
+            Cell::new(short_id).fg(Color::Yellow),
             Cell::new(star).fg(Color::Yellow),
             Cell::new(&artifact.kind),
             Cell::new(truncate(&summary.prompt_or_name, 50)),
@@ -455,9 +488,9 @@ async fn run_search(query: &str, limit: usize) -> Result<()> {
     ]);
 
     for (artifact, prompt) in &matching_artifacts {
-        let short = short_id(&artifact.artifact_id);
+        let short = &artifact.artifact_id;
         table.add_row(vec![
-            Cell::new(&short).fg(Color::Yellow),
+            Cell::new(short).fg(Color::Yellow),
             Cell::new(&artifact.kind),
             Cell::new(truncate(prompt, 40)),
             Cell::new(truncate(&artifact.path, 40)),
@@ -484,7 +517,7 @@ async fn run_fav(id: &str, favorited: bool) -> Result<()> {
     let artifact = output_service::find_artifact_by_prefix(id, &db)?;
     let changed = output_service::set_favorite(&artifact.path, favorited)?;
 
-    let short = short_id(&artifact.artifact_id);
+    let short = &artifact.artifact_id;
     if favorited {
         if changed {
             println!(
@@ -523,7 +556,7 @@ async fn run_fav(id: &str, favorited: bool) -> Result<()> {
 async fn run_rm(id: &str, force: bool) -> Result<()> {
     let db = Database::open()?;
     let artifact = output_service::find_artifact_by_prefix(id, &db)?;
-    let short = short_id(&artifact.artifact_id);
+    let short = &artifact.artifact_id;
 
     let path = std::path::Path::new(&artifact.path);
     let filename = path
@@ -682,15 +715,6 @@ async fn run_export(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Return the first 8 chars of an ID for display.
-fn short_id(id: &str) -> String {
-    if id.len() > 12 {
-        id[..12].to_string()
-    } else {
-        id.to_string()
-    }
-}
 
 /// Truncate a string for table display.
 fn truncate(s: &str, max: usize) -> String {

--- a/src/cli/run_status.rs
+++ b/src/cli/run_status.rs
@@ -3,7 +3,10 @@ use console::style;
 
 use crate::core::db::Database;
 
-pub async fn run(run_id: &str, json: bool, pod: bool) -> Result<()> {
+pub async fn run(run_id: Option<&str>, json: bool, pod: bool) -> Result<()> {
+    let Some(run_id) = run_id else {
+        return list_recent_runs(json);
+    };
     if pod {
         return run_on_pod(run_id, json).await;
     }
@@ -140,6 +143,80 @@ pub async fn run(run_id: &str, json: bool, pod: bool) -> Result<()> {
         );
     }
 
+    Ok(())
+}
+
+/// No-arg `modl status` — list recent workflow runs so run IDs are
+/// discoverable without spelunking `~/.modl/run-logs/`.
+fn list_recent_runs(json: bool) -> Result<()> {
+    let db = Database::open()?;
+    let runs = db.list_recent_runs(20)?;
+
+    if runs.is_empty() {
+        if json {
+            println!("[]");
+        } else {
+            println!("No workflow runs yet. Start one with: modl run <workflow.yaml>");
+        }
+        return Ok(());
+    }
+
+    let aggregate = |r: &crate::core::db::RunSummary| -> &'static str {
+        let is_terminal = r.running == 0 && r.completed + r.failed + r.cancelled == r.total;
+        if r.failed > 0 && is_terminal {
+            "partial_failure"
+        } else if r.running > 0 {
+            "running"
+        } else if r.completed == r.total {
+            "completed"
+        } else if r.cancelled > 0 && is_terminal {
+            "cancelled"
+        } else {
+            "pending"
+        }
+    };
+
+    if json {
+        let out: Vec<serde_json::Value> = runs
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "run_id": r.run_id,
+                    "status": aggregate(r),
+                    "steps": { "total": r.total, "completed": r.completed,
+                               "failed": r.failed, "running": r.running,
+                               "cancelled": r.cancelled },
+                    "started_at": r.started_at,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&out)?);
+        return Ok(());
+    }
+
+    println!("Recent workflow runs:\n");
+    for r in &runs {
+        let status = aggregate(r);
+        let status_styled = match status {
+            "completed" => style(status).green(),
+            "running" => style(status).cyan(),
+            "partial_failure" | "cancelled" => style(status).red(),
+            _ => style(status).yellow(),
+        };
+        println!(
+            "  {}  {:<16} {}/{} steps  {}",
+            style(&r.run_id).bold(),
+            status_styled,
+            r.completed,
+            r.total,
+            style(&r.started_at).dim()
+        );
+    }
+    println!(
+        "\n  {} runs shown. Use {} for details.",
+        runs.len(),
+        style("modl status <run-id>").cyan()
+    );
     Ok(())
 }
 

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -16,7 +16,17 @@ pub async fn run(id: &str, force: bool) -> Result<()> {
     }
 
     if !db.is_installed(id)? {
-        anyhow::bail!("'{}' is not installed.", id);
+        let installed = db.list_installed(None)?;
+        let suggestions =
+            crate::core::registry::suggest_from_ids(id, installed.iter().map(|m| m.id.as_str()), 5);
+        if suggestions.is_empty() {
+            anyhow::bail!("'{}' is not installed. See installed models: modl ls", id);
+        }
+        anyhow::bail!(
+            "'{}' is not installed. Did you mean:\n\n  {}",
+            id,
+            suggestions.join("\n  ")
+        );
     }
 
     // Check for dependents (items that depend on this one)

--- a/src/core/db/jobs.rs
+++ b/src/core/db/jobs.rs
@@ -189,6 +189,38 @@ impl Database {
             .context("Failed to collect job results")
     }
 
+    /// Summarize recent workflow runs (newest first): per-run step counts by
+    /// status, for the no-arg `modl status` listing.
+    pub fn list_recent_runs(&self, limit: usize) -> Result<Vec<RunSummary>> {
+        let mut stmt = self
+            .conn
+            .prepare(
+                "SELECT workflow_run_id, COUNT(*), \
+                        SUM(status = 'completed'), SUM(status = 'error'), \
+                        SUM(status = 'running'), SUM(status = 'cancelled'), \
+                        MIN(created_at) \
+                 FROM jobs WHERE workflow_run_id IS NOT NULL \
+                 GROUP BY workflow_run_id \
+                 ORDER BY MIN(created_at) DESC LIMIT ?1",
+            )
+            .context("Failed to prepare recent-runs query")?;
+        let rows = stmt
+            .query_map(params![limit as i64], |row| {
+                Ok(RunSummary {
+                    run_id: row.get(0)?,
+                    total: row.get::<_, i64>(1)? as usize,
+                    completed: row.get::<_, i64>(2)? as usize,
+                    failed: row.get::<_, i64>(3)? as usize,
+                    running: row.get::<_, i64>(4)? as usize,
+                    cancelled: row.get::<_, i64>(5)? as usize,
+                    started_at: row.get(6)?,
+                })
+            })
+            .context("Failed to query recent runs")?;
+        rows.collect::<std::result::Result<Vec<_>, _>>()
+            .context("Failed to collect recent runs")
+    }
+
     /// Count total jobs in the database.
     pub fn count_jobs(&self) -> Result<usize> {
         let count: i64 = self
@@ -208,6 +240,18 @@ impl Database {
             .context("Failed to insert job event")?;
         Ok(())
     }
+}
+
+/// Aggregate summary of one workflow run, from `list_recent_runs`.
+#[derive(Debug, Clone)]
+pub struct RunSummary {
+    pub run_id: String,
+    pub total: usize,
+    pub completed: usize,
+    pub failed: usize,
+    pub running: usize,
+    pub cancelled: usize,
+    pub started_at: String,
 }
 
 #[derive(Debug)]

--- a/src/core/db/mod.rs
+++ b/src/core/db/mod.rs
@@ -7,7 +7,7 @@ mod sessions;
 mod training_queue;
 
 pub use artifacts::ArtifactRecord;
-pub use jobs::JobRecord;
+pub use jobs::{JobRecord, RunSummary};
 pub use lora_library::LibraryLoraRecord;
 pub use models::{InstalledModel, InstalledModelRecord};
 

--- a/src/core/db/models.rs
+++ b/src/core/db/models.rs
@@ -149,7 +149,7 @@ pub struct InstalledModelRecord<'a> {
     pub store_path: &'a str,
 }
 
-#[derive(Debug)]
+#[derive(Debug, serde::Serialize)]
 pub struct InstalledModel {
     pub id: String,
     pub name: String,

--- a/src/core/outputs.rs
+++ b/src/core/outputs.rs
@@ -806,19 +806,18 @@ pub fn find_artifact_by_prefix(prefix: &str, db: &Database) -> Result<ArtifactRe
         0 => bail!("No output found matching '{prefix}'."),
         1 => Ok(matches.into_iter().next().unwrap()),
         n => {
-            let ids: Vec<_> = matches
-                .iter()
-                .map(|a| {
-                    if a.artifact_id.len() > 12 {
-                        a.artifact_id[..12].to_string()
-                    } else {
-                        a.artifact_id.clone()
-                    }
-                })
-                .collect();
+            let mut ids: Vec<_> = matches.iter().map(|a| a.artifact_id.clone()).collect();
+            ids.sort();
+            ids.dedup();
+            let shown = ids.len().min(10);
+            let more = if ids.len() > shown {
+                format!(" (+{} more)", ids.len() - shown)
+            } else {
+                String::new()
+            };
             bail!(
-                "Ambiguous ID '{prefix}' matches {n} outputs: {}. Be more specific.",
-                ids.join(", ")
+                "Ambiguous ID '{prefix}' matches {n} outputs:\n  {}{more}",
+                ids[..shown].join("\n  ")
             );
         }
     }

--- a/src/core/preflight.rs
+++ b/src/core/preflight.rs
@@ -66,15 +66,49 @@ pub fn check_base_model(base_model_id: &str) -> Result<()> {
         return Ok(());
     }
 
+    // Known model (registry or models.toml) that simply isn't installed →
+    // suggest pulling it. Unknown id → it's a typo; suggest close matches
+    // instead of a pull command that would also fail.
+    let known = model_family::resolve_model(base_model_id).is_some()
+        || crate::core::registry::RegistryIndex::load()
+            .map(|i| i.find(base_model_id).is_some())
+            .unwrap_or(false);
+    if known {
+        bail!(
+            "Base model '{}' is not installed.\n\n\
+             Pull it first:\n\n  \
+             modl pull {}\n\n\
+             Or see available models:\n\n  \
+             modl search \"{}\"",
+            base_model_id,
+            base_model_id,
+            base_model_id.split('-').next().unwrap_or(base_model_id)
+        );
+    }
+
+    let mut candidates: Vec<String> = crate::core::registry::RegistryIndex::load()
+        .map(|i| i.items.iter().map(|m| m.id.clone()).collect())
+        .unwrap_or_default();
+    candidates.extend(db.list_installed(None)?.into_iter().map(|m| m.id));
+    let suggestions = crate::core::registry::suggest_from_ids(
+        base_model_id,
+        candidates.iter().map(|s| s.as_str()),
+        5,
+    );
+    if suggestions.is_empty() {
+        bail!(
+            "'{}' is not a known model id.\n\n  \
+             See installed models: modl ls\n  \
+             Search the registry:  modl search \"{}\"",
+            base_model_id,
+            base_model_id
+        );
+    }
     bail!(
-        "Base model '{}' is not installed.\n\n\
-         Pull it first:\n\n  \
-         modl pull {}\n\n\
-         Or see available models:\n\n  \
-         modl search \"{}\"",
+        "'{}' is not a known model id. Did you mean:\n\n  {}\n\n  \
+         See installed models: modl ls",
         base_model_id,
-        base_model_id,
-        base_model_id.split('-').next().unwrap_or(base_model_id)
+        suggestions.join("\n  ")
     )
 }
 

--- a/src/core/registry.rs
+++ b/src/core/registry.rs
@@ -214,6 +214,32 @@ impl RegistryIndex {
     }
 }
 
+/// Suggest the closest matches to `query` from arbitrary candidate ids —
+/// same matching rules as `RegistryIndex::suggest` (substring first, then
+/// edit distance). Used for did-you-mean hints on `info`, `rm`, and
+/// generate/edit base-model resolution.
+pub fn suggest_from_ids<'a, I>(query: &str, ids: I, max: usize) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    let q = query.to_lowercase();
+    let mut candidates: Vec<(String, usize)> = ids
+        .into_iter()
+        .filter_map(|id| {
+            let lower = id.to_lowercase();
+            let dist = edit_distance(&q, &lower);
+            if lower.contains(&q) || q.contains(&lower) || dist <= q.len().max(3) / 2 {
+                Some((id.to_string(), dist))
+            } else {
+                None
+            }
+        })
+        .collect();
+    candidates.sort_by(|a, b| (a.1, &a.0).cmp(&(b.1, &b.0)));
+    candidates.dedup_by(|a, b| a.0 == b.0);
+    candidates.into_iter().take(max).map(|(id, _)| id).collect()
+}
+
 /// Simple Levenshtein edit distance for typo suggestions.
 fn edit_distance(a: &str, b: &str) -> usize {
     let a_len = a.len();


### PR DESCRIPTION
Five fixes from a systematic CLI UX review (misuse probes + help-surface audit):

## 1. `outputs ls` IDs were unusable
IDs truncated to 12 chars showed only the date — every row read `gen-20260717`, and following the table's own hint (`modl outputs show <id>`) errored with an ambiguity list of identical truncated IDs. Tables now show full IDs; the ambiguity error lists distinct full IDs (capped at 10).

## 2. Errors referenced commands that don't exist
`modl doctor`'s fix hint said `modl uninstall X && modl install X` — both renamed long ago; copy-pasting the tool's own advice failed. Now `rm`/`pull`, plus hidden `install`/`uninstall` aliases.

## 3. Did-you-mean everywhere, not just `pull`
New `registry::suggest_from_ids` helper (same substring + edit-distance rules as `RegistryIndex::suggest`) wired into:
- `modl info flux-schnel` → suggests `flux-schnell` (was: "Run modl system update first?")
- `modl rm qwen-imge` → suggests `qwen-image` from installed models
- generate/edit preflight → distinguishes known-but-not-installed ("Pull it first: …") from unknown id; previously it suggested `modl pull bogus-model`, guaranteeing a second failure

## 4. No-arg `modl status` lists recent runs
Run IDs were undiscoverable after losing scrollback (fire-and-forget MCP runs). `modl status` now lists the 20 most recent workflow runs with aggregate status via a group-by on the indexed `workflow_run_id` column. Supports `--json`.

## 5. `--json` for scripting
Added to `modl ls` and `modl outputs ls` — the two primary listings were table-only while everything else had `--json`.

All error paths exercised against real data; 226 tests pass; CLI reference regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)