### PR TITLE
chore: bump version to 0.2.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "modl"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "modl"
-version = "0.2.15"
+version = "0.2.16"
 edition = "2024"
 description = "CLI model manager for the AI image generation ecosystem"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Version bump for the v0.2.16 release — 9 commits since v0.2.15, headlined by Krea 2 Raw with LoRA training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)