### PR TITLE
fix: surface two silently-dropped configs

### DIFF
--- a/skills/modl/SKILL.md
+++ b/skills/modl/SKILL.md
@@ -535,7 +535,9 @@ modl run <SPEC.yaml>                    # execute
 modl run a.yaml b.yaml c.yaml           # sequential multi-spec
 modl run spec.yaml --dry-run            # validate + show plan, no execution
 modl run spec.yaml --dry-run --json     # machine-readable plan
-modl run spec.yaml --skip-existing      # resume — skip already-generated sub-jobs
+modl run spec.yaml                      # resume by default — sub-jobs whose
+                                        # (prompt, seed, model) already exist are skipped
+modl run spec.yaml --force              # regenerate everything, ignoring prior outputs
 ```
 
 **YAML format** (flat fields — `generate:` takes the prompt directly; `edit:` takes the image ref with a separate `prompt:`):
@@ -703,7 +705,7 @@ modl run batch.yaml --dry-run
 # 2. Execute — returns a run_id; the run is tracked in SQLite
 modl run batch.yaml
 
-# 3. Check later (survives disconnects; resume partial runs with --skip-existing)
+# 3. Check later (survives disconnects; re-running the spec resumes by default)
 modl status <run-id> --json
 
 # 4. Collect artifacts

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -298,10 +298,21 @@ impl LocalExecutor {
 
         let sock_path = crate::core::paths::modl_root().join("worker.sock");
 
-        // Try to connect — if socket doesn't exist or daemon isn't running, return None
+        // Try to connect — if socket doesn't exist or daemon isn't running, return None.
+        // Hint once per process: without the daemon every job reloads the model from
+        // scratch, which is silent and easy to pay for indefinitely without noticing.
         let mut stream = match UnixStream::connect(&sock_path) {
             Ok(s) => s,
-            Err(_) => return Ok(None),
+            Err(_) => {
+                static HINTED: std::sync::Once = std::sync::Once::new();
+                HINTED.call_once(|| {
+                    eprintln!(
+                        "  i No persistent worker — each job reloads the model. \
+                         Start one with `modl worker start` to keep it in VRAM."
+                    );
+                });
+                return Ok(None);
+            }
         };
 
         // Build the request envelope

--- a/src/core/workflow.rs
+++ b/src/core/workflow.rs
@@ -191,6 +191,12 @@ struct RawWorkflow {
 
 #[derive(Debug, Default, Deserialize)]
 struct StepDefaults {
+    /// Any key that isn't a recognized default. Captured rather than silently
+    /// dropped so `parse` can warn — a typo'd or step-only key here (notably
+    /// `seeds:`, which is step-level and has no `defaults` equivalent) would
+    /// otherwise change nothing and produce a quietly wrong run.
+    #[serde(flatten)]
+    unknown: HashMap<String, serde_yaml::Value>,
     #[serde(default)]
     seed: Option<u64>,
     #[serde(default)]
@@ -303,6 +309,19 @@ pub fn parse_file(path: &Path) -> Result<Workflow> {
 
 pub fn parse_str(yaml: &str, base_dir: &Path) -> Result<Workflow> {
     let raw: RawWorkflow = serde_yaml::from_str(yaml).context("Failed to parse workflow YAML")?;
+
+    // Unrecognized keys under `defaults:` are inert. Warn rather than ignore:
+    // a silently dropped key produces a run that looks correct and isn't.
+    for key in raw.defaults.unknown.keys() {
+        if key == "seeds" {
+            eprintln!(
+                "  ! `seeds` is not a workflow default — it is only valid on a step, \
+                 and was ignored here. Move `seeds: [...]` onto each step."
+            );
+        } else {
+            eprintln!("  ! unknown key `{key}` under `defaults:` — ignored");
+        }
+    }
 
     if raw.name.trim().is_empty() {
         bail!("workflow `name` is required");
@@ -838,6 +857,33 @@ steps:
         assert_eq!(wf.steps[0].id, "a");
         match &wf.steps[0].kind {
             StepKind::Generate(g) => assert_eq!(g.prompt, "a cat"),
+            _ => panic!("expected generate"),
+        }
+    }
+
+    /// `seeds:` is step-level only. Under `defaults:` it is inert — serde used to
+    /// drop it silently, so a 3-seed batch quietly produced 1 image per step. The
+    /// key is now captured (and warned about at parse time) instead of vanishing.
+    #[test]
+    fn unknown_defaults_keys_are_captured_not_dropped() {
+        let yaml = r#"
+name: test
+model: flux-dev
+defaults:
+  seeds: [7, 42, 1234]
+  typo_key: 1
+steps:
+  - id: a
+    generate: "a cat"
+"#;
+        let wf = parse(yaml).unwrap();
+        // Still parses, and the step is unaffected by the inert key.
+        assert_eq!(wf.steps.len(), 1);
+        match &wf.steps[0].kind {
+            StepKind::Generate(g) => assert!(
+                g.seeds.is_none(),
+                "`seeds:` under defaults is inert — it must not reach the step"
+            ),
             _ => panic!("expected generate"),
         }
     }


### PR DESCRIPTION
Two bugs found while running a 36-image prompt experiment today. They share a failure mode: the config looks accepted, nothing errors, and the run is quietly not what was asked for. That's the worst kind of bug for batch work — you only find out by auditing output counts.

## 1. `seeds:` under `defaults:` was silently discarded

`StepDefaults` has `seed` (singular) and no `deny_unknown_fields`, so serde dropped `seeds:` without complaint.

```yaml
defaults:
  seeds: [7, 42, 1234]   # ignored — 1 image per step, not 3
```

I hit this designing a seed-replication run. It only surfaced because I happened to `--dry-run` first and noticed `count=1`. Had I not, I'd have drawn conclusions from a third of the intended data.

Unknown keys are now captured via `#[serde(flatten)]` and warned at parse time, with a specific hint for `seeds` since it's step-level only:

```
! `seeds` is not a workflow default — it is only valid on a step, and was ignored here.
  Move `seeds: [...]` onto each step.
! unknown key `bogus` under `defaults:` — ignored
```

Warn rather than `deny_unknown_fields` so existing workflows carrying stray keys keep running. This catches every future typo under `defaults:`, not just this one.

## 2. Missing persistent worker was invisible

`try_submit_via_socket` swallowed the connect error and fell back to one-shot mode. Without a running daemon every job reloads the model from scratch — indefinitely, with no indication. Every run I did today paid this, and I only noticed by reading `executor.rs`.

Now hints once per process:

```
i No persistent worker — each job reloads the model.
  Start one with `modl worker start` to keep it in VRAM.
```

Not auto-started: that's a bigger decision about VRAM ownership and belongs in its own change.

## 3. Docs: `--skip-existing` doesn't exist

`skills/modl/SKILL.md` documented a flag that was never implemented. Skipping already-generated sub-jobs is the **default**; `--force` opts out. (The same error is in the org-level CLAUDE.md, which isn't in this repo — fixed separately.)

## Testing

- 232 tests pass (231 + 1 new regression test pinning the inert-`seeds` behaviour)
- Both warnings verified firing against a real workflow
- `cargo fmt` + `clippy` clean via pre-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)