### PR TITLE
feat: distribute the Claude Code skill via install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ cargo build --release
 # Binary at target/release/modl
 ```
 
+### Claude Code skill
+
+modl ships a [Claude Code](https://claude.com/claude-code) skill so an agent can drive it — generate, edit, train, and run workflows straight from your prompts. `install.sh` installs it automatically when Claude Code is present (opt out with `--no-skill`).
+
+Installing from a clone instead? Symlink it (updates on every `git pull`):
+
+```bash
+ln -s "$(pwd)/skills/modl" ~/.claude/skills/modl
+```
+
+Restart Claude Code, then try `/modl` or just ask it to "generate an image of…".
+
 ---
 
 ## Web UI

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@
 #   --quick              Non-interactive: init + pull model + install service
 #   --model <id>         Model to pull (default: flux-schnell, used with --quick)
 #   --no-service         Skip service installation (used with --quick)
+#   --no-skill           Skip installing the Claude Code skill
 #   MODL_INSTALL_DIR     Override binary install path (default: /usr/local/bin)
 
 set -e
@@ -15,6 +16,7 @@ INSTALL_DIR="${MODL_INSTALL_DIR:-/usr/local/bin}"
 QUICK=0
 MODEL="flux-schnell"
 NO_SERVICE=0
+NO_SKILL=0
 
 # Parse flags
 while [ $# -gt 0 ]; do
@@ -22,6 +24,7 @@ while [ $# -gt 0 ]; do
         --quick)    QUICK=1; shift ;;
         --model)    MODEL="$2"; shift 2 ;;
         --no-service) NO_SERVICE=1; shift ;;
+        --no-skill) NO_SKILL=1; shift ;;
         *)          echo "Unknown option: $1"; exit 1 ;;
     esac
 done
@@ -33,6 +36,31 @@ for cmd in curl tar; do
         exit 1
     fi
 done
+
+# Install the Claude Code skill so agents can drive modl.
+# Only runs if Claude Code is present (~/.claude exists). Fetches SKILL.md from
+# the repo pinned to the installed release, falling back to main. Never clobbers
+# an existing symlink (dev setups point it at a local checkout).
+install_claude_skill() {
+    [ -d "${HOME}/.claude" ] || return 0
+
+    SKILL_DEST="${HOME}/.claude/skills/modl"
+    if [ -L "$SKILL_DEST" ]; then
+        return 0   # symlinked (dev checkout) — leave it alone
+    fi
+
+    for REF in "${LATEST}" "main"; do
+        SKILL_SRC="https://raw.githubusercontent.com/${REPO}/${REF}/skills/modl/SKILL.md"
+        mkdir -p "$SKILL_DEST"
+        if curl -fsSL "$SKILL_SRC" -o "$SKILL_DEST/SKILL.md" 2>/dev/null; then
+            echo "Installed Claude Code skill → ${SKILL_DEST}/SKILL.md"
+            echo "  Restart Claude Code, then try: /modl"
+            return 0
+        fi
+    done
+    # Non-fatal: a missing skill never blocks the install.
+    return 0
+}
 
 # Detect OS and architecture
 OS="$(uname -s)"
@@ -135,6 +163,11 @@ fi
 
 echo ""
 echo "modl ${LATEST} installed to ${INSTALL_DIR}/modl"
+
+# Install the Claude Code skill (opt out with --no-skill)
+if [ "$NO_SKILL" = "0" ]; then
+    install_claude_skill || true
+fi
 
 # Quick install mode: init + pull + service
 if [ "$QUICK" = "1" ]; then

--- a/skills/modl/SKILL.md
+++ b/skills/modl/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: modl
 description: >
-  AI image generation toolkit — generate images, edit photos, train LoRAs, manage models,
-  analyze images, upscale, remove backgrounds, and more via the modl CLI.
+  Generate images, edit photos, train LoRAs, run img2img/inpaint, upscale, remove
+  backgrounds, caption/score images, and run batch workflows via the modl CLI. Use
+  whenever the user wants to create, edit, analyze, or train on images locally.
+  Triggers: generate an image, edit this photo, train a lora, img2img, inpaint,
+  upscale, remove background, describe image, batch generate, run a workflow.
 triggers:
   # Direct invocation
   - /modl


### PR DESCRIPTION
## What

Makes the bundled `modl` Claude Code skill installable without a repo clone, so an agent can drive modl (generate, edit, train, workflows) from prompts.

## Changes

- **`install.sh`** — new `install_claude_skill` step:
  - Fetches `skills/modl/SKILL.md` from GitHub raw, pinned to the installed release tag, falling back to `main`.
  - Runs **only** when Claude Code is present (`~/.claude` exists) — no-op otherwise.
  - **Skips an existing symlink**, so dev checkouts (`~/.claude/skills/modl` → local repo) are never clobbered.
  - Fully non-fatal — a failed fetch never breaks the binary install.
  - Opt out with `--no-skill`.
- **`skills/modl/SKILL.md`** — rewrote the `description` with trigger phrases so Claude Code auto-invokes the skill instead of requiring an explicit `/modl`.
- **`README.md`** — documented the skill and the clone/symlink install path.

## Notes

- Existing releases predate the skill, so the tag-pinned fetch will 404 and correctly fall back to `main`. Once a release is cut with the skill present, it pins to the tag.
- Verified: `sh -n install.sh` passes; the `main` raw URL returns HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)